### PR TITLE
docs: App subpage and Skills+App hero (v2.0)

### DIFF
--- a/docs/app.html
+++ b/docs/app.html
@@ -1,0 +1,251 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="description" content="SRS Navigator: a GitHub Copilot canvas that renders your Problem-Based SRS specification as an interactive graph, with an inline action bar to decompose and iterate on it alongside the agent.">
+    <meta name="theme-color" content="#f3f6f8">
+    <title>SRS Navigator &middot; Problem-Based SRS</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Bricolage+Grotesque:wght@700;800&family=Figtree:wght@400;500;600&family=JetBrains+Mono:wght@400&display=swap" rel="stylesheet">
+    <link rel="stylesheet" href="assets/site.css">
+</head>
+<body>
+    <a href="#main" class="skip-link">Skip to content</a>
+
+    <nav class="site-nav" aria-label="Primary">
+        <div class="wrap">
+            <div class="site-nav-id">
+                <a href="index.html" class="site-nav-brand" aria-label="Problem-Based SRS home">Problem-Based <span>SRS</span></a>
+                <a href="https://github.com/RafaelGorski/Problem-Based-SRS/releases" class="version-badge" target="_blank" rel="noopener" aria-label="Version 2.0, view releases">v2.0</a>
+            </div>
+            <ul class="site-nav-links">
+                <li><a href="index.html">Home</a></li>
+                <li><a href="#graph">The graph</a></li>
+                <li><a href="#action-bar">Action bar</a></li>
+                <li><a href="#decompose">Decompose</a></li>
+                <li><a href="#health">Health</a></li>
+                <li><a href="#launch">Launch</a></li>
+                <li>
+                    <a href="https://github.com/RafaelGorski/Problem-Based-SRS" class="gh-link" target="_blank" rel="noopener" aria-label="View on GitHub">
+                        <svg viewBox="0 0 24 24" aria-hidden="true"><path d="M12 2C6.477 2 2 6.484 2 12.017c0 4.425 2.865 8.18 6.839 9.504.5.092.682-.217.682-.483 0-.237-.008-.868-.013-1.703-2.782.605-3.369-1.343-3.369-1.343-.454-1.158-1.11-1.466-1.11-1.466-.908-.62.069-.608.069-.608 1.003.07 1.531 1.032 1.531 1.032.892 1.53 2.341 1.088 2.91.832.092-.647.35-1.088.636-1.338-2.22-.253-4.555-1.113-4.555-4.951 0-1.093.39-1.988 1.029-2.688-.103-.253-.446-1.272.098-2.65 0 0 .84-.27 2.75 1.026A9.564 9.564 0 0112 6.844c.85.004 1.705.115 2.504.337 1.909-1.296 2.747-1.027 2.747-1.027.546 1.379.202 2.398.1 2.651.64.7 1.028 1.595 1.028 2.688 0 3.848-2.339 4.695-4.566 4.943.359.309.678.92.678 1.855 0 1.338-.012 2.419-.012 2.747 0 .268.18.58.688.482A10.019 10.019 0 0022 12.017C22 6.484 17.522 2 12 2z"/></svg>
+                        GitHub
+                    </a>
+                </li>
+            </ul>
+        </div>
+    </nav>
+
+    <header class="hero subhero">
+        <div class="wrap hero-content">
+            <div class="hero-copy">
+                <p class="breadcrumb"><a href="index.html">Problem-Based SRS</a><span class="sep" aria-hidden="true">/</span>The app</p>
+                <h1>Your spec, as a <span class="hl">living graph</span></h1>
+                <p class="hero-sub">The <strong>SRS Navigator</strong> is a GitHub Copilot canvas that renders every customer problem, need, and requirement as one connected graph, then lets you decompose and iterate on it together with the agent, without leaving the panel.</p>
+                <div class="hero-actions">
+                    <a href="https://github.com/RafaelGorski/Problem-Based-SRS/tree/main/.github/extensions/srs-navigator" class="btn-primary">Get the Copilot extension</a>
+                    <a href="index.html#parts" class="btn-ghost">Back to the methodology</a>
+                </div>
+                <div class="hero-meta">
+                    <span class="hero-badge">Copilot canvas</span>
+                    <span class="hero-badge">Force-directed graph</span>
+                    <span class="hero-badge">Live agent iteration</span>
+                </div>
+            </div>
+            <figure class="hero-visual">
+                <div class="app-frame">
+                    <div class="app-frame-bar">
+                        <div class="app-dots" aria-hidden="true"><span></span><span></span><span></span></div>
+                        <span class="app-frame-title">Copilot &middot; SRS Navigator</span>
+                    </div>
+                    <div class="tbd" data-taskbar-demo
+                         data-instruction="Break FR-1 into finer-grained sub-items"
+                         data-placeholder="Describe a change&hellip;"
+                         data-working="Running functional_requirements skill&hellip;">
+                        <div class="tbd-stage" role="img"
+                             aria-label="The SRS Navigator action bar in use: a functional-requirement node is selected, an instruction to break it into finer-grained sub-items is typed, the decompose action runs, and two sub-requirement nodes appear.">
+                            <svg class="tbd-links" viewBox="0 0 100 100" preserveAspectRatio="none" aria-hidden="true">
+                                <path d="M50 24 C 42 46, 33 56, 30 68" />
+                                <path d="M50 24 C 58 46, 67 56, 70 68" />
+                            </svg>
+                            <span class="tbd-node tbd-parent"><span class="tbd-glyph" aria-hidden="true">&lt;/&gt;</span>FR-1 &middot; Contact management</span>
+                            <span class="tbd-node tbd-child tbd-child-a"><span class="tbd-glyph" aria-hidden="true">&lt;/&gt;</span>FR-1.1 &middot; Create</span>
+                            <span class="tbd-node tbd-child tbd-child-b"><span class="tbd-glyph" aria-hidden="true">&lt;/&gt;</span>FR-1.2 &middot; Edit</span>
+                            <div class="tbd-bar" aria-hidden="true">
+                                <span class="tbd-bar-input"><span class="tbd-bar-text is-placeholder" data-tbd-text>Describe a change&hellip;</span><span class="tbd-caret"></span></span>
+                                <span class="tbd-btn">+NFR</span>
+                                <span class="tbd-btn is-decompose is-primary">+Sub-FR</span>
+                            </div>
+                            <div class="tbd-cursor" aria-hidden="true">
+                                <svg viewBox="0 0 24 24" fill="oklch(0.24 0.02 266)" stroke="#fff" stroke-width="1.4"><path d="M5 3l14 8-6 1.6L9.6 19 5 3z"/></svg>
+                            </div>
+                        </div>
+                        <div class="tbd-caption">
+                            <span class="tbd-status-dot" aria-hidden="true"></span>
+                            Decompose a requirement, live in the side panel
+                        </div>
+                    </div>
+                </div>
+                <figcaption>Hover a node, describe a change, and the agent runs the matching skill.</figcaption>
+            </figure>
+        </div>
+    </header>
+
+    <main id="main">
+        <!-- The graph -->
+        <section id="graph" class="section">
+            <div class="wrap">
+                <div class="feature-block">
+                    <div class="feature-copy reveal">
+                        <h2>See every artifact and its links</h2>
+                        <p>The navigator reads your <code>.spec/</code> folder and draws each artifact as a node in a force-directed graph. Traceability links are dashed; drag to rearrange, scroll to zoom, and search any node by name.</p>
+                        <p class="legend-intro" style="margin-top: var(--space-md)">Every node is color-coded by type:</p>
+                        <ul class="node-legend" aria-label="Node types in the graph">
+                            <li><span class="node-chip" style="--c: var(--step-why)">CP</span> Customer Problem</li>
+                            <li><span class="node-chip" style="--c: var(--step-what)">CN</span> Customer Need</li>
+                            <li><span class="node-chip" style="--c: var(--step-how)">FR</span> Functional Requirement</li>
+                            <li><span class="node-chip" style="--c: var(--step-nfr)">NFR</span> Non-Functional Requirement</li>
+                        </ul>
+                    </div>
+                    <div class="feature-media reveal">
+                        <div class="app-frame">
+                            <div class="app-frame-bar">
+                                <div class="app-dots" aria-hidden="true"><span></span><span></span><span></span></div>
+                                <span class="app-frame-title">Copilot &middot; SRS Navigator</span>
+                            </div>
+                            <img src="assets/srs-navigator.png" width="1280" height="796" loading="lazy" decoding="async"
+                                 alt="The SRS Navigator graph of a CRM specification: orange customer-problem nodes, teal customer-need nodes, indigo functional-requirement nodes, and purple non-functional nodes connected by dashed traceability links.">
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </section>
+
+        <!-- The action bar -->
+        <section id="action-bar" class="section">
+            <div class="wrap">
+                <div class="feature-block is-reversed">
+                    <div class="feature-copy reveal">
+                        <h2>Derive or decompose, inline</h2>
+                        <p>Hover any node to reveal a floating action bar. Type an instruction, then pick an action: <strong>derive</strong> the next artifact downstream, or <strong>decompose</strong> the node into finer-grained, independently testable sub-items. Each action runs the methodology skill that owns that step.</p>
+                        <ul class="action-map">
+                            <li class="action-row">
+                                <span class="action-from" style="--c: var(--step-why)">Problem</span>
+                                <span class="action-to"><span class="action-pill">+CN</span><span class="action-pill is-decompose">+Sub-CP</span></span>
+                            </li>
+                            <li class="action-row">
+                                <span class="action-from" style="--c: var(--step-what)">Need</span>
+                                <span class="action-to"><span class="action-pill">+FR</span><span class="action-pill is-decompose">+Sub-CN</span></span>
+                            </li>
+                            <li class="action-row">
+                                <span class="action-from" style="--c: var(--step-how)">FR</span>
+                                <span class="action-to"><span class="action-pill">+NFR</span><span class="action-pill is-decompose">+Sub-FR</span></span>
+                            </li>
+                            <li class="action-row">
+                                <span class="action-from" style="--c: var(--step-nfr)">NFR</span>
+                                <span class="action-to"><span class="action-pill is-decompose">+Sub-NFR</span></span>
+                            </li>
+                        </ul>
+                    </div>
+                    <div class="feature-media reveal">
+                        <div class="app-frame">
+                            <div class="app-frame-bar">
+                                <div class="app-dots" aria-hidden="true"><span></span><span></span><span></span></div>
+                                <span class="app-frame-title">Copilot &middot; SRS Navigator</span>
+                            </div>
+                            <img src="assets/srs-navigator-actionbar.png" width="1440" height="900" loading="lazy" decoding="async"
+                                 alt="The SRS Navigator graph with a Functional Requirement node selected. A floating action bar below it holds a typed decompose instruction and +NFR and +Sub-FR action buttons.">
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </section>
+
+        <!-- Decompose & iterate -->
+        <section id="decompose" class="section">
+            <div class="wrap">
+                <div class="feature-block">
+                    <div class="feature-copy reveal">
+                        <h2>Refine the spec with the agent</h2>
+                        <p>Triggering an action opens the node's detail panel (description, a complexity score, and its upstream and downstream traceability) next to a live <strong>Agent activity</strong> log. Your request runs through the skill, the spec files are edited, and the graph refreshes on its own.</p>
+                        <div class="flow-trace" style="text-align: left; margin-top: var(--space-lg)">
+                            <span class="t-cp">Hover &amp; describe</span><span class="arrow" aria-hidden="true">&rarr;</span><span class="t-cn">skill runs</span><span class="arrow" aria-hidden="true">&rarr;</span><span class="t-fr">graph refreshes</span>
+                        </div>
+                    </div>
+                    <div class="feature-media reveal">
+                        <div class="app-frame">
+                            <div class="app-frame-bar">
+                                <div class="app-dots" aria-hidden="true"><span></span><span></span><span></span></div>
+                                <span class="app-frame-title">Copilot &middot; SRS Navigator</span>
+                            </div>
+                            <img src="assets/srs-navigator-iteration.png" width="1440" height="900" loading="lazy" decoding="async"
+                                 alt="The SRS Navigator with a right-side detail panel open for a Functional Requirement, showing its traceability and an Agent Activity conversation where the user asks to decompose the requirement and the agent is working on it.">
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </section>
+
+        <!-- Health -->
+        <section id="health" class="section">
+            <div class="wrap">
+                <h2 class="reveal">Spot the gaps in your traceability</h2>
+                <p class="reveal section-lead">A health bar runs across the top of the graph. Each metric is a filter: click one to isolate the nodes that need attention, so a problem with no need or a need with no requirement never slips through.</p>
+                <div class="metric-grid reveal">
+                    <div class="metric"><div class="m-count">38</div><div class="m-label">nodes</div></div>
+                    <div class="metric"><div class="m-count ok">92%</div><div class="m-label">traceability</div></div>
+                    <div class="metric"><div class="m-count alert">2</div><div class="m-label">orphaned problems</div></div>
+                    <div class="metric"><div class="m-count alert">1</div><div class="m-label">unmet needs</div></div>
+                    <div class="metric"><div class="m-count alert">0</div><div class="m-label">isolated</div></div>
+                    <div class="metric"><div class="m-count ok">4</div><div class="m-label">need clusters</div></div>
+                </div>
+                <p class="reveal section-lead" style="margin-top: var(--space-lg)">Pair the metrics with <strong>search</strong> to jump to any node, and the <strong>hierarchy view</strong> to read the same spec as a nested outline.</p>
+            </div>
+        </section>
+
+        <!-- Launch -->
+        <section id="launch" class="section">
+            <div class="wrap">
+                <h2 class="reveal">Launch it with <code>/live</code></h2>
+                <p class="reveal section-lead">The navigator ships inside the Problem-Based SRS plugin. Once installed, open it from any session:</p>
+                <pre class="reveal"><code>/live</code></pre>
+                <p class="reveal section-lead">Copilot opens the canvas in the side panel and loads the specification from your project's <code>.spec/</code> folder. No spec yet? Run the methodology first (<code>/problem-based-srs</code>), then open the navigator to see it take shape.</p>
+                <div class="app-actions reveal">
+                    <a href="https://github.com/RafaelGorski/Problem-Based-SRS/tree/main/.github/extensions/srs-navigator" class="btn-primary">Get the Copilot extension</a>
+                    <a href="https://github.com/RafaelGorski/Problem-Based-SRS/blob/main/.github/extensions/srs-navigator/README.md" class="btn-ghost" target="_blank" rel="noopener">Extension docs</a>
+                </div>
+            </div>
+        </section>
+    </main>
+
+    <!-- Footer CTA -->
+    <div class="footer-cta">
+        <div class="wrap">
+            <p class="cta-chain reveal" role="img" aria-label="Customer Problem to Customer Need to Functional Requirement">
+                <span class="chain-cp">CP</span><span class="chain-arrow" aria-hidden="true">&rarr;</span><span class="chain-cn">CN</span><span class="chain-arrow" aria-hidden="true">&rarr;</span><span class="chain-fr">FR</span>
+            </p>
+            <h2 class="reveal">From problem to requirement, on one canvas</h2>
+            <p class="reveal">Run the methodology as Skills, then watch the spec come alive in the SRS Navigator.</p>
+            <div class="hero-actions reveal">
+                <a href="https://github.com/RafaelGorski/Problem-Based-SRS" class="btn-primary">View on GitHub</a>
+                <a href="index.html" class="btn-ghost">Back to home</a>
+            </div>
+        </div>
+    </div>
+
+    <footer class="site-footer">
+        <div class="wrap">
+            <p>Problem-Based SRS &middot; <a href="https://github.com/RafaelGorski/Problem-Based-SRS/releases" class="footer-version">v2.0</a> &middot; Methodology by Gorski &amp; Stadzisz</p>
+            <p class="footer-links">
+                <a href="index.html">Home</a>
+                <a href="https://github.com/RafaelGorski/Problem-Based-SRS">GitHub</a>
+                <a href="https://github.com/RafaelGorski/Problem-Based-SRS/blob/main/CHANGELOG.md">Changelog</a>
+                <a href="https://github.com/RafaelGorski/Problem-Based-SRS/blob/main/LICENSE">MIT License</a>
+            </p>
+        </div>
+    </footer>
+
+    <script src="assets/site.js" defer></script>
+</body>
+</html>

