### PR TITLE
feat: Animate CP → CN → FR chain build on graph load

### DIFF
--- a/.github/extensions/srs-navigator/README.md
+++ b/.github/extensions/srs-navigator/README.md
@@ -8,6 +8,7 @@ An interactive force-directed graph visualization for **Problem-Based SRS** spec
 
 - **Learn from your codebase** — Open the navigator without a spec and it offers to scan your code, README, and docs to draft a Problem-Based SRS automatically
 - **Interactive D3.js graph** — Force-directed layout showing relationships between problems, needs, and requirements
+- **Traceability build animation** — On first open, the graph assembles itself in methodology order: Customer Problems surface first, then the Customer Needs and links that address them, then the Functional and Non-Functional Requirements that satisfy them (respects `prefers-reduced-motion`)
 - **Search & filter** — Find nodes by ID or label text, toggle node types via the legend
 - **Detail panel** — Click any node to see its full description and connections
 - **Graph/Hierarchy views** — Toggle between force-directed graph and hierarchical layout

--- a/.github/extensions/srs-navigator/lib/renderer.mjs
+++ b/.github/extensions/srs-navigator/lib/renderer.mjs
@@ -2589,6 +2589,59 @@ export function renderGraphHtml(graphData, options = {}) {
     // Initial visibility
     updateVisibility();
 
+    // === Intro: build the traceability chain (Customer Problem -> Customer Need -> Requirement) ===
+    // The graph assembles itself in the methodology's causal order: problems surface first,
+    // then the needs and links that address them, then the requirements that satisfy them.
+    (function introReveal() {
+      const prefersReduced = window.matchMedia && window.matchMedia("(prefers-reduced-motion: reduce)").matches;
+      let alreadyPlayed = false;
+      try { alreadyPlayed = sessionStorage.getItem("srsIntroPlayed") === "1"; } catch (e) {}
+
+      // Skip the choreography for reduced-motion users and on later refreshes
+      // (agent edits reload the page); the chain builds once per canvas session.
+      if (prefersReduced || alreadyPlayed || nodes.length === 0) {
+        nodeElements.attr("opacity", 1);
+        linkElements.attr("opacity", 1);
+        return;
+      }
+      try { sessionStorage.setItem("srsIntroPlayed", "1"); } catch (e) {}
+
+      // problem (CP) reveals first, need (CN) second, fr/nfr (requirements) last
+      const tierOf = (t) => t === "problem" ? 0 : t === "need" ? 1 : 2;
+      const TIER_GAP = 340; // ms between successive tiers
+      const STEP = 45;      // ms stagger between siblings within a tier
+      const MAX_STAGGER = 12; // cap the staggered count so large tiers stay snappy
+
+      const tierCounts = {};
+      nodeElements.attr("opacity", 0).each(function(d) {
+        const tier = tierOf(d.type);
+        const idx = (tierCounts[tier] = (tierCounts[tier] || 0) + 1) - 1;
+        d._introDelay = tier * TIER_GAP + Math.min(idx, MAX_STAGGER) * STEP;
+      });
+
+      nodeElements.transition()
+        .delay(d => d._introDelay)
+        .duration(460)
+        .ease(d3.easeCubicOut)
+        .attr("opacity", 1);
+
+      // A link forms once its downstream endpoint has appeared, so the chain
+      // visibly connects CP -> CN, then CN -> FR.
+      linkElements.attr("opacity", 0)
+        .transition()
+        .delay(d => {
+          const src = typeof d.source === "object" ? d.source : nodes.find(n => n.id === d.source);
+          const tgt = typeof d.target === "object" ? d.target : nodes.find(n => n.id === d.target);
+          const tier = Math.max(tierOf(src && src.type), tierOf(tgt && tgt.type));
+          return tier * TIER_GAP + 140;
+        })
+        .duration(420)
+        .ease(d3.easeCubicOut)
+        .attr("opacity", 1);
+
+      announce("Building traceability chain: customer problems, then needs, then requirements.");
+    })();
+
     // Handle resize
     window.addEventListener("resize", () => {
       simulation.force("center", d3.forceCenter(container.clientWidth / 2, container.clientHeight / 2));

--- a/.github/extensions/srs-navigator/tests/renderer.test.mjs
+++ b/.github/extensions/srs-navigator/tests/renderer.test.mjs
@@ -178,6 +178,15 @@ describe("renderGraphHtml", () => {
     assert.ok(html.includes("stroke-dasharray: 5,5"));
   });
 
+  it("includes the CP -> CN -> FR intro build animation", () => {
+    const html = renderGraphHtml(sampleGraph);
+    // Signature entrance: nodes reveal in methodology tier order, once per session.
+    assert.ok(html.includes("srsIntroPlayed"), "intro reveal is gated once per session");
+    assert.ok(html.includes("introReveal"), "intro reveal routine present");
+    assert.ok(html.includes("_introDelay"), "per-node tier delay is computed");
+    assert.ok(html.includes("prefers-reduced-motion"), "intro respects reduced motion");
+  });
+
   it("includes hull polygon for selection", () => {
     const html = renderGraphHtml(sampleGraph);
     assert.ok(html.includes("hull-group"));

--- a/docs/index.html
+++ b/docs/index.html
@@ -309,7 +309,7 @@
         <section id="visualize" class="section">
             <div class="wrap">
                 <h2 class="reveal">See your spec as a living graph</h2>
-                <p class="reveal section-lead">The <strong>SRS Navigator</strong> renders every artifact and its traceability as an interactive, force-directed graph inside the GitHub Copilot side panel. Filter by analysis mode, search any node, and follow problem to need to requirement without switching tools.</p>
+                <p class="reveal section-lead">The <strong>SRS Navigator</strong> renders every artifact and its traceability as an interactive, force-directed graph inside the GitHub Copilot side panel. It opens by building the chain in front of you, problems first, then the needs and links that address them, then the requirements that satisfy them, so the structure reads before you touch it. Filter by analysis mode, search any node, and follow problem to need to requirement without switching tools.</p>
 
                 <p class="reveal legend-intro">Every node is color-coded by type:</p>
                 <ul class="node-legend reveal" aria-label="Node types in the graph">


### PR DESCRIPTION
## What

The SRS Navigator canvas now **builds the traceability chain in front of you** when the graph first opens, instead of dropping every node in at once.

The reveal follows the methodology's causal order:
1. **Customer Problems (CP)** surface first
2. **Customer Needs (CN)** and the links that address them appear next
3. **Functional & Non-Functional Requirements (FR/NFR)** that satisfy the needs come last

Nodes stagger within each tier, links fade in with their downstream endpoint, and the whole choreography plays **once per canvas session** (later agent-edit refreshes are instant). Fully honors `prefers-reduced-motion` — reduced-motion users get the finished graph immediately.

## Changes

- `lib/renderer.mjs` — tiered, staggered opacity reveal driven by d3 transitions, gated via `sessionStorage` and a reduced-motion check.
- `tests/renderer.test.mjs` — new assertion covering the intro build routine.
- `README.md` (extension) — added the animation to the feature list.
- `docs/index.html` — updated the GitHub Pages "See your spec as a living graph" section to describe the on-load build.

## Verification

- `npm test` → 137 passing (incl. the new intro test).
- Playwright render of the demo spec confirmed: at ~120ms only the Customer Problems are visible (27/29 nodes still hidden), by ~1.7s all 29 nodes and links are revealed, **no console errors**.

The minor version release is handled by the `Release Canvas Extension` workflow after merge.

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>