--- a/docs/assets/site.css
+++ b/docs/assets/site.css
@@ -1,0 +1,803 @@
+        /* ── Tokens ── */
+        :root {
+            /* Primary — deep indigo, sampled from the SRS Navigator app's "Graph" control. */
+            --primary: oklch(0.45 0.16 266);
+            --primary-hover: oklch(0.38 0.16 266);
+            --primary-subtle: oklch(0.955 0.022 266);
+            /* Text on the primary fill — near-white for AA contrast on indigo. */
+            --on-primary: oklch(0.99 0 0);
+            /* Background — clean, slightly-cool off-white, matched to the app canvas. */
+            --bg: oklch(0.975 0.003 240);
+            --bg-elevated: oklch(1 0 0);
+            /* Surface — faint panels, hairline borders. */
+            --surface: oklch(0.965 0.004 240);
+            --surface-hover: oklch(0.945 0.005 240);
+            --surface-border: oklch(0.900 0.006 240);
+            /* Ink — near-black text, high contrast on off-white. */
+            --ink: oklch(0.30 0.012 264);
+            --ink-heading: oklch(0.19 0.018 264);
+            /* Accent — teal, sampled from the CN nodes. Darkened for link contrast. */
+            --accent: oklch(0.53 0.10 205);
+            --accent-hover: oklch(0.46 0.11 205);
+            /* Muted — secondary text, ≥4.5:1 on off-white. */
+            --muted: oklch(0.47 0.012 264);
+            --muted-light: oklch(0.57 0.012 264);
+            /* Methodology node colors — sampled directly from the SRS Navigator app. */
+            --step-context: oklch(0.52 0.16 305);
+            --step-why: oklch(0.61 0.18 48);
+            --step-glance: oklch(0.58 0.10 202);
+            --step-what: oklch(0.58 0.10 202);
+            --step-vision: oklch(0.55 0.12 150);
+            --step-how: oklch(0.56 0.16 266);
+            --step-nfr: oklch(0.54 0.15 320);
+            /* Bolder accents — committed color moments */
+            --cp-bold: oklch(0.55 0.17 50);          /* deepened amber for the hero "problem" word (4.8:1 on bg) */
+            --primary-deep: oklch(0.30 0.12 266);    /* drenched dark indigo for the closing panel */
+            --on-deep: oklch(0.99 0 0);
+            --on-deep-muted: oklch(0.86 0.04 266);
+            --chain-cp: oklch(0.84 0.13 55);         /* light node tints, ≥7.9:1 on the deep panel */
+            --chain-cn: oklch(0.82 0.09 200);
+            --chain-fr: oklch(0.88 0.05 266);
+            --cn-text: oklch(0.50 0.10 202);          /* CN teal at text contrast (5:1 on surface) */
+            --font-display: 'Bricolage Grotesque', system-ui, sans-serif;
+            --font-body: 'Figtree', system-ui, sans-serif;
+            --font-mono: 'JetBrains Mono', 'Cascadia Code', monospace;
+            --text-xs: clamp(0.75rem, 0.7rem + 0.15vw, 0.8rem);
+            --text-sm: clamp(0.825rem, 0.78rem + 0.2vw, 0.9rem);
+            --text-base: clamp(0.95rem, 0.88rem + 0.25vw, 1.05rem);
+            --text-lg: clamp(1.125rem, 1rem + 0.4vw, 1.3rem);
+            --text-xl: clamp(1.4rem, 1.2rem + 0.6vw, 1.65rem);
+            --text-2xl: clamp(1.75rem, 1.4rem + 1vw, 2.1rem);
+            --text-3xl: clamp(2.2rem, 1.7rem + 1.5vw, 2.8rem);
+            --text-hero: clamp(3.2rem, 2.2rem + 3vw, 5rem);
+            --space-xs: clamp(0.25rem, 0.2rem + 0.15vw, 0.375rem);
+            --space-sm: clamp(0.5rem, 0.4rem + 0.3vw, 0.75rem);
+            --space-md: clamp(1rem, 0.8rem + 0.6vw, 1.5rem);
+            --space-lg: clamp(1.5rem, 1.2rem + 1vw, 2.5rem);
+            --space-xl: clamp(2.5rem, 1.8rem + 2vw, 4rem);
+            --space-2xl: clamp(4rem, 2.8rem + 3.5vw, 6.5rem);
+            --space-section: clamp(5rem, 3.5rem + 4.5vw, 9rem);
+            --ease-out-quart: cubic-bezier(0.25, 1, 0.5, 1);
+        }
+
+        /* ── Reset ── */
+        *, *::before, *::after { margin: 0; padding: 0; box-sizing: border-box; }
+
+        body {
+            font-family: var(--font-body);
+            font-size: var(--text-base);
+            line-height: 1.7;
+            color: var(--ink);
+            background: var(--bg);
+            -webkit-font-smoothing: antialiased;
+            text-rendering: optimizeLegibility;
+        }
+
+        /* ── Typography ── */
+        h1, h2, h3 {
+            font-family: var(--font-display);
+            color: var(--ink-heading);
+            text-wrap: balance;
+            letter-spacing: -0.02em;
+        }
+        h2 { font-size: var(--text-3xl); font-weight: 800; letter-spacing: -0.03em; margin-bottom: var(--space-lg); }
+        h3 { font-size: var(--text-xl); margin-bottom: var(--space-sm); color: var(--ink); }
+        p { max-width: 68ch; }
+        a { color: var(--accent); text-decoration: none; transition: color 0.2s ease; }
+        a:hover { color: var(--accent-hover); }
+        a:focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; border-radius: 2px; }
+        code {
+            font-family: var(--font-mono);
+            font-size: 0.9em;
+            color: var(--ink-heading);
+            background: var(--surface);
+            padding: 0.15em 0.4em;
+            border-radius: 4px;
+            border: 1px solid var(--surface-border);
+        }
+        pre {
+            background: var(--bg-elevated);
+            border: 1px solid var(--surface-border);
+            border-radius: 8px;
+            padding: var(--space-md);
+            overflow-x: auto;
+            margin: var(--space-md) 0;
+        }
+        pre code { background: none; border: none; padding: 0; font-size: var(--text-sm); line-height: 1.6; }
+
+        /* ── Layout ── */
+        .wrap { max-width: 1120px; margin: 0 auto; padding: 0 var(--space-lg); }
+        .section { padding: var(--space-section) 0; }
+        .section + .section { border-top: 1px solid var(--surface-border); }
+
+        /* ── Skip link ── */
+        .skip-link {
+            position: absolute; left: -9999px; top: var(--space-sm);
+            background: var(--primary); color: var(--ink-heading);
+            padding: var(--space-sm) var(--space-md); border-radius: 8px;
+            font-weight: 600; z-index: 200;
+        }
+        .skip-link:focus { left: var(--space-md); }
+
+        /* ── Nav ── */
+        .site-nav {
+            position: sticky; top: 0; z-index: 100;
+            background: oklch(0.975 0.003 240 / 0.82);
+            backdrop-filter: blur(12px);
+            -webkit-backdrop-filter: blur(12px);
+            border-bottom: 1px solid var(--surface-border);
+        }
+        .site-nav .wrap {
+            display: flex; align-items: center; justify-content: space-between;
+            padding-top: var(--space-sm); padding-bottom: var(--space-sm);
+            gap: var(--space-md);
+        }
+        .site-nav-brand {
+            font-family: var(--font-display); font-size: var(--text-lg); font-weight: 700;
+            color: var(--ink-heading); text-decoration: none; white-space: nowrap;
+        }
+        .site-nav-brand span { color: var(--primary); }
+        .site-nav-id { display: inline-flex; align-items: center; gap: var(--space-sm); min-width: 0; }
+        .version-badge {
+            font-family: var(--font-mono); font-size: var(--text-xs); font-weight: 400;
+            line-height: 1.35; letter-spacing: 0.01em; white-space: nowrap;
+            color: var(--primary); background: var(--primary-subtle);
+            border: 1px solid color-mix(in oklch, var(--primary) 24%, transparent);
+            border-radius: 999px; padding: 0.18em 0.62em; text-decoration: none;
+            transition: background 0.2s ease, color 0.2s ease, border-color 0.2s ease;
+        }
+        .version-badge:hover {
+            color: var(--on-primary); background: var(--primary);
+            border-color: var(--primary);
+        }
+        .version-badge:focus-visible { outline: 2px solid var(--primary); outline-offset: 2px; }
+        .site-nav-links {
+            display: flex; gap: var(--space-md); list-style: none;
+            flex-wrap: wrap; align-items: center;
+        }
+        .site-nav-links a {
+            color: var(--muted); font-size: var(--text-sm); font-weight: 500;
+            transition: color 0.2s ease;
+            display: inline-flex; align-items: center; min-height: 24px; padding: 0.4rem 0;
+        }
+        .site-nav-links a:hover { color: var(--ink); }
+        .gh-link {
+            display: inline-flex; align-items: center; gap: 0.35em;
+            color: var(--muted); font-size: var(--text-sm); font-weight: 500;
+        }
+        .gh-link:hover { color: var(--ink); }
+        .gh-link svg { width: 18px; height: 18px; fill: currentColor; }
+
+        /* ── Hero ── */
+        .hero {
+            padding: var(--space-2xl) 0 var(--space-section);
+            position: relative; overflow: hidden;
+        }
+        .hero::before, .hero::after {
+            content: ''; position: absolute; pointer-events: none; z-index: 0;
+            width: clamp(280px, 42vw, 560px); height: clamp(280px, 42vw, 560px);
+            border-radius: 50%;
+        }
+        .hero::before { /* indigo field, anchored behind the app frame */
+            background: radial-gradient(circle, oklch(0.45 0.16 266 / 0.13), transparent 70%);
+            top: 16%; right: -8%;
+        }
+        .hero::after { /* amber field, anchored behind the headline */
+            background: radial-gradient(circle, oklch(0.61 0.18 48 / 0.11), transparent 70%);
+            top: 44%; left: -10%;
+        }
+        .hero-content { position: relative; z-index: 1; display: grid; gap: var(--space-2xl); align-items: center; }
+        @media (min-width: 900px) {
+            .hero-content { grid-template-columns: minmax(0, 1.05fr) minmax(0, 1fr); gap: var(--space-section); }
+        }
+        .hero-copy { min-width: 0; }
+        .hero-visual { margin: 0; min-width: 0; }
+        .hero-visual .app-frame { transition: transform 0.4s var(--ease-out-quart); }
+        @media (min-width: 900px) and (prefers-reduced-motion: no-preference) {
+            .hero-visual .app-frame:hover { transform: translateY(-4px); }
+        }
+        .hero-visual figcaption {
+            margin-top: var(--space-sm); font-size: var(--text-xs);
+            color: var(--muted); text-align: center;
+        }
+        .hero h1 {
+            font-size: var(--text-hero);
+            line-height: 1.04;
+            font-weight: 800;
+            letter-spacing: -0.03em;
+            margin-bottom: var(--space-lg);
+            max-width: 16ch;
+        }
+        .hero h1 .hl { color: var(--cp-bold); position: relative; white-space: nowrap; }
+        .hero h1 .hl::after {
+            content: ''; position: absolute; left: 0; right: 0; bottom: 0.04em;
+            height: 0.1em; border-radius: 2px;
+            background: var(--cp-bold); opacity: 0.22;
+        }
+        .hero-sub {
+            font-size: var(--text-lg);
+            color: var(--muted);
+            max-width: 52ch;
+            margin-bottom: var(--space-xl);
+            line-height: 1.6;
+        }
+        .hero-actions { display: flex; gap: var(--space-md); flex-wrap: wrap; align-items: center; }
+        .btn-primary {
+            display: inline-flex; align-items: center; gap: 0.5em;
+            background: var(--primary); color: var(--on-primary);
+            padding: 0.75em 1.5em; border-radius: 8px;
+            font-family: var(--font-body); font-size: var(--text-base); font-weight: 600;
+            text-decoration: none; transition: background 0.2s ease;
+        }
+        .btn-primary:hover { background: var(--primary-hover); color: var(--on-primary); }
+        .btn-ghost {
+            display: inline-flex; align-items: center; gap: 0.5em;
+            background: transparent; color: var(--ink);
+            padding: 0.75em 1.5em; border-radius: 8px;
+            border: 1px solid var(--surface-border);
+            font-family: var(--font-body); font-size: var(--text-base); font-weight: 500;
+            text-decoration: none; transition: background 0.2s ease, border-color 0.2s ease;
+        }
+        .btn-ghost:hover { background: var(--surface); border-color: var(--muted-light); color: var(--ink); }
+        .hero-meta {
+            margin-top: var(--space-xl); display: flex; gap: var(--space-md);
+            flex-wrap: wrap; align-items: center;
+        }
+        .hero-badge {
+            font-size: var(--text-xs); color: var(--muted);
+            border: 1px solid var(--surface-border); padding: 0.3em 0.8em;
+            border-radius: 100px; white-space: nowrap;
+        }
+
+        /* ── Problem section ── */
+        .problem-before {
+            background: var(--surface); border-radius: 10px;
+            padding: var(--space-lg); margin: var(--space-lg) 0;
+            max-width: 56ch;
+        }
+        .problem-before p { color: var(--muted); }
+        .problem-before .quote {
+            font-size: var(--text-lg); color: var(--ink);
+            font-style: italic; margin-bottom: var(--space-md);
+        }
+        .problem-after {
+            margin: var(--space-lg) 0; max-width: 56ch;
+        }
+        .problem-after .cp {
+            font-family: var(--font-mono); font-size: var(--text-base);
+            color: oklch(0.48 0.14 50); background: oklch(0.61 0.18 48 / 0.10);
+            padding: var(--space-sm) var(--space-md); border-radius: 8px;
+            display: block; margin: var(--space-md) 0;
+        }
+
+        /* ── Flow (methodology timeline) ── */
+        .flow { position: relative; padding-left: 2.5rem; margin: var(--space-xl) 0; }
+        .flow::before {
+            content: ''; position: absolute; left: 7px; top: 8px; bottom: 8px;
+            width: 2px; background: var(--surface-border);
+        }
+        .flow-step {
+            position: relative; padding-bottom: var(--space-xl);
+        }
+        .flow-step:last-child { padding-bottom: 0; }
+        .flow-dot {
+            position: absolute; left: -2.5rem; top: 4px;
+            width: 16px; height: 16px; border-radius: 50%;
+            background: var(--dot-color, var(--muted));
+        }
+        .flow-name {
+            font-family: var(--font-display); font-size: var(--text-xl);
+            font-weight: 700; color: var(--ink-heading);
+            margin-bottom: var(--space-xs);
+        }
+        .flow-question {
+            font-size: var(--text-sm); color: var(--muted);
+            font-style: italic; margin-bottom: var(--space-xs);
+        }
+        .flow-desc { color: var(--ink); max-width: 52ch; }
+        .flow-cmd {
+            display: inline-block; margin-top: var(--space-sm);
+            font-family: var(--font-mono); font-size: var(--text-sm);
+            color: var(--accent); background: var(--bg-elevated);
+            padding: 0.2em 0.6em; border-radius: 4px;
+            border: 1px solid var(--surface-border);
+        }
+        .flow-trace {
+            margin-top: var(--space-xl); padding: var(--space-md) var(--space-lg);
+            background: var(--surface); border-radius: 10px;
+            font-family: var(--font-mono); font-size: var(--text-base);
+            color: var(--ink); text-align: center; letter-spacing: 0.02em;
+        }
+        .flow-trace .arrow { color: var(--muted); margin: 0 0.3em; }
+        .flow-trace .t-cp { color: var(--cp-bold); }
+        .flow-trace .t-cn { color: var(--cn-text); }
+        .flow-trace .t-fr { color: var(--primary); }
+
+        /* ── Classification ── */
+        .class-grid { margin-top: var(--space-lg); display: flex; flex-direction: column; gap: var(--space-md); }
+        .class-row {
+            display: grid; grid-template-columns: auto 1fr;
+            gap: var(--space-md); align-items: start;
+            padding: var(--space-md) var(--space-lg);
+            background: var(--surface); border-radius: 10px;
+        }
+        .class-indicator {
+            width: 10px; height: 10px; border-radius: 50%;
+            margin-top: 0.45em; flex-shrink: 0;
+        }
+        .class-label {
+            font-family: var(--font-display); font-size: var(--text-lg); font-weight: 700;
+            color: var(--ink-heading);
+        }
+        .class-verb { font-family: var(--font-mono); font-size: var(--text-sm); color: var(--muted); }
+        .class-desc { color: var(--ink); margin-top: var(--space-xs); }
+
+        /* ── Commands table ── */
+        .cmd-table { width: 100%; border-collapse: collapse; margin-top: var(--space-lg); }
+        .cmd-table th {
+            text-align: left; font-size: var(--text-sm); color: var(--muted);
+            font-weight: 500; padding: var(--space-sm) var(--space-md);
+            border-bottom: 1px solid var(--surface-border);
+        }
+        .cmd-table td {
+            padding: var(--space-sm) var(--space-md);
+            border-bottom: 1px solid var(--surface-border);
+            font-size: var(--text-sm);
+        }
+        .cmd-table tr:hover td { background: var(--surface); }
+        .cmd-table .cmd-name {
+            font-family: var(--font-mono); color: var(--accent); white-space: nowrap;
+        }
+        .table-scroll { overflow-x: auto; -webkit-overflow-scrolling: touch; margin-top: var(--space-lg); }
+        .table-scroll .cmd-table { margin-top: 0; }
+
+        /* ── App showcase (SRS Navigator) ── */
+        .section-lead { color: var(--muted); max-width: 62ch; margin-bottom: var(--space-lg); }
+        .section-lead strong { color: var(--ink-heading); font-weight: 600; }
+        .legend-intro { color: var(--muted); font-size: var(--text-sm); margin-bottom: var(--space-sm); }
+        .node-legend {
+            list-style: none; display: flex; flex-wrap: wrap;
+            gap: var(--space-md); margin-bottom: var(--space-lg);
+        }
+        .node-legend li {
+            display: inline-flex; align-items: center; gap: 0.5rem;
+            font-size: var(--text-sm); color: var(--muted);
+        }
+        .node-chip {
+            font-family: var(--font-mono); font-size: var(--text-xs); font-weight: 600;
+            color: color-mix(in oklab, var(--c) 76%, black); background: color-mix(in oklab, var(--c) 12%, transparent);
+            border: 1px solid color-mix(in oklab, var(--c) 32%, transparent);
+            padding: 0.2em 0.55em; border-radius: 6px; letter-spacing: 0.02em;
+        }
+        .app-frame {
+            border-radius: 14px; overflow: hidden; background: var(--bg-elevated);
+            box-shadow: 0 2px 4px oklch(0.2 0.02 264 / 0.05),
+                        0 20px 44px oklch(0.42 0.05 25 / 0.12);
+        }
+        .app-frame-bar {
+            display: flex; align-items: center; gap: 0.7rem;
+            padding: 0.7rem 1rem; background: var(--surface);
+            border-bottom: 1px solid var(--surface-border);
+        }
+        .app-dots { display: flex; gap: 0.4rem; }
+        .app-dots span { width: 11px; height: 11px; border-radius: 50%; background: var(--surface-border); }
+        .app-frame-title { font-family: var(--font-mono); font-size: var(--text-xs); color: var(--muted); }
+        .app-frame img { display: block; width: 100%; height: auto; }
+        .app-actions { margin-top: var(--space-lg); display: flex; gap: var(--space-md); flex-wrap: wrap; }
+
+        /* ── Iterate section: stacked annotated screenshots ── */
+        .shot-stack { display: grid; gap: var(--space-xl); margin-top: var(--space-xl); }
+        .shot figure { margin: 0; }
+        .shot-copy { margin-bottom: var(--space-md); }
+        .shot-copy h3 { font-size: var(--text-lg); margin: 0 0 0.4rem; }
+        .shot-copy p { color: var(--muted); max-width: 60ch; }
+        .shot figcaption { margin-top: var(--space-sm); font-family: var(--font-mono); font-size: var(--text-xs); color: var(--muted); }
+
+        /* ── Footer CTA ── */
+        /* ── Footer CTA — drenched dark panel, the bold close ── */
+        .footer-cta {
+            background: var(--primary-deep);
+            padding: var(--space-section) 0;
+            text-align: center;
+            position: relative; overflow: hidden;
+        }
+        .footer-cta::before {
+            content: ''; position: absolute; inset: 0; pointer-events: none;
+            background:
+                radial-gradient(58% 80% at 12% 8%, oklch(0.61 0.18 48 / 0.16), transparent 60%),
+                radial-gradient(58% 80% at 88% 92%, oklch(0.58 0.10 202 / 0.16), transparent 60%);
+        }
+        .footer-cta .wrap { position: relative; z-index: 1; }
+        .cta-chain {
+            font-family: var(--font-display); font-weight: 800;
+            font-size: clamp(2.75rem, 1.6rem + 4.5vw, 5rem);
+            letter-spacing: -0.03em; line-height: 1;
+            margin: 0 auto var(--space-lg);
+            display: flex; align-items: center; justify-content: center;
+            gap: clamp(0.5rem, 2.5vw, 1.5rem);
+        }
+        .cta-chain .chain-cp { color: var(--chain-cp); }
+        .cta-chain .chain-cn { color: var(--chain-cn); }
+        .cta-chain .chain-fr { color: var(--chain-fr); }
+        .cta-chain .chain-arrow { color: var(--on-deep-muted); font-weight: 400; font-size: 0.55em; }
+        .footer-cta h2 { color: var(--on-deep); margin-bottom: var(--space-md); }
+        .footer-cta p { margin: 0 auto var(--space-lg); color: var(--on-deep-muted); max-width: 54ch; }
+        .footer-cta .hero-actions { justify-content: center; }
+        .footer-cta .btn-primary { background: var(--on-deep); color: var(--primary-deep); }
+        .footer-cta .btn-primary:hover { background: oklch(0.92 0.03 266); color: var(--primary-deep); }
+        .footer-cta .btn-ghost { color: var(--on-deep); border-color: oklch(0.92 0.02 266 / 0.4); }
+        .footer-cta .btn-ghost:hover { background: oklch(1 0 0 / 0.08); border-color: var(--on-deep); color: var(--on-deep); }
+
+        /* ── Footer ── */
+        .site-footer {
+            padding: var(--space-xl) 0; text-align: center;
+            border-top: 1px solid var(--surface-border);
+        }
+        .site-footer p { color: var(--muted-light); font-size: var(--text-sm); margin: 0 auto; }
+        .site-footer a { color: var(--muted); display: inline-block; padding: 0.3rem 0.15rem; min-height: 24px; }
+        .site-footer a:hover { color: var(--ink); }
+        .footer-links { margin-top: var(--space-xs); }
+        .footer-version { font-family: var(--font-mono); font-size: 0.92em; color: var(--accent); }
+        .footer-version:hover { color: var(--accent-hover); }
+        .footer-links a + a::before { content: ' · '; color: var(--muted-light); }
+
+        /* ── Scroll reveal ── */
+        .reveal { opacity: 1; }
+        @media (prefers-reduced-motion: no-preference) {
+            body.js .reveal {
+                opacity: 0; transform: translateY(12px);
+                transition: opacity 0.5s var(--ease-out-quart), transform 0.5s var(--ease-out-quart);
+            }
+            body.js .reveal.visible { opacity: 1; transform: translateY(0); }
+        }
+
+        /* ── Responsive ── */
+        @media (max-width: 640px) {
+            .site-nav-links { gap: var(--space-sm); }
+            .site-nav-links a { font-size: var(--text-xs); }
+            .hero h1 { max-width: none; }
+            .hero-actions { flex-direction: column; align-items: stretch; }
+            .btn-primary, .btn-ghost { justify-content: center; }
+            .class-row { grid-template-columns: 1fr; }
+            .class-indicator { display: none; }
+            .cmd-table { font-size: var(--text-xs); }
+            .cmd-table th:last-child, .cmd-table td:last-child { display: none; }
+        }
+
+        @media (prefers-reduced-motion: reduce) {
+            *, *::before, *::after {
+                animation-duration: 0.01ms !important;
+                transition-duration: 0.01ms !important;
+            }
+        }
+
+/* ════════════════════════════════════════════════════════════════
+   v2.0 — Skills + App: pillars, animated task bar, App subpage
+   ════════════════════════════════════════════════════════════════ */
+
+/* ── Hero feature line (Skills + App) ── */
+.hero-features {
+    margin-top: var(--space-lg);
+    margin-bottom: var(--space-md);
+    display: flex; flex-wrap: wrap; gap: var(--space-md);
+}
+.hero-feature {
+    display: inline-flex; align-items: baseline; gap: 0.45em;
+    font-size: var(--text-sm); color: var(--ink);
+}
+.hero-feature b {
+    font-family: var(--font-display); font-weight: 700; color: var(--ink-heading);
+}
+.hero-feature .hf-kind {
+    font-family: var(--font-mono); font-size: var(--text-xs); color: var(--muted);
+}
+.hero-feature .hf-dot {
+    width: 8px; height: 8px; border-radius: 50%;
+    background: var(--hf, var(--primary)); align-self: center;
+}
+
+/* ── Two parts: Skills + App ── */
+.parts-grid { display: grid; gap: var(--space-lg); margin-top: var(--space-xl); }
+@media (min-width: 860px) { .parts-grid { grid-template-columns: 1fr 1fr; } }
+.part {
+    display: flex; flex-direction: column;
+    padding: var(--space-lg);
+    background: var(--bg-elevated);
+    border: 1px solid var(--surface-border);
+    border-radius: 14px;
+}
+.part-tag {
+    align-self: flex-start;
+    font-family: var(--font-mono); font-size: var(--text-xs);
+    font-weight: 600; letter-spacing: 0.06em; text-transform: uppercase;
+    color: var(--primary); background: var(--primary-subtle);
+    border: 1px solid color-mix(in oklch, var(--primary) 22%, transparent);
+    padding: 0.28em 0.72em; border-radius: 999px;
+    margin-bottom: var(--space-md);
+}
+.part--app .part-tag {
+    color: var(--cn-text);
+    background: color-mix(in oklab, var(--accent) 10%, transparent);
+    border-color: color-mix(in oklab, var(--accent) 28%, transparent);
+}
+.part h3 {
+    font-family: var(--font-display); font-size: var(--text-2xl); font-weight: 800;
+    letter-spacing: -0.02em; color: var(--ink-heading); margin-bottom: var(--space-sm);
+}
+.part > p { color: var(--muted); max-width: 48ch; }
+.part-list { list-style: none; margin: var(--space-md) 0 var(--space-lg); display: flex; flex-direction: column; gap: 0.6rem; }
+.part-list li { display: flex; gap: 0.65rem; align-items: flex-start; font-size: var(--text-sm); color: var(--ink); line-height: 1.5; }
+.part-list li::before {
+    content: ''; width: 7px; height: 7px; border-radius: 50%;
+    margin-top: 0.5em; flex: 0 0 auto; background: var(--bullet, var(--primary));
+}
+.part-chain {
+    display: flex; align-items: center; gap: 0.5rem; flex-wrap: wrap;
+    font-family: var(--font-mono); font-size: var(--text-sm);
+    margin: var(--space-sm) 0 var(--space-lg);
+}
+.part-chain .pc { padding: 0.15em 0.55em; border-radius: 6px; font-weight: 600; }
+.part-chain .pc-cp { color: color-mix(in oklab, var(--step-why) 76%, black); background: color-mix(in oklab, var(--step-why) 12%, transparent); }
+.part-chain .pc-cn { color: var(--cn-text); background: color-mix(in oklab, var(--step-what) 12%, transparent); }
+.part-chain .pc-fr { color: color-mix(in oklab, var(--step-how) 76%, black); background: color-mix(in oklab, var(--step-how) 12%, transparent); }
+.part-chain .pc-arrow { color: var(--muted-light); }
+.part-cta { margin-top: auto; display: flex; gap: var(--space-md); flex-wrap: wrap; }
+.part-link {
+    display: inline-flex; align-items: center; gap: 0.4em;
+    font-weight: 600; font-size: var(--text-sm); color: var(--primary);
+}
+.part-link svg { width: 1em; height: 1em; transition: transform 0.2s var(--ease-out-quart); }
+.part-link:hover { color: var(--primary-hover); }
+@media (prefers-reduced-motion: no-preference) {
+    .part-link:hover svg { transform: translateX(3px); }
+}
+
+/* ── Animated task-bar demo ── */
+.tbd { position: relative; }
+.tbd-stage {
+    position: relative;
+    aspect-ratio: 8 / 5;
+    background-color: var(--bg-elevated);
+    background-image: radial-gradient(oklch(0.30 0.012 264 / 0.06) 1px, transparent 1.5px);
+    background-size: 20px 20px; background-position: -6px -6px;
+    overflow: hidden;
+}
+.tbd-links { position: absolute; inset: 0; width: 100%; height: 100%; pointer-events: none; }
+.tbd-links path {
+    fill: none; stroke: color-mix(in oklab, var(--step-how) 55%, transparent);
+    stroke-width: 1.4; stroke-dasharray: 4 4;
+    stroke-dashoffset: 0; opacity: 1;
+    transition: opacity 0.5s var(--ease-out-quart);
+}
+.tbd-node {
+    position: absolute; transform: translate(-50%, -50%);
+    display: inline-flex; align-items: center; gap: 0.5em;
+    font-family: var(--font-mono); font-weight: 600;
+    font-size: clamp(0.66rem, 0.55rem + 0.45vw, 0.84rem);
+    padding: 0.5em 0.7em; border-radius: 10px;
+    background: var(--bg-elevated); white-space: nowrap;
+    color: color-mix(in oklab, var(--c) 68%, black);
+    border: 1.5px solid color-mix(in oklab, var(--c) 45%, transparent);
+    box-shadow: 0 1px 3px oklch(0.2 0.02 264 / 0.10);
+    transition: box-shadow 0.35s var(--ease-out-quart), transform 0.35s var(--ease-out-quart), opacity 0.4s var(--ease-out-quart);
+    z-index: 2;
+}
+.tbd-node .tbd-glyph {
+    display: inline-grid; place-items: center;
+    width: 1.45em; height: 1.45em; border-radius: 6px;
+    background: color-mix(in oklab, var(--c) 16%, transparent);
+    color: color-mix(in oklab, var(--c) 72%, black);
+    font-size: 0.78em;
+}
+.tbd-parent { left: 50%; top: 20%; --c: var(--step-how); }
+.tbd-child { --c: var(--step-how); top: 74%; font-size: clamp(0.58rem, 0.48rem + 0.38vw, 0.74rem); }
+.tbd-child-a { left: 27%; }
+.tbd-child-b { left: 73%; }
+.tbd-child .tbd-glyph { background: color-mix(in oklab, var(--c) 14%, transparent); }
+
+/* Action bar */
+.tbd-bar {
+    position: absolute; left: 50%; top: 40%; transform: translate(-50%, 0);
+    display: flex; align-items: center; gap: 0.35rem;
+    width: min(86%, 30rem);
+    padding: 0.4rem 0.42rem;
+    background: oklch(0.24 0.02 266); color: oklch(0.96 0.008 266);
+    border: 1px solid oklch(0.40 0.03 266); border-radius: 10px;
+    box-shadow: 0 14px 34px oklch(0.18 0.04 266 / 0.30);
+    z-index: 3;
+    transition: opacity 0.4s var(--ease-out-quart), transform 0.45s var(--ease-out-quart);
+}
+.tbd-bar-input {
+    flex: 1 1 auto; min-width: 0;
+    display: flex; align-items: center; gap: 1px;
+    padding: 0.28em 0.5em;
+    font-family: var(--font-body); font-size: clamp(0.66rem, 0.56rem + 0.35vw, 0.8rem);
+    line-height: 1.3; color: oklch(0.97 0.008 266);
+    background: oklch(0.20 0.02 266); border-radius: 7px;
+    border: 1px solid oklch(0.34 0.03 266);
+    white-space: nowrap; overflow: hidden;
+}
+.tbd-bar-text { overflow: hidden; text-overflow: clip; }
+.tbd-bar-text.is-placeholder { color: oklch(0.66 0.02 266); }
+.tbd-caret {
+    display: inline-block; width: 1.5px; height: 1em; flex: 0 0 auto;
+    background: var(--step-glance); opacity: 0; transform: translateY(0.12em);
+}
+.tbd-btn {
+    flex: 0 0 auto;
+    display: inline-flex; align-items: center; gap: 0.3em;
+    font-family: var(--font-mono); font-weight: 600;
+    font-size: clamp(0.6rem, 0.5rem + 0.3vw, 0.72rem);
+    padding: 0.36em 0.5em; border-radius: 7px;
+    color: oklch(0.88 0.02 266); background: oklch(0.30 0.02 266);
+    border: 1px solid oklch(0.42 0.03 266); white-space: nowrap;
+    transition: background 0.25s var(--ease-out-quart), color 0.25s var(--ease-out-quart), transform 0.15s var(--ease-out-quart), box-shadow 0.25s var(--ease-out-quart);
+}
+.tbd-btn svg { width: 1em; height: 1em; }
+.tbd-btn.is-primary {
+    color: oklch(0.97 0.01 266);
+    background: var(--step-how);
+    border-color: color-mix(in oklab, var(--step-how) 70%, white);
+    box-shadow: 0 0 0 3px oklch(0.56 0.16 266 / 0.30);
+}
+.tbd-cursor {
+    position: absolute; left: 50%; top: 20%; z-index: 4;
+    width: 18px; height: 18px; pointer-events: none;
+    transform: translate(40px, 34px);
+    transition: transform 0.7s var(--ease-out-quart), opacity 0.4s var(--ease-out-quart);
+    filter: drop-shadow(0 1px 2px oklch(0.2 0.02 264 / 0.4));
+}
+.tbd-cursor svg { width: 100%; height: 100%; display: block; }
+
+/* Caption strip under the stage */
+.tbd-caption {
+    display: flex; align-items: center; gap: 0.5em;
+    padding: 0.6rem 1rem;
+    font-family: var(--font-mono); font-size: var(--text-xs); color: var(--muted);
+    border-top: 1px solid var(--surface-border); background: var(--surface);
+}
+.tbd-caption .tbd-status-dot {
+    width: 7px; height: 7px; border-radius: 50%; background: var(--step-vision);
+    flex: 0 0 auto;
+}
+
+/* ── Playing state: choreography driven by data-phase ── */
+.tbd.is-playing .tbd-bar { opacity: 0; transform: translate(-50%, 8px); }
+.tbd.is-playing .tbd-child { opacity: 0; transform: translate(-50%, -50%) scale(0.7); }
+.tbd.is-playing .tbd-links path { opacity: 0; }
+.tbd.is-playing .tbd-caret { opacity: 0; }
+.tbd.is-playing .tbd-node.tbd-parent { box-shadow: 0 1px 3px oklch(0.2 0.02 264 / 0.10); }
+
+.tbd.is-playing[data-phase="focus"] .tbd-node.tbd-parent,
+.tbd.is-playing[data-phase="bar"] .tbd-node.tbd-parent,
+.tbd.is-playing[data-phase="type"] .tbd-node.tbd-parent,
+.tbd.is-playing[data-phase="press"] .tbd-node.tbd-parent,
+.tbd.is-playing[data-phase="work"] .tbd-node.tbd-parent,
+.tbd.is-playing[data-phase="done"] .tbd-node.tbd-parent {
+    box-shadow: 0 0 0 3px oklch(0.56 0.16 266 / 0.28), 0 6px 18px oklch(0.2 0.04 266 / 0.16);
+    transform: translate(-50%, -50%) translateY(-2px);
+}
+
+.tbd.is-playing[data-phase="bar"] .tbd-bar,
+.tbd.is-playing[data-phase="type"] .tbd-bar,
+.tbd.is-playing[data-phase="press"] .tbd-bar,
+.tbd.is-playing[data-phase="work"] .tbd-bar { opacity: 1; transform: translate(-50%, 0); }
+
+.tbd.is-playing[data-phase="bar"] .tbd-caret,
+.tbd.is-playing[data-phase="type"] .tbd-caret { opacity: 1; animation: tbd-blink 1s steps(1) infinite; }
+
+.tbd.is-playing[data-phase="press"] .tbd-btn.is-decompose,
+.tbd.is-playing[data-phase="work"] .tbd-btn.is-decompose {
+    color: oklch(0.97 0.01 266); background: var(--step-how);
+    border-color: color-mix(in oklab, var(--step-how) 70%, white);
+    box-shadow: 0 0 0 3px oklch(0.56 0.16 266 / 0.30);
+}
+.tbd.is-playing[data-phase="press"] .tbd-btn.is-decompose { transform: scale(0.94); }
+
+.tbd.is-playing[data-phase="work"] .tbd-child { opacity: 0.45; transform: translate(-50%, -50%) scale(0.9); }
+.tbd.is-playing[data-phase="done"] .tbd-child { opacity: 1; transform: translate(-50%, -50%) scale(1); }
+.tbd.is-playing[data-phase="done"] .tbd-bar { opacity: 0; transform: translate(-50%, 6px); }
+.tbd.is-playing[data-phase="work"] .tbd-links path,
+.tbd.is-playing[data-phase="done"] .tbd-links path { opacity: 1; }
+
+.tbd.is-playing[data-phase="idle"] .tbd-cursor { transform: translate(40px, 34px); opacity: 1; }
+.tbd.is-playing[data-phase="focus"] .tbd-cursor,
+.tbd.is-playing[data-phase="bar"] .tbd-cursor,
+.tbd.is-playing[data-phase="type"] .tbd-cursor { transform: translate(6px, 6px); opacity: 1; }
+.tbd.is-playing[data-phase="press"] .tbd-cursor { transform: translate(0, 2px) scale(0.86); opacity: 1; }
+.tbd.is-playing[data-phase="work"] .tbd-cursor,
+.tbd.is-playing[data-phase="done"] .tbd-cursor { transform: translate(40px, 30px); opacity: 0; }
+
+@keyframes tbd-blink { 0%, 50% { opacity: 1; } 51%, 100% { opacity: 0; } }
+
+.tbd-child { transform: translate(-50%, -50%); }
+
+/* ── App subpage ── */
+.subhero { padding: var(--space-2xl) 0 var(--space-xl); position: relative; overflow: hidden; }
+.subhero::before {
+    content: ''; position: absolute; pointer-events: none; z-index: 0;
+    width: clamp(280px, 42vw, 560px); height: clamp(280px, 42vw, 560px); border-radius: 50%;
+    background: radial-gradient(circle, oklch(0.45 0.16 266 / 0.12), transparent 70%);
+    top: 8%; right: -10%;
+}
+.subhero .hero-content { position: relative; z-index: 1; }
+.breadcrumb {
+    font-size: var(--text-sm); color: var(--muted); margin-bottom: var(--space-md);
+}
+.breadcrumb a { color: var(--muted); }
+.breadcrumb a:hover { color: var(--ink); }
+.breadcrumb .sep { margin: 0 0.5em; color: var(--muted-light); }
+.subhero h1 {
+    font-family: var(--font-display); font-weight: 800;
+    font-size: clamp(2.6rem, 1.9rem + 2.4vw, 4rem);
+    line-height: 1.05; letter-spacing: -0.03em; color: var(--ink-heading);
+    margin-bottom: var(--space-md); max-width: 16ch;
+}
+.subhero h1 .hl { color: var(--primary); }
+
+.feature-block { display: grid; gap: var(--space-xl); align-items: center; }
+@media (min-width: 900px) {
+    .feature-block { grid-template-columns: minmax(0, 1fr) minmax(0, 1.1fr); }
+    .feature-block.is-reversed .feature-media { order: -1; }
+}
+.feature-copy h2 { font-size: var(--text-2xl); margin-bottom: var(--space-md); }
+.feature-copy > p { color: var(--muted); max-width: 52ch; }
+.feature-media { min-width: 0; }
+.feature-eyebrow {
+    display: inline-block; font-family: var(--font-mono); font-size: var(--text-xs);
+    font-weight: 600; letter-spacing: 0.06em; text-transform: uppercase;
+    color: var(--accent); margin-bottom: var(--space-sm);
+}
+
+/* Action map: what each node type can derive */
+.action-map { list-style: none; margin: var(--space-lg) 0 0; display: flex; flex-direction: column; gap: var(--space-sm); }
+.action-row {
+    display: grid; grid-template-columns: auto 1fr; gap: var(--space-md); align-items: center;
+    padding: var(--space-sm) var(--space-md);
+    background: var(--surface); border-radius: 10px;
+}
+.action-from {
+    font-family: var(--font-mono); font-size: var(--text-sm); font-weight: 600;
+    color: color-mix(in oklab, var(--c) 72%, black);
+    background: color-mix(in oklab, var(--c) 12%, transparent);
+    border: 1px solid color-mix(in oklab, var(--c) 30%, transparent);
+    padding: 0.2em 0.6em; border-radius: 6px; white-space: nowrap; justify-self: start;
+}
+.action-to { display: flex; flex-wrap: wrap; gap: 0.4rem; align-items: center; }
+.action-pill {
+    font-family: var(--font-mono); font-size: var(--text-xs); font-weight: 600;
+    color: var(--ink); background: var(--bg-elevated);
+    border: 1px solid var(--surface-border); padding: 0.25em 0.55em; border-radius: 6px;
+}
+.action-pill.is-decompose { color: var(--primary); border-color: color-mix(in oklch, var(--primary) 30%, transparent); }
+
+/* Health metric chips */
+.metric-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(150px, 1fr)); gap: var(--space-md); margin-top: var(--space-lg); }
+.metric {
+    padding: var(--space-md); background: var(--bg-elevated);
+    border: 1px solid var(--surface-border); border-radius: 10px;
+}
+.metric .m-count { font-family: var(--font-display); font-size: var(--text-2xl); font-weight: 800; color: var(--ink-heading); }
+.metric .m-count.alert { color: oklch(0.55 0.19 30); }
+.metric .m-count.ok { color: oklch(0.45 0.15 145); }
+.metric .m-label { font-size: var(--text-sm); color: var(--muted); margin-top: 0.1em; }
+
+@media (max-width: 640px) {
+    .action-row { grid-template-columns: 1fr; gap: var(--space-sm); }
+}
+
+/* Decompose button: reset the static `is-primary` highlight while the demo
+   plays so it only lights up at the press/work phases (rules above). */
+.tbd.is-playing .tbd-btn.is-decompose {
+    color: oklch(0.88 0.02 266); background: oklch(0.30 0.02 266);
+    border-color: oklch(0.42 0.03 266); box-shadow: none; transform: none;
+}
+
+/* Subhero highlight underline tracks the primary (indigo), not the amber CP tint. */
+.subhero h1 .hl::after { background: var(--primary); }
+
+/* Stack the nav on narrow screens so wrapped links never collide with the brand. */
+@media (max-width: 768px) {
+    .site-nav .wrap { flex-wrap: wrap; row-gap: var(--space-sm); }
+    .site-nav-links { width: 100%; order: 3; justify-content: flex-start; gap: var(--space-md); }
+}

--- a/docs/assets/site.js
+++ b/docs/assets/site.js
@@ -1,0 +1,87 @@
+(function () {
+    'use strict';
+
+    document.body.classList.add('js');
+
+    var reduceMotion = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+
+    // ── Scroll reveal ──────────────────────────────────────────────
+    if ('IntersectionObserver' in window && !reduceMotion) {
+        var observer = new IntersectionObserver(function (entries) {
+            entries.forEach(function (entry) {
+                if (entry.isIntersecting) {
+                    entry.target.classList.add('visible');
+                    observer.unobserve(entry.target);
+                }
+            });
+        }, { threshold: 0.15, rootMargin: '0px 0px -40px 0px' });
+        document.querySelectorAll('.reveal').forEach(function (el) { observer.observe(el); });
+    }
+
+    // ── Smooth scroll for in-page anchors ─────────────────────────
+    document.querySelectorAll('a[href^="#"]').forEach(function (a) {
+        var hash = a.getAttribute('href');
+        if (hash === '#' || hash.length < 2) { return; }
+        a.addEventListener('click', function (e) {
+            var target = document.querySelector(hash);
+            if (target) {
+                e.preventDefault();
+                target.scrollIntoView({ behavior: 'smooth', block: 'start' });
+            }
+        });
+    });
+
+    // ── Animated task-bar demo ────────────────────────────────────
+    // Markup already renders the full, composed scene (visible default).
+    // When motion is allowed, we add `.is-playing` and cycle data-phase
+    // to choreograph: focus → action bar → typing → decompose → result.
+    function runTaskbarDemo(root) {
+        var textEl = root.querySelector('[data-tbd-text]');
+        var instruction = root.getAttribute('data-instruction') || 'Break into finer-grained sub-items';
+        var placeholder = root.getAttribute('data-placeholder') || 'Describe a change\u2026';
+        var working = root.getAttribute('data-working') || 'Running functional_requirements skill\u2026';
+        var phaseTimer = null;
+        var typeTimer = null;
+
+        function setText(value, isPlaceholder) {
+            if (!textEl) { return; }
+            textEl.textContent = value;
+            textEl.classList.toggle('is-placeholder', !!isPlaceholder);
+        }
+
+        function wait(ms, next) { phaseTimer = setTimeout(next, ms); }
+
+        function typeOut(text, next) {
+            setText('', false);
+            var i = 0;
+            (function tick() {
+                i += 1;
+                setText(text.slice(0, i), false);
+                if (i >= text.length) { wait(520, next); return; }
+                typeTimer = setTimeout(tick, 32);
+            })();
+        }
+
+        var steps = [
+            function (next) { root.dataset.phase = 'idle'; setText(placeholder, true); wait(1100, next); },
+            function (next) { root.dataset.phase = 'focus'; wait(720, next); },
+            function (next) { root.dataset.phase = 'bar'; setText(placeholder, true); wait(640, next); },
+            function (next) { root.dataset.phase = 'type'; typeOut(instruction, next); },
+            function (next) { root.dataset.phase = 'press'; wait(680, next); },
+            function (next) { root.dataset.phase = 'work'; setText(working, false); wait(1300, next); },
+            function (next) { root.dataset.phase = 'done'; setText(instruction, false); wait(2600, next); }
+        ];
+
+        var index = 0;
+        function step() {
+            steps[index](function () { index = (index + 1) % steps.length; step(); });
+        }
+
+        root.classList.add('is-playing');
+        requestAnimationFrame(step);
+    }
+
+    if (!reduceMotion) {
+        document.querySelectorAll('[data-taskbar-demo]').forEach(runTaskbarDemo);
+    }
+})();

--- a/docs/index.html
+++ b/docs/index.html
@@ -9,480 +9,7 @@
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Bricolage+Grotesque:wght@700;800&family=Figtree:wght@400;500;600&family=JetBrains+Mono:wght@400&display=swap" rel="stylesheet">
-    <style>
-        /* ── Tokens ── */
-        :root {
-            /* Primary — deep indigo, sampled from the SRS Navigator app's "Graph" control. */
-            --primary: oklch(0.45 0.16 266);
-            --primary-hover: oklch(0.38 0.16 266);
-            --primary-subtle: oklch(0.955 0.022 266);
-            /* Text on the primary fill — near-white for AA contrast on indigo. */
-            --on-primary: oklch(0.99 0 0);
-            /* Background — clean, slightly-cool off-white, matched to the app canvas. */
-            --bg: oklch(0.975 0.003 240);
-            --bg-elevated: oklch(1 0 0);
-            /* Surface — faint panels, hairline borders. */
-            --surface: oklch(0.965 0.004 240);
-            --surface-hover: oklch(0.945 0.005 240);
-            --surface-border: oklch(0.900 0.006 240);
-            /* Ink — near-black text, high contrast on off-white. */
-            --ink: oklch(0.30 0.012 264);
-            --ink-heading: oklch(0.19 0.018 264);
-            /* Accent — teal, sampled from the CN nodes. Darkened for link contrast. */
-            --accent: oklch(0.53 0.10 205);
-            --accent-hover: oklch(0.46 0.11 205);
-            /* Muted — secondary text, ≥4.5:1 on off-white. */
-            --muted: oklch(0.47 0.012 264);
-            --muted-light: oklch(0.57 0.012 264);
-            /* Methodology node colors — sampled directly from the SRS Navigator app. */
-            --step-context: oklch(0.52 0.16 305);
-            --step-why: oklch(0.61 0.18 48);
-            --step-glance: oklch(0.58 0.10 202);
-            --step-what: oklch(0.58 0.10 202);
-            --step-vision: oklch(0.55 0.12 150);
-            --step-how: oklch(0.56 0.16 266);
-            --step-nfr: oklch(0.54 0.15 320);
-            /* Bolder accents — committed color moments */
-            --cp-bold: oklch(0.55 0.17 50);          /* deepened amber for the hero "problem" word (4.8:1 on bg) */
-            --primary-deep: oklch(0.30 0.12 266);    /* drenched dark indigo for the closing panel */
-            --on-deep: oklch(0.99 0 0);
-            --on-deep-muted: oklch(0.86 0.04 266);
-            --chain-cp: oklch(0.84 0.13 55);         /* light node tints, ≥7.9:1 on the deep panel */
-            --chain-cn: oklch(0.82 0.09 200);
-            --chain-fr: oklch(0.88 0.05 266);
-            --cn-text: oklch(0.50 0.10 202);          /* CN teal at text contrast (5:1 on surface) */
-            --font-display: 'Bricolage Grotesque', system-ui, sans-serif;
-            --font-body: 'Figtree', system-ui, sans-serif;
-            --font-mono: 'JetBrains Mono', 'Cascadia Code', monospace;
-            --text-xs: clamp(0.75rem, 0.7rem + 0.15vw, 0.8rem);
-            --text-sm: clamp(0.825rem, 0.78rem + 0.2vw, 0.9rem);
-            --text-base: clamp(0.95rem, 0.88rem + 0.25vw, 1.05rem);
-            --text-lg: clamp(1.125rem, 1rem + 0.4vw, 1.3rem);
-            --text-xl: clamp(1.4rem, 1.2rem + 0.6vw, 1.65rem);
-            --text-2xl: clamp(1.75rem, 1.4rem + 1vw, 2.1rem);
-            --text-3xl: clamp(2.2rem, 1.7rem + 1.5vw, 2.8rem);
-            --text-hero: clamp(3.2rem, 2.2rem + 3vw, 5rem);
-            --space-xs: clamp(0.25rem, 0.2rem + 0.15vw, 0.375rem);
-            --space-sm: clamp(0.5rem, 0.4rem + 0.3vw, 0.75rem);
-            --space-md: clamp(1rem, 0.8rem + 0.6vw, 1.5rem);
-            --space-lg: clamp(1.5rem, 1.2rem + 1vw, 2.5rem);
-            --space-xl: clamp(2.5rem, 1.8rem + 2vw, 4rem);
-            --space-2xl: clamp(4rem, 2.8rem + 3.5vw, 6.5rem);
-            --space-section: clamp(5rem, 3.5rem + 4.5vw, 9rem);
-            --ease-out-quart: cubic-bezier(0.25, 1, 0.5, 1);
-        }
-
-        /* ── Reset ── */
-        *, *::before, *::after { margin: 0; padding: 0; box-sizing: border-box; }
-
-        body {
-            font-family: var(--font-body);
-            font-size: var(--text-base);
-            line-height: 1.7;
-            color: var(--ink);
-            background: var(--bg);
-            -webkit-font-smoothing: antialiased;
-            text-rendering: optimizeLegibility;
-        }
-
-        /* ── Typography ── */
-        h1, h2, h3 {
-            font-family: var(--font-display);
-            color: var(--ink-heading);
-            text-wrap: balance;
-            letter-spacing: -0.02em;
-        }
-        h2 { font-size: var(--text-3xl); font-weight: 800; letter-spacing: -0.03em; margin-bottom: var(--space-lg); }
-        h3 { font-size: var(--text-xl); margin-bottom: var(--space-sm); color: var(--ink); }
-        p { max-width: 68ch; }
-        a { color: var(--accent); text-decoration: none; transition: color 0.2s ease; }
-        a:hover { color: var(--accent-hover); }
-        a:focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; border-radius: 2px; }
-        code {
-            font-family: var(--font-mono);
-            font-size: 0.9em;
-            color: var(--ink-heading);
-            background: var(--surface);
-            padding: 0.15em 0.4em;
-            border-radius: 4px;
-            border: 1px solid var(--surface-border);
-        }
-        pre {
-            background: var(--bg-elevated);
-            border: 1px solid var(--surface-border);
-            border-radius: 8px;
-            padding: var(--space-md);
-            overflow-x: auto;
-            margin: var(--space-md) 0;
-        }
-        pre code { background: none; border: none; padding: 0; font-size: var(--text-sm); line-height: 1.6; }
-
-        /* ── Layout ── */
-        .wrap { max-width: 1120px; margin: 0 auto; padding: 0 var(--space-lg); }
-        .section { padding: var(--space-section) 0; }
-        .section + .section { border-top: 1px solid var(--surface-border); }
-
-        /* ── Skip link ── */
-        .skip-link {
-            position: absolute; left: -9999px; top: var(--space-sm);
-            background: var(--primary); color: var(--ink-heading);
-            padding: var(--space-sm) var(--space-md); border-radius: 8px;
-            font-weight: 600; z-index: 200;
-        }
-        .skip-link:focus { left: var(--space-md); }
-
-        /* ── Nav ── */
-        .site-nav {
-            position: sticky; top: 0; z-index: 100;
-            background: oklch(0.975 0.003 240 / 0.82);
-            backdrop-filter: blur(12px);
-            -webkit-backdrop-filter: blur(12px);
-            border-bottom: 1px solid var(--surface-border);
-        }
-        .site-nav .wrap {
-            display: flex; align-items: center; justify-content: space-between;
-            padding-top: var(--space-sm); padding-bottom: var(--space-sm);
-            gap: var(--space-md);
-        }
-        .site-nav-brand {
-            font-family: var(--font-display); font-size: var(--text-lg); font-weight: 700;
-            color: var(--ink-heading); text-decoration: none; white-space: nowrap;
-        }
-        .site-nav-brand span { color: var(--primary); }
-        .site-nav-id { display: inline-flex; align-items: center; gap: var(--space-sm); min-width: 0; }
-        .version-badge {
-            font-family: var(--font-mono); font-size: var(--text-xs); font-weight: 400;
-            line-height: 1.35; letter-spacing: 0.01em; white-space: nowrap;
-            color: var(--primary); background: var(--primary-subtle);
-            border: 1px solid color-mix(in oklch, var(--primary) 24%, transparent);
-            border-radius: 999px; padding: 0.18em 0.62em; text-decoration: none;
-            transition: background 0.2s ease, color 0.2s ease, border-color 0.2s ease;
-        }
-        .version-badge:hover {
-            color: var(--on-primary); background: var(--primary);
-            border-color: var(--primary);
-        }
-        .version-badge:focus-visible { outline: 2px solid var(--primary); outline-offset: 2px; }
-        .site-nav-links {
-            display: flex; gap: var(--space-md); list-style: none;
-            flex-wrap: wrap; align-items: center;
-        }
-        .site-nav-links a {
-            color: var(--muted); font-size: var(--text-sm); font-weight: 500;
-            transition: color 0.2s ease;
-            display: inline-flex; align-items: center; min-height: 24px; padding: 0.4rem 0;
-        }
-        .site-nav-links a:hover { color: var(--ink); }
-        .gh-link {
-            display: inline-flex; align-items: center; gap: 0.35em;
-            color: var(--muted); font-size: var(--text-sm); font-weight: 500;
-        }
-        .gh-link:hover { color: var(--ink); }
-        .gh-link svg { width: 18px; height: 18px; fill: currentColor; }
-
-        /* ── Hero ── */
-        .hero {
-            padding: var(--space-2xl) 0 var(--space-section);
-            position: relative; overflow: hidden;
-        }
-        .hero::before, .hero::after {
-            content: ''; position: absolute; pointer-events: none; z-index: 0;
-            width: clamp(280px, 42vw, 560px); height: clamp(280px, 42vw, 560px);
-            border-radius: 50%;
-        }
-        .hero::before { /* indigo field, anchored behind the app frame */
-            background: radial-gradient(circle, oklch(0.45 0.16 266 / 0.13), transparent 70%);
-            top: 16%; right: -8%;
-        }
-        .hero::after { /* amber field, anchored behind the headline */
-            background: radial-gradient(circle, oklch(0.61 0.18 48 / 0.11), transparent 70%);
-            top: 44%; left: -10%;
-        }
-        .hero-content { position: relative; z-index: 1; display: grid; gap: var(--space-2xl); align-items: center; }
-        @media (min-width: 900px) {
-            .hero-content { grid-template-columns: minmax(0, 1.05fr) minmax(0, 1fr); gap: var(--space-section); }
-        }
-        .hero-copy { min-width: 0; }
-        .hero-visual { margin: 0; min-width: 0; }
-        .hero-visual .app-frame { transition: transform 0.4s var(--ease-out-quart); }
-        @media (min-width: 900px) and (prefers-reduced-motion: no-preference) {
-            .hero-visual .app-frame:hover { transform: translateY(-4px); }
-        }
-        .hero-visual figcaption {
-            margin-top: var(--space-sm); font-size: var(--text-xs);
-            color: var(--muted); text-align: center;
-        }
-        .hero h1 {
-            font-size: var(--text-hero);
-            line-height: 1.04;
-            font-weight: 800;
-            letter-spacing: -0.03em;
-            margin-bottom: var(--space-lg);
-            max-width: 16ch;
-        }
-        .hero h1 .hl { color: var(--cp-bold); position: relative; white-space: nowrap; }
-        .hero h1 .hl::after {
-            content: ''; position: absolute; left: 0; right: 0; bottom: 0.04em;
-            height: 0.1em; border-radius: 2px;
-            background: var(--cp-bold); opacity: 0.22;
-        }
-        .hero-sub {
-            font-size: var(--text-lg);
-            color: var(--muted);
-            max-width: 52ch;
-            margin-bottom: var(--space-xl);
-            line-height: 1.6;
-        }
-        .hero-actions { display: flex; gap: var(--space-md); flex-wrap: wrap; align-items: center; }
-        .btn-primary {
-            display: inline-flex; align-items: center; gap: 0.5em;
-            background: var(--primary); color: var(--on-primary);
-            padding: 0.75em 1.5em; border-radius: 8px;
-            font-family: var(--font-body); font-size: var(--text-base); font-weight: 600;
-            text-decoration: none; transition: background 0.2s ease;
-        }
-        .btn-primary:hover { background: var(--primary-hover); color: var(--on-primary); }
-        .btn-ghost {
-            display: inline-flex; align-items: center; gap: 0.5em;
-            background: transparent; color: var(--ink);
-            padding: 0.75em 1.5em; border-radius: 8px;
-            border: 1px solid var(--surface-border);
-            font-family: var(--font-body); font-size: var(--text-base); font-weight: 500;
-            text-decoration: none; transition: background 0.2s ease, border-color 0.2s ease;
-        }
-        .btn-ghost:hover { background: var(--surface); border-color: var(--muted-light); color: var(--ink); }
-        .hero-meta {
-            margin-top: var(--space-xl); display: flex; gap: var(--space-md);
-            flex-wrap: wrap; align-items: center;
-        }
-        .hero-badge {
-            font-size: var(--text-xs); color: var(--muted);
-            border: 1px solid var(--surface-border); padding: 0.3em 0.8em;
-            border-radius: 100px; white-space: nowrap;
-        }
-
-        /* ── Problem section ── */
-        .problem-before {
-            background: var(--surface); border-radius: 10px;
-            padding: var(--space-lg); margin: var(--space-lg) 0;
-            max-width: 56ch;
-        }
-        .problem-before p { color: var(--muted); }
-        .problem-before .quote {
-            font-size: var(--text-lg); color: var(--ink);
-            font-style: italic; margin-bottom: var(--space-md);
-        }
-        .problem-after {
-            margin: var(--space-lg) 0; max-width: 56ch;
-        }
-        .problem-after .cp {
-            font-family: var(--font-mono); font-size: var(--text-base);
-            color: oklch(0.48 0.14 50); background: oklch(0.61 0.18 48 / 0.10);
-            padding: var(--space-sm) var(--space-md); border-radius: 8px;
-            display: block; margin: var(--space-md) 0;
-        }
-
-        /* ── Flow (methodology timeline) ── */
-        .flow { position: relative; padding-left: 2.5rem; margin: var(--space-xl) 0; }
-        .flow::before {
-            content: ''; position: absolute; left: 7px; top: 8px; bottom: 8px;
-            width: 2px; background: var(--surface-border);
-        }
-        .flow-step {
-            position: relative; padding-bottom: var(--space-xl);
-        }
-        .flow-step:last-child { padding-bottom: 0; }
-        .flow-dot {
-            position: absolute; left: -2.5rem; top: 4px;
-            width: 16px; height: 16px; border-radius: 50%;
-            background: var(--dot-color, var(--muted));
-        }
-        .flow-name {
-            font-family: var(--font-display); font-size: var(--text-xl);
-            font-weight: 700; color: var(--ink-heading);
-            margin-bottom: var(--space-xs);
-        }
-        .flow-question {
-            font-size: var(--text-sm); color: var(--muted);
-            font-style: italic; margin-bottom: var(--space-xs);
-        }
-        .flow-desc { color: var(--ink); max-width: 52ch; }
-        .flow-cmd {
-            display: inline-block; margin-top: var(--space-sm);
-            font-family: var(--font-mono); font-size: var(--text-sm);
-            color: var(--accent); background: var(--bg-elevated);
-            padding: 0.2em 0.6em; border-radius: 4px;
-            border: 1px solid var(--surface-border);
-        }
-        .flow-trace {
-            margin-top: var(--space-xl); padding: var(--space-md) var(--space-lg);
-            background: var(--surface); border-radius: 10px;
-            font-family: var(--font-mono); font-size: var(--text-base);
-            color: var(--ink); text-align: center; letter-spacing: 0.02em;
-        }
-        .flow-trace .arrow { color: var(--muted); margin: 0 0.3em; }
-        .flow-trace .t-cp { color: var(--cp-bold); }
-        .flow-trace .t-cn { color: var(--cn-text); }
-        .flow-trace .t-fr { color: var(--primary); }
-
-        /* ── Classification ── */
-        .class-grid { margin-top: var(--space-lg); display: flex; flex-direction: column; gap: var(--space-md); }
-        .class-row {
-            display: grid; grid-template-columns: auto 1fr;
-            gap: var(--space-md); align-items: start;
-            padding: var(--space-md) var(--space-lg);
-            background: var(--surface); border-radius: 10px;
-        }
-        .class-indicator {
-            width: 10px; height: 10px; border-radius: 50%;
-            margin-top: 0.45em; flex-shrink: 0;
-        }
-        .class-label {
-            font-family: var(--font-display); font-size: var(--text-lg); font-weight: 700;
-            color: var(--ink-heading);
-        }
-        .class-verb { font-family: var(--font-mono); font-size: var(--text-sm); color: var(--muted); }
-        .class-desc { color: var(--ink); margin-top: var(--space-xs); }
-
-        /* ── Commands table ── */
-        .cmd-table { width: 100%; border-collapse: collapse; margin-top: var(--space-lg); }
-        .cmd-table th {
-            text-align: left; font-size: var(--text-sm); color: var(--muted);
-            font-weight: 500; padding: var(--space-sm) var(--space-md);
-            border-bottom: 1px solid var(--surface-border);
-        }
-        .cmd-table td {
-            padding: var(--space-sm) var(--space-md);
-            border-bottom: 1px solid var(--surface-border);
-            font-size: var(--text-sm);
-        }
-        .cmd-table tr:hover td { background: var(--surface); }
-        .cmd-table .cmd-name {
-            font-family: var(--font-mono); color: var(--accent); white-space: nowrap;
-        }
-        .table-scroll { overflow-x: auto; -webkit-overflow-scrolling: touch; margin-top: var(--space-lg); }
-        .table-scroll .cmd-table { margin-top: 0; }
-
-        /* ── App showcase (SRS Navigator) ── */
-        .section-lead { color: var(--muted); max-width: 62ch; margin-bottom: var(--space-lg); }
-        .section-lead strong { color: var(--ink-heading); font-weight: 600; }
-        .legend-intro { color: var(--muted); font-size: var(--text-sm); margin-bottom: var(--space-sm); }
-        .node-legend {
-            list-style: none; display: flex; flex-wrap: wrap;
-            gap: var(--space-md); margin-bottom: var(--space-lg);
-        }
-        .node-legend li {
-            display: inline-flex; align-items: center; gap: 0.5rem;
-            font-size: var(--text-sm); color: var(--muted);
-        }
-        .node-chip {
-            font-family: var(--font-mono); font-size: var(--text-xs); font-weight: 600;
-            color: color-mix(in oklab, var(--c) 76%, black); background: color-mix(in oklab, var(--c) 12%, transparent);
-            border: 1px solid color-mix(in oklab, var(--c) 32%, transparent);
-            padding: 0.2em 0.55em; border-radius: 6px; letter-spacing: 0.02em;
-        }
-        .app-frame {
-            border-radius: 14px; overflow: hidden; background: var(--bg-elevated);
-            box-shadow: 0 2px 4px oklch(0.2 0.02 264 / 0.05),
-                        0 20px 44px oklch(0.42 0.05 25 / 0.12);
-        }
-        .app-frame-bar {
-            display: flex; align-items: center; gap: 0.7rem;
-            padding: 0.7rem 1rem; background: var(--surface);
-            border-bottom: 1px solid var(--surface-border);
-        }
-        .app-dots { display: flex; gap: 0.4rem; }
-        .app-dots span { width: 11px; height: 11px; border-radius: 50%; background: var(--surface-border); }
-        .app-frame-title { font-family: var(--font-mono); font-size: var(--text-xs); color: var(--muted); }
-        .app-frame img { display: block; width: 100%; height: auto; }
-        .app-actions { margin-top: var(--space-lg); display: flex; gap: var(--space-md); flex-wrap: wrap; }
-
-        /* ── Iterate section: stacked annotated screenshots ── */
-        .shot-stack { display: grid; gap: var(--space-xl); margin-top: var(--space-xl); }
-        .shot figure { margin: 0; }
-        .shot-copy { margin-bottom: var(--space-md); }
-        .shot-copy h3 { font-size: var(--text-lg); margin: 0 0 0.4rem; }
-        .shot-copy p { color: var(--muted); max-width: 60ch; }
-        .shot figcaption { margin-top: var(--space-sm); font-family: var(--font-mono); font-size: var(--text-xs); color: var(--muted); }
-
-        /* ── Footer CTA ── */
-        /* ── Footer CTA — drenched dark panel, the bold close ── */
-        .footer-cta {
-            background: var(--primary-deep);
-            padding: var(--space-section) 0;
-            text-align: center;
-            position: relative; overflow: hidden;
-        }
-        .footer-cta::before {
-            content: ''; position: absolute; inset: 0; pointer-events: none;
-            background:
-                radial-gradient(58% 80% at 12% 8%, oklch(0.61 0.18 48 / 0.16), transparent 60%),
-                radial-gradient(58% 80% at 88% 92%, oklch(0.58 0.10 202 / 0.16), transparent 60%);
-        }
-        .footer-cta .wrap { position: relative; z-index: 1; }
-        .cta-chain {
-            font-family: var(--font-display); font-weight: 800;
-            font-size: clamp(2.75rem, 1.6rem + 4.5vw, 5rem);
-            letter-spacing: -0.03em; line-height: 1;
-            margin: 0 auto var(--space-lg);
-            display: flex; align-items: center; justify-content: center;
-            gap: clamp(0.5rem, 2.5vw, 1.5rem);
-        }
-        .cta-chain .chain-cp { color: var(--chain-cp); }
-        .cta-chain .chain-cn { color: var(--chain-cn); }
-        .cta-chain .chain-fr { color: var(--chain-fr); }
-        .cta-chain .chain-arrow { color: var(--on-deep-muted); font-weight: 400; font-size: 0.55em; }
-        .footer-cta h2 { color: var(--on-deep); margin-bottom: var(--space-md); }
-        .footer-cta p { margin: 0 auto var(--space-lg); color: var(--on-deep-muted); max-width: 54ch; }
-        .footer-cta .hero-actions { justify-content: center; }
-        .footer-cta .btn-primary { background: var(--on-deep); color: var(--primary-deep); }
-        .footer-cta .btn-primary:hover { background: oklch(0.92 0.03 266); color: var(--primary-deep); }
-        .footer-cta .btn-ghost { color: var(--on-deep); border-color: oklch(0.92 0.02 266 / 0.4); }
-        .footer-cta .btn-ghost:hover { background: oklch(1 0 0 / 0.08); border-color: var(--on-deep); color: var(--on-deep); }
-
-        /* ── Footer ── */
-        .site-footer {
-            padding: var(--space-xl) 0; text-align: center;
-            border-top: 1px solid var(--surface-border);
-        }
-        .site-footer p { color: var(--muted-light); font-size: var(--text-sm); margin: 0 auto; }
-        .site-footer a { color: var(--muted); display: inline-block; padding: 0.3rem 0.15rem; min-height: 24px; }
-        .site-footer a:hover { color: var(--ink); }
-        .footer-links { margin-top: var(--space-xs); }
-        .footer-version { font-family: var(--font-mono); font-size: 0.92em; color: var(--accent); }
-        .footer-version:hover { color: var(--accent-hover); }
-        .footer-links a + a::before { content: ' · '; color: var(--muted-light); }
-
-        /* ── Scroll reveal ── */
-        .reveal { opacity: 1; }
-        @media (prefers-reduced-motion: no-preference) {
-            body.js .reveal {
-                opacity: 0; transform: translateY(12px);
-                transition: opacity 0.5s var(--ease-out-quart), transform 0.5s var(--ease-out-quart);
-            }
-            body.js .reveal.visible { opacity: 1; transform: translateY(0); }
-        }
-
-        /* ── Responsive ── */
-        @media (max-width: 640px) {
-            .site-nav-links { gap: var(--space-sm); }
-            .site-nav-links a { font-size: var(--text-xs); }
-            .hero h1 { max-width: none; }
-            .hero-actions { flex-direction: column; align-items: stretch; }
-            .btn-primary, .btn-ghost { justify-content: center; }
-            .class-row { grid-template-columns: 1fr; }
-            .class-indicator { display: none; }
-            .cmd-table { font-size: var(--text-xs); }
-            .cmd-table th:last-child, .cmd-table td:last-child { display: none; }
-        }
-
-        @media (prefers-reduced-motion: reduce) {
-            *, *::before, *::after {
-                animation-duration: 0.01ms !important;
-                transition-duration: 0.01ms !important;
-            }
-        }
-    </style>
+    <link rel="stylesheet" href="assets/site.css">
 </head>
 <body>
     <a href="#main" class="skip-link">Skip to content</a>
@@ -498,6 +25,7 @@
                 <li><a href="#methodology">How it works</a></li>
                 <li><a href="#visualize">Visualize</a></li>
                 <li><a href="#iterate">Iterate</a></li>
+                <li><a href="app.html">The app</a></li>
                 <li><a href="#start">Get started</a></li>
                 <li><a href="#commands">Commands</a></li>
                 <li><a href="#research">Research</a></li>
@@ -515,10 +43,14 @@
         <div class="wrap hero-content">
             <div class="hero-copy">
             <h1>Trace every feature to the <span class="hl">problem</span> it solves</h1>
-            <p class="hero-sub">AI-guided requirements engineering for software teams. Your coding assistant walks you from customer problems to functional requirements, with complete traceability at every step.</p>
+            <p class="hero-sub">Problem-Based SRS is two things at once: a <strong>methodology</strong> your AI assistant runs as Skills, and the <strong>SRS Navigator</strong> app that turns the result into a living graph you refine together.</p>
+            <div class="hero-features">
+                <span class="hero-feature"><span class="hf-dot" style="--hf: var(--step-why)" aria-hidden="true"></span><b>Skills</b> <span class="hf-kind">the methodology</span></span>
+                <span class="hero-feature"><span class="hf-dot" style="--hf: var(--step-how)" aria-hidden="true"></span><b>SRS Navigator</b> <span class="hf-kind">the app</span></span>
+            </div>
             <div class="hero-actions">
                 <a href="https://github.com/RafaelGorski/Problem-Based-SRS" class="btn-primary">View on GitHub</a>
-                <a href="https://www.periodicosibepes.org.br/index.php/reinfo/article/view/2230" class="btn-ghost" target="_blank" rel="noopener">Read the research</a>
+                <a href="app.html" class="btn-ghost">Explore the app</a>
             </div>
             <div class="hero-meta">
                 <span class="hero-badge">AgentSkills standard</span>
@@ -532,15 +64,87 @@
                         <div class="app-dots" aria-hidden="true"><span></span><span></span><span></span></div>
                         <span class="app-frame-title">Copilot &middot; SRS Navigator</span>
                     </div>
-                    <img src="assets/srs-navigator.png" width="1280" height="796" fetchpriority="high" decoding="async"
-                         alt="The SRS Navigator graph of a CRM specification: orange customer-problem nodes, teal customer-need nodes, indigo functional-requirement nodes, and purple non-functional nodes connected by dashed traceability links.">
+                    <div class="tbd" data-taskbar-demo
+                         data-instruction="Break FR-1 into finer-grained sub-items"
+                         data-placeholder="Describe a change&hellip;"
+                         data-working="Running functional_requirements skill&hellip;">
+                        <div class="tbd-stage" role="img"
+                             aria-label="The SRS Navigator action bar in use: a functional-requirement node is selected, an instruction to break it into finer-grained sub-items is typed, the decompose action runs, and two sub-requirement nodes appear.">
+                            <svg class="tbd-links" viewBox="0 0 100 100" preserveAspectRatio="none" aria-hidden="true">
+                                <path d="M50 24 C 42 46, 33 56, 30 68" />
+                                <path d="M50 24 C 58 46, 67 56, 70 68" />
+                            </svg>
+                            <span class="tbd-node tbd-parent"><span class="tbd-glyph" aria-hidden="true">&lt;/&gt;</span>FR-1 &middot; Contact management</span>
+                            <span class="tbd-node tbd-child tbd-child-a"><span class="tbd-glyph" aria-hidden="true">&lt;/&gt;</span>FR-1.1 &middot; Create</span>
+                            <span class="tbd-node tbd-child tbd-child-b"><span class="tbd-glyph" aria-hidden="true">&lt;/&gt;</span>FR-1.2 &middot; Edit</span>
+                            <div class="tbd-bar" aria-hidden="true">
+                                <span class="tbd-bar-input"><span class="tbd-bar-text is-placeholder" data-tbd-text>Describe a change&hellip;</span><span class="tbd-caret"></span></span>
+                                <span class="tbd-btn">+NFR</span>
+                                <span class="tbd-btn is-decompose is-primary">+Sub-FR</span>
+                            </div>
+                            <div class="tbd-cursor" aria-hidden="true">
+                                <svg viewBox="0 0 24 24" fill="oklch(0.24 0.02 266)" stroke="#fff" stroke-width="1.4"><path d="M5 3l14 8-6 1.6L9.6 19 5 3z"/></svg>
+                            </div>
+                        </div>
+                        <div class="tbd-caption">
+                            <span class="tbd-status-dot" aria-hidden="true"></span>
+                            Decompose a requirement, live in the side panel
+                        </div>
+                    </div>
                 </div>
-                <figcaption>The SRS Navigator graph, live in the GitHub Copilot side panel.</figcaption>
+                <figcaption>The action bar in the SRS Navigator: hover a node, describe a change, and the agent runs the matching skill.</figcaption>
             </figure>
         </div>
     </header>
 
     <main id="main">
+        <!-- Two parts: Skills + App -->
+        <section id="parts" class="section">
+            <div class="wrap">
+                <h2 class="reveal">One project, two ways to work</h2>
+                <p class="reveal section-lead">Problem-Based SRS ships as two things: <strong>Skills</strong>, the methodology your AI assistant runs step by step, and the <strong>SRS Navigator</strong>, a Copilot app that turns the resulting spec into a graph you refine together. Use either on its own, or both.</p>
+                <div class="parts-grid">
+                    <div class="part part--skills reveal">
+                        <span class="part-tag">The methodology</span>
+                        <h3>Skills</h3>
+                        <p>Ten AgentSkills walk a coding assistant from a customer problem to traceable requirements, one decision at a time.</p>
+                        <div class="part-chain" aria-label="Traceability chain: Customer Problem to Customer Need to Functional Requirement">
+                            <span class="pc pc-cp">CP</span><span class="pc-arrow" aria-hidden="true">&rarr;</span>
+                            <span class="pc pc-cn">CN</span><span class="pc-arrow" aria-hidden="true">&rarr;</span>
+                            <span class="pc pc-fr">FR</span>
+                        </div>
+                        <ul class="part-list" style="--bullet: var(--step-why)">
+                            <li>Business context, customer problems, needs, then functional requirements</li>
+                            <li>Every requirement traces back to the problem it solves</li>
+                            <li>Runs in GitHub Copilot, Claude Code, and Claude.ai</li>
+                        </ul>
+                        <div class="part-cta">
+                            <a class="part-link" href="#methodology">See the method <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M5 12h14M13 6l6 6-6 6"/></svg></a>
+                        </div>
+                    </div>
+                    <div class="part part--app reveal">
+                        <span class="part-tag">The app</span>
+                        <h3>SRS Navigator</h3>
+                        <p>A Copilot canvas that renders your specification as an interactive graph, then lets you decompose and iterate on it with the agent, in place.</p>
+                        <ul class="node-legend" aria-label="Node types in the graph" style="margin-bottom: var(--space-lg)">
+                            <li><span class="node-chip" style="--c: var(--step-why)">CP</span> Problem</li>
+                            <li><span class="node-chip" style="--c: var(--step-what)">CN</span> Need</li>
+                            <li><span class="node-chip" style="--c: var(--step-how)">FR</span> Requirement</li>
+                            <li><span class="node-chip" style="--c: var(--step-nfr)">NFR</span> Non-functional</li>
+                        </ul>
+                        <ul class="part-list" style="--bullet: var(--step-how)">
+                            <li>Force-directed graph of every artifact and its traceability</li>
+                            <li>Inline action bar to derive or decompose any node</li>
+                            <li>Health metrics surface orphaned problems and unmet needs</li>
+                        </ul>
+                        <div class="part-cta">
+                            <a class="part-link" href="app.html">Explore the app <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M5 12h14M13 6l6 6-6 6"/></svg></a>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </section>
+
         <!-- The Problem -->
         <section id="problem" class="section">
             <div class="wrap">
@@ -675,7 +279,7 @@
         <section id="iterate" class="section">
             <div class="wrap">
                 <h2 class="reveal">Decompose and iterate with the agent</h2>
-                <p class="reveal section-lead">The navigator is more than a viewer — it's where you refine the specification <em>together with the agent</em>, without leaving the graph. Hover a node, describe the change, and the matching methodology skill does the work while traceability is preserved.</p>
+                <p class="reveal section-lead">The navigator is more than a viewer. It's where you refine the specification <em>together with the agent</em>, without leaving the graph. Hover a node, describe the change, and the matching methodology skill does the work while traceability is preserved.</p>
 
                 <div class="shot-stack">
                     <div class="shot reveal">
@@ -699,7 +303,7 @@
                     <div class="shot reveal">
                         <div class="shot-copy">
                             <h3>2 &middot; The agent works in the side panel</h3>
-                            <p>Triggering an action opens the node's detail panel — description, complexity, and upstream/downstream traceability — alongside a live <strong>Agent Activity</strong> log. Your request runs through the methodology skill, the spec is edited, and the graph refreshes automatically.</p>
+                            <p>Triggering an action opens the node's detail panel (description, complexity, and upstream/downstream traceability) alongside a live <strong>Agent Activity</strong> log. Your request runs through the methodology skill, the spec is edited, and the graph refreshes automatically.</p>
                         </div>
                         <figure>
                             <div class="app-frame">
@@ -857,25 +461,6 @@ Our warehouse tracks everything in spreadsheets and loses $50k/month due to erro
         </div>
     </footer>
 
-    <script>
-        document.body.classList.add('js');
-        if ('IntersectionObserver' in window && !window.matchMedia('(prefers-reduced-motion: reduce)').matches) {
-            var observer = new IntersectionObserver(function(entries) {
-                entries.forEach(function(entry) {
-                    if (entry.isIntersecting) {
-                        entry.target.classList.add('visible');
-                        observer.unobserve(entry.target);
-                    }
-                });
-            }, { threshold: 0.15, rootMargin: '0px 0px -40px 0px' });
-            document.querySelectorAll('.reveal').forEach(function(el) { observer.observe(el); });
-        }
-        document.querySelectorAll('.site-nav-links a[href^="#"]').forEach(function(a) {
-            a.addEventListener('click', function(e) {
-                var target = document.querySelector(this.getAttribute('href'));
-                if (target) { e.preventDefault(); target.scrollIntoView({ behavior: 'smooth', block: 'start' }); }
-            });
-        });
-    </script>
+    <script src="assets/site.js" defer></script>
 </body>
 </html>


### PR DESCRIPTION
Adds the SRS Navigator App subpage (docs/app.html) and reworks the homepage hero to emphasize the two v2.0 deliverables: the Skills methodology and the SRS Navigator app.

## Changes
- Extract shared design system into docs/assets/site.css and docs/assets/site.js
- Rework hero: Skills + App messaging, two-pillar section, animated task-bar/action-bar demo (with prefers-reduced-motion fallback)
- New docs/app.html: graph view, action bar action map, decompose flow, spec-health metrics, /live launch
- Nav 'The app' link; v2.0 reflected across both pages

Verified with Playwright across desktop, mobile, and reduced-motion.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>