### PR TITLE
Animate the problem and how-it-works sections (v2.3)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "problem-based-srs",
-  "version": "2.2.0",
+  "version": "2.3.0",
   "description": "Problem-Based Software Requirements Specification methodology for AI-assisted requirements engineering. Provides structured approach to capture Customer Problems (WHY), Customer Needs (WHAT), and Functional Requirements (HOW) with full traceability.",
   "author": {
     "name": "Rafael Gorski",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.3] - 2026-07-01
+
+### Added
+
+- **"Most requirements start in the wrong place" now shows the problem-highlight
+  animation.** `docs/index.html` gains a two-column layout with an app-faithful SRS
+  Navigator graph of the VagrantChefHubot example (`docs/assets/srs-problems.svg`). Its
+  CSS keyframes present the whole 28-node spec, then dim the Needs and Requirements while
+  the five Customer Problems (CP-1 through CP-5) light up with pulsing rings, making the
+  visual argument that requirements begin at the problem. Honors `prefers-reduced-motion`.
+- **"How it works" now opens with a CLI chat simulation.** A dark terminal mockup animates
+  the Copilot CLI calling each methodology skill in order (`/business-context`,
+  `/customer-problems`, `/software-glance`, `/customer-needs`, `/software-vision`,
+  `/functional-requirements`), each command tinted with its step color, ending on
+  100% traceability from FR back to CN back to CP. Built with pure CSS/HTML; the assembled
+  state is the default so it stays readable under reduced motion.
+- **`scripts/build-problem-highlight.mjs`**: generator for `srs-problems.svg`. Node colors
+  and Phosphor icons are sampled verbatim from the extension's `renderer.mjs`; the chrome
+  mirrors the navigator on the VagrantChefHubot spec. The canvas app itself is unchanged.
+
+[2.3]: https://github.com/RafaelGorski/Problem-Based-SRS/releases/tag/v2.3
+
 ## [2.2] - 2026-07-01
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Problem-Based SRS
 
-[![Version 2.2](https://img.shields.io/badge/version-2.2-green.svg)](https://github.com/RafaelGorski/Problem-Based-SRS/releases/tag/v2.2)
+[![Version 2.3](https://img.shields.io/badge/version-2.3-green.svg)](https://github.com/RafaelGorski/Problem-Based-SRS/releases/tag/v2.3)
 [![AgentSkills](https://img.shields.io/badge/AgentSkills-Open%20Standard-blue)](https://agentskills.io)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 
@@ -155,8 +155,10 @@ CRM demo if you haven't created one yet). The extension also bundles the full me
 as agent tools, so every step is available without leaving the panel.
 
 > Prefer a preview first? The [project website](https://rafaelgorski.github.io/Problem-Based-SRS/)
-> plays an app-faithful animation of the chain building itself: Customer Problems first,
-> then the Needs that address them, then the Requirements that satisfy them.
+> plays app-faithful animations of the methodology: the traceability chain building itself
+> (Customer Problems first, then the Needs that address them, then the Requirements that
+> satisfy them), a real 28-node spec with its five Customer Problems highlighted, and a
+> Copilot CLI walkthrough calling each skill in order.
 
 ### Decompose and iterate with the agent
 

--- a/docs/app.html
+++ b/docs/app.html
@@ -18,7 +18,7 @@
         <div class="wrap">
             <div class="site-nav-id">
                 <a href="index.html" class="site-nav-brand" aria-label="Problem-Based SRS home">Problem-Based <span>SRS</span></a>
-                <a href="https://github.com/RafaelGorski/Problem-Based-SRS/releases" class="version-badge" target="_blank" rel="noopener" aria-label="Version 2.2, view releases">v2.2</a>
+                <a href="https://github.com/RafaelGorski/Problem-Based-SRS/releases" class="version-badge" target="_blank" rel="noopener" aria-label="Version 2.3, view releases">v2.3</a>
             </div>
             <ul class="site-nav-links">
                 <li><a href="index.html">Home</a></li>
@@ -260,7 +260,7 @@
 
     <footer class="site-footer">
         <div class="wrap">
-            <p>Problem-Based SRS &middot; <a href="https://github.com/RafaelGorski/Problem-Based-SRS/releases" class="footer-version">v2.2</a> &middot; Methodology by Gorski &amp; Stadzisz</p>
+            <p>Problem-Based SRS &middot; <a href="https://github.com/RafaelGorski/Problem-Based-SRS/releases" class="footer-version">v2.3</a> &middot; Methodology by Gorski &amp; Stadzisz</p>
             <p class="footer-links">
                 <a href="index.html">Home</a>
                 <a href="https://github.com/RafaelGorski/Problem-Based-SRS">GitHub</a>

--- a/docs/assets/site.css
+++ b/docs/assets/site.css
@@ -269,6 +269,23 @@
             padding: var(--space-sm) var(--space-md); border-radius: 8px;
             display: block; margin: var(--space-md) 0;
         }
+        .problem-grid {
+            display: grid; grid-template-columns: minmax(0, 1fr) minmax(0, 1.05fr);
+            gap: clamp(1.5rem, 1rem + 3vw, 3.5rem); align-items: center;
+        }
+        .problem-copy .problem-before:first-child { margin-top: 0; }
+        .problem-figure { margin: 0; position: sticky; top: 2rem; }
+        .problem-figure .app-frame img { background: var(--bg-elevated); }
+        .problem-figure figcaption {
+            margin-top: var(--space-md); color: var(--muted);
+            font-size: var(--text-sm); max-width: 46ch;
+        }
+        .problem-figure figcaption strong { color: var(--cp-bold); font-weight: 700; }
+        @media (max-width: 860px) {
+            .problem-grid { grid-template-columns: 1fr; }
+            .problem-figure { position: static; order: -1; }
+            .problem-copy .problem-before, .problem-copy .problem-after { max-width: none; }
+        }
 
         /* ── Flow (methodology timeline) ── */
         .flow { position: relative; padding-left: 2.5rem; margin: var(--space-xl) 0; }
@@ -312,6 +329,56 @@
         .flow-trace .t-cp { color: var(--cp-bold); }
         .flow-trace .t-cn { color: var(--cn-text); }
         .flow-trace .t-fr { color: var(--primary); }
+
+        /* ── CLI simulation: the assistant calling each skill ── */
+        .cli-sim {
+            border-radius: 12px; overflow: hidden;
+            background: oklch(0.20 0.018 264);
+            border: 1px solid oklch(0.32 0.02 264);
+            box-shadow: 0 2px 4px oklch(0.15 0.02 264 / 0.2),
+                        0 22px 48px oklch(0.20 0.03 264 / 0.28);
+            margin-bottom: var(--space-xl); max-width: 760px;
+        }
+        .cli-bar {
+            display: flex; align-items: center; gap: 0.7rem;
+            padding: 0.6rem 0.9rem; background: oklch(0.26 0.018 264);
+            border-bottom: 1px solid oklch(0.34 0.02 264);
+        }
+        .cli-dots { display: flex; gap: 0.4rem; }
+        .cli-dots span { width: 11px; height: 11px; border-radius: 50%; background: oklch(0.42 0.02 264); }
+        .cli-title { font-family: var(--font-mono); font-size: var(--text-xs); color: oklch(0.72 0.015 264); }
+        .cli-body {
+            font-family: var(--font-mono); font-size: var(--text-sm); line-height: 1.75;
+            color: oklch(0.86 0.015 264); padding: var(--space-md) var(--space-lg) var(--space-lg);
+        }
+        .cli-line { display: flex; align-items: baseline; flex-wrap: wrap; gap: 0.2rem 0.75rem; }
+        .cli-you { color: oklch(0.9 0.012 264); margin-bottom: 0.4rem; }
+        .cli-caret { color: var(--step-what); font-weight: 700; }
+        .cli-cmd {
+            color: color-mix(in oklab, var(--c) 62%, white);
+            font-weight: 600; min-width: 15.5em;
+        }
+        .cli-cmd::before { content: '↳ '; color: oklch(0.55 0.015 264); font-weight: 400; }
+        .cli-out { color: oklch(0.68 0.015 264); }
+        .cli-done { margin-top: 0.5rem; color: var(--step-vision); font-weight: 600; }
+        .cli-check { color: var(--step-vision); font-weight: 700; }
+        .cli-cursor {
+            display: inline-block; width: 0.55em; height: 1.05em; margin-left: 0.35em;
+            background: oklch(0.82 0.015 264); vertical-align: text-bottom; border-radius: 1px;
+        }
+        @media (prefers-reduced-motion: no-preference) {
+            .cli-line { opacity: 0; transform: translateY(6px);
+                animation: cliReveal 13s var(--ease-out-quart) infinite both;
+                animation-delay: calc(0.35s + var(--i) * 0.62s); }
+            .cli-cursor { animation: cliBlink 1.05s steps(1) infinite; }
+        }
+        @keyframes cliReveal {
+            0% { opacity: 0; transform: translateY(6px); }
+            3% { opacity: 1; transform: translateY(0); }
+            88% { opacity: 1; transform: translateY(0); }
+            94%, 100% { opacity: 0; transform: translateY(0); }
+        }
+        @keyframes cliBlink { 0%, 50% { opacity: 1; } 50.01%, 100% { opacity: 0; } }
 
         /* ── Classification ── */
         .class-grid { margin-top: var(--space-lg); display: flex; flex-direction: column; gap: var(--space-md); }

--- a/docs/assets/srs-problems.svg
+++ b/docs/assets/srs-problems.svg
@@ -1,0 +1,309 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 720 640" width="720" height="640" role="img" aria-labelledby="t d" preserveAspectRatio="xMidYMid meet">
+  <title id="t">The SRS Navigator highlighting five Customer Problems</title>
+  <desc id="d">The VagrantChefHubot specification appears in full, then the Needs, Functional and Non-Functional Requirements dim and the five Customer Problems light up, showing that every requirement traces back to a problem.</desc>
+  <style>
+    :root { color-scheme: light; }
+    svg { background: oklch(1 0 0); }
+    text { font-family: 'Figtree', system-ui, -apple-system, 'Segoe UI', Roboto, sans-serif; }
+    .wordmark { font-weight: 800; font-size: 16px; letter-spacing: -0.01em; }
+    .wordmark .accent { fill: oklch(0.45 0.16 266); }
+    .toggle-txt { font-size: 12px; font-weight: 650; text-anchor: middle; dominant-baseline: middle; }
+    .chip-txt { font-size: 11.5px; font-weight: 600; fill: oklch(0.30 0.012 264); dominant-baseline: middle; }
+    .badge-txt { font-family: 'JetBrains Mono', ui-monospace, monospace; font-size: 8px; font-weight: 700; letter-spacing: 0.04em; text-anchor: middle; dominant-baseline: middle; }
+    .stat { font-size: 11px; fill: oklch(0.47 0.012 264); dominant-baseline: middle; }
+    .stat b { font-weight: 700; fill: oklch(0.55 0.17 50); }
+    .legend { font-size: 11px; fill: oklch(0.47 0.012 264); dominant-baseline: middle; }
+    .zoom-glyph { font-size: 14px; fill: oklch(0.47 0.012 264); text-anchor: middle; dominant-baseline: central; }
+    .nid { font-family: 'JetBrains Mono', ui-monospace, monospace; font-size: 11.5px; font-weight: 700; fill: oklch(0.19 0.018 264); text-anchor: middle; }
+    .nname { font-size: 9.5px; fill: oklch(0.47 0.012 264); text-anchor: middle; }
+
+    /* Two-phase loop: (1) whole spec present, (2) support dims + CPs pulse. */
+    .node { transform-box: fill-box; transform-origin: center; }
+    .support { animation: dimCycle 9s cubic-bezier(0.25,1,0.5,1) infinite both; }
+    .link { animation: linkCycle 9s cubic-bezier(0.25,1,0.5,1) infinite both; }
+    .cp { animation: cpCycle 9s cubic-bezier(0.25,1,0.5,1) infinite both; animation-delay: calc(var(--i) * 0.12s); }
+    .glow { opacity: 0; transform-box: fill-box; transform-origin: center;
+            animation: glowPulse 9s ease-out infinite both; animation-delay: calc(var(--i) * 0.12s); }
+
+    @keyframes dimCycle { 0%,32%{opacity:1} 46%,88%{opacity:0.28} 100%{opacity:1} }
+    @keyframes linkCycle { 0%{opacity:0} 10%,32%{opacity:0.8} 46%,88%{opacity:0.2} 100%{opacity:0} }
+    @keyframes cpCycle {
+      0%{opacity:0;transform:scale(0.6)} 9%{opacity:1;transform:scale(1)}
+      44%{transform:scale(1)} 52%{transform:scale(1.07)} 60%,88%{transform:scale(1)}
+      96%,100%{opacity:0;transform:scale(1)}
+    }
+    @keyframes glowPulse {
+      0%,42%{opacity:0;transform:scale(1)}
+      54%{opacity:0.55;transform:scale(1)}
+      72%{opacity:0;transform:scale(1.55)}
+      88%,100%{opacity:0;transform:scale(1.55)}
+    }
+
+    @media (prefers-reduced-motion: reduce) {
+      .support { animation: none; opacity: 0.32; }
+      .link { animation: none; opacity: 0.2; }
+      .cp { animation: none; opacity: 1; transform: none; }
+      .glow { animation: none; opacity: 0.5; transform: none; }
+    }
+  </style>
+
+  <defs>
+    <pattern id="dots" width="26" height="26" patternUnits="userSpaceOnUse">
+      <circle cx="1.5" cy="1.5" r="1.1" fill="oklch(0.900 0.006 240)" opacity="0.55"/>
+    </pattern>
+  </defs>
+
+  <!-- canvas -->
+  <rect x="0" y="106" width="720" height="534" fill="url(#dots)"/>
+
+  <!-- header chrome -->
+  <text class="wordmark" x="24" y="33"><tspan fill="oklch(0.19 0.018 264)">Problem-Based </tspan><tspan class="accent">SRS</tspan></text>
+  <rect x="196" y="18" width="150" height="22" rx="11" fill="oklch(0.61 0.18 48 / 0.14)"/>
+  <text x="271" y="30" class="badge-txt" fill="oklch(0.55 0.17 50)" style="font-size:9.5px; letter-spacing:0.02em;">5 Customer Problems</text>
+
+  <!-- Graph / Hierarchy toggle -->
+  <rect x="470" y="14" width="152" height="30" rx="9" fill="oklch(0.965 0.004 240)" stroke="oklch(0.900 0.006 240)"/>
+  <rect x="474" y="18" width="74" height="22" rx="6" fill="oklch(0.45 0.16 266)"/>
+  <text class="toggle-txt" x="511" y="30" fill="#fff">Graph</text>
+  <text class="toggle-txt" x="588" y="30" fill="oklch(0.47 0.012 264)">Hierarchy</text>
+
+  <!-- github mark -->
+  <g transform="translate(666 18) scale(0.83)" fill="oklch(0.47 0.012 264)"><path d="M12 2C6.477 2 2 6.484 2 12.017c0 4.425 2.865 8.18 6.839 9.504.5.092.682-.217.682-.483 0-.237-.008-.868-.013-1.703-2.782.605-3.369-1.343-3.369-1.343-.454-1.158-1.11-1.466-1.11-1.466-.908-.62.069-.608.069-.608 1.003.07 1.531 1.032 1.531 1.032.892 1.53 2.341 1.088 2.91.832.092-.647.35-1.088.636-1.338-2.22-.253-4.555-1.113-4.555-4.951 0-1.093.39-1.988 1.029-2.688-.103-.253-.446-1.272.098-2.65 0 0 .84-.27 2.75 1.026A9.564 9.564 0 0112 6.844c.85.004 1.705.115 2.504.337 1.909-1.296 2.747-1.027 2.747-1.027.546 1.379.202 2.398.1 2.651.64.7 1.028 1.595 1.028 2.688 0 3.848-2.339 4.695-4.566 4.943.359.309.678.92.678 1.855 0 1.338-.012 2.419-.012 2.747 0 .268.18.58.688.482A10.019 10.019 0 0022 12.017C22 6.484 17.522 2 12 2z"/></g>
+
+  <!-- file chip -->
+  <rect x="24" y="58" width="164" height="26" rx="8" fill="oklch(0.965 0.004 240)" stroke="oklch(0.900 0.006 240)"/>
+  <text class="chip-txt" x="40" y="72">VagrantChefHubot</text>
+
+  <!-- legend -->
+  <circle cx="300" cy="86" r="6" fill="oklch(0.61 0.18 48)"/><text class="legend" x="312" y="90">Problem</text>
+  <circle cx="392" cy="86" r="6" fill="oklch(0.58 0.10 202)"/><text class="legend" x="404" y="90">Need</text>
+  <circle cx="462" cy="86" r="6" fill="oklch(0.56 0.16 266)"/><text class="legend" x="474" y="90">FR</text>
+  <circle cx="514" cy="86" r="6" fill="oklch(0.54 0.15 320)"/><text class="legend" x="526" y="90">NFR</text>
+
+  <line x1="0" y1="94" x2="720" y2="94" stroke="oklch(0.900 0.006 240)"/>
+  <!-- stats bar -->
+  <text class="stat" x="24" y="101">28 nodes</text>
+  <text class="stat" x="120" y="101">5 need clusters</text>
+  <text class="stat" x="232" y="101"><tspan>100% traceability</tspan></text>
+  <line x1="0" y1="106" x2="720" y2="106" stroke="oklch(0.900 0.006 240)"/>
+
+  <!-- zoom controls -->
+  <g>
+    <rect x="24" y="132" width="28" height="86" rx="9" fill="oklch(1 0 0)" stroke="oklch(0.900 0.006 240)"/>
+    <line x1="28" y1="161" x2="48" y2="161" stroke="oklch(0.900 0.006 240)"/>
+    <line x1="28" y1="189" x2="48" y2="189" stroke="oklch(0.900 0.006 240)"/>
+    <text class="zoom-glyph" x="38" y="147">+</text>
+    <text class="zoom-glyph" x="38" y="175">&#8722;</text>
+    <text class="zoom-glyph" x="38" y="204">&#8635;</text>
+  </g>
+
+  <!-- links (drawn behind nodes) -->
+  <g fill="none" stroke="oklch(0.74 0.02 262)" stroke-width="1.6" stroke-dasharray="4 5" stroke-linecap="round">
+    <path class="link" d="M189.6 203.5 Q240.4 195.2 278.4 160.5"/>
+    <path class="link" d="M191.7 218.0 Q305.2 266.4 428.3 258.0"/>
+    <path class="link" d="M343.9 310.2 Q392.8 304.0 430.1 271.8"/>
+    <path class="link" d="M145.5 432.1 Q181.2 403.6 194.5 359.9"/>
+    <path class="link" d="M470.0 462.0 Q479.8 437.0 470.0 412.0"/>
+    <path class="link" d="M545.2 208.0 Q502.4 217.6 472.8 250.0"/>
+    <path class="link" d="M428.3 258.1 Q358.2 226.6 281.7 233.9"/>
+    <path class="link" d="M447.4 238.5 Q452.2 203.8 434.6 173.5"/>
+    <path class="link" d="M491.8 398.0 Q533.6 434.0 588.2 442.0"/>
+    <path class="link" d="M232.0 338.5 Q412.6 367.4 588.0 315.5"/>
+    <path class="link" d="M280.7 164.3 Q170.2 211.4 93.3 303.7"/>
+    <path class="link" d="M491.3 376.9 Q548.4 365.2 590.7 325.1"/>
+  </g>
+
+  <!-- nodes -->
+  
+  <g transform="translate(168 214)">
+    <g class="node cp" style="--i:0">
+      <circle class="glow" r="24" fill="none" stroke="oklch(0.61 0.18 48)" stroke-width="3" style="--i:0"/>
+      <circle r="24" fill="oklch(0.61 0.18 48)" stroke="oklch(0.51 0.18 48)" stroke-width="2.5"/>
+      <g transform="scale(0.1094) translate(-128 -128)" fill="#fff" opacity="0.97">
+        <path d="M128,24A104,104,0,1,0,232,128,104.11,104.11,0,0,0,128,24Zm0,192a88,88,0,1,1,88-88A88.1,88.1,0,0,1,128,216ZM152,176a8,8,0,0,1-8,8H108a8,8,0,0,1-7.41-11l20-48H108a8,8,0,0,1,0-16h36a8,8,0,0,1,7.41,11l-20,48H144A8,8,0,0,1,152,176Z"/>
+      </g>
+      <text class="nid" y="42">CP-1</text>
+      <text class="nname"><tspan x="0" y="56">Slow, error-prone</tspan><tspan x="0" y="68">Hubot + Skype setup</tspan></text>
+    </g>
+  </g>
+  
+  <g transform="translate(132 452)">
+    <g class="node cp" style="--i:1">
+      <circle class="glow" r="24" fill="none" stroke="oklch(0.61 0.18 48)" stroke-width="3" style="--i:1"/>
+      <circle r="24" fill="oklch(0.61 0.18 48)" stroke="oklch(0.51 0.18 48)" stroke-width="2.5"/>
+      <g transform="scale(0.1094) translate(-128 -128)" fill="#fff" opacity="0.97">
+        <path d="M128,24A104,104,0,1,0,232,128,104.11,104.11,0,0,0,128,24Zm0,192a88,88,0,1,1,88-88A88.1,88.1,0,0,1,128,216ZM152,176a8,8,0,0,1-8,8H108a8,8,0,0,1-7.41-11l20-48H108a8,8,0,0,1,0-16h36a8,8,0,0,1,7.41,11l-20,48H144A8,8,0,0,1,152,176Z"/>
+      </g>
+      <text class="nid" y="42">CP-2</text>
+      <text class="nname"><tspan x="0" y="56">Environments drift</tspan><tspan x="0" y="68">between machines</tspan></text>
+    </g>
+  </g>
+  
+  <g transform="translate(470 486)">
+    <g class="node cp" style="--i:2">
+      <circle class="glow" r="24" fill="none" stroke="oklch(0.61 0.18 48)" stroke-width="3" style="--i:2"/>
+      <circle r="24" fill="oklch(0.61 0.18 48)" stroke="oklch(0.51 0.18 48)" stroke-width="2.5"/>
+      <g transform="scale(0.1094) translate(-128 -128)" fill="#fff" opacity="0.97">
+        <path d="M128,24A104,104,0,1,0,232,128,104.11,104.11,0,0,0,128,24Zm0,192a88,88,0,1,1,88-88A88.1,88.1,0,0,1,128,216ZM152,176a8,8,0,0,1-8,8H108a8,8,0,0,1-7.41-11l20-48H108a8,8,0,0,1,0-16h36a8,8,0,0,1,7.41,11l-20,48H144A8,8,0,0,1,152,176Z"/>
+      </g>
+      <text class="nid" y="42">CP-3</text>
+      <text class="nname"><tspan x="0" y="56">New devs can not ship</tspan><tspan x="0" y="68">bot commands fast</tspan></text>
+    </g>
+  </g>
+  
+  <g transform="translate(566 196)">
+    <g class="node cp" style="--i:3">
+      <circle class="glow" r="24" fill="none" stroke="oklch(0.61 0.18 48)" stroke-width="3" style="--i:3"/>
+      <circle r="24" fill="oklch(0.61 0.18 48)" stroke="oklch(0.51 0.18 48)" stroke-width="2.5"/>
+      <g transform="scale(0.1094) translate(-128 -128)" fill="#fff" opacity="0.97">
+        <path d="M128,24A104,104,0,1,0,232,128,104.11,104.11,0,0,0,128,24Zm0,192a88,88,0,1,1,88-88A88.1,88.1,0,0,1,128,216ZM152,176a8,8,0,0,1-8,8H108a8,8,0,0,1-7.41-11l20-48H108a8,8,0,0,1,0-16h36a8,8,0,0,1,7.41,11l-20,48H144A8,8,0,0,1,152,176Z"/>
+      </g>
+      <text class="nid" y="42">CP-4</text>
+      <text class="nname"><tspan x="0" y="56">Rebuilding a broken</tspan><tspan x="0" y="68">box costs a day</tspan></text>
+    </g>
+  </g>
+  
+  <g transform="translate(322 320)">
+    <g class="node cp" style="--i:4">
+      <circle class="glow" r="24" fill="none" stroke="oklch(0.61 0.18 48)" stroke-width="3" style="--i:4"/>
+      <circle r="24" fill="oklch(0.61 0.18 48)" stroke="oklch(0.51 0.18 48)" stroke-width="2.5"/>
+      <g transform="scale(0.1094) translate(-128 -128)" fill="#fff" opacity="0.97">
+        <path d="M128,24A104,104,0,1,0,232,128,104.11,104.11,0,0,0,128,24Zm0,192a88,88,0,1,1,88-88A88.1,88.1,0,0,1,128,216ZM152,176a8,8,0,0,1-8,8H108a8,8,0,0,1-7.41-11l20-48H108a8,8,0,0,1,0-16h36a8,8,0,0,1,7.41,11l-20,48H144A8,8,0,0,1,152,176Z"/>
+      </g>
+      <text class="nid" y="42">CP-5</text>
+      <text class="nname"><tspan x="0" y="56">Setup needs undocumented</tspan><tspan x="0" y="68">prerequisites</tspan></text>
+    </g>
+  </g>
+  
+  <g transform="translate(300 150)">
+    <g class="node support" style="--i:5">
+      
+      <circle r="24" fill="oklch(0.58 0.10 202)" stroke="oklch(0.48 0.10 202)" stroke-width="2.5"/>
+      <g transform="scale(0.1094) translate(-128 -128)" fill="#fff" opacity="0.97">
+        <path d="M221.87,83.16l-40-32A8,8,0,0,0,176,48H80a8,8,0,0,0-5.87,2.56l-40,32A8,8,0,0,0,32,88v80a8,8,0,0,0,2.13,5.44l40,44A8,8,0,0,0,80,220h96a8,8,0,0,0,5.87-2.56l40-44A8,8,0,0,0,224,168V88A8,8,0,0,0,221.87,83.16ZM208,165.1l-36.42,40H84.42L48,165.1V90.9l36.42-26.9h87.16L208,90.9Z"/>
+      </g>
+      <text class="nid" y="42">CN-3</text>
+      <text class="nname"><tspan x="0" y="56">All OS deps installed</tspan></text>
+    </g>
+  </g>
+  
+  <g transform="translate(452 262)">
+    <g class="node support" style="--i:6">
+      
+      <circle r="24" fill="oklch(0.58 0.10 202)" stroke="oklch(0.48 0.10 202)" stroke-width="2.5"/>
+      <g transform="scale(0.1094) translate(-128 -128)" fill="#fff" opacity="0.97">
+        <path d="M221.87,83.16l-40-32A8,8,0,0,0,176,48H80a8,8,0,0,0-5.87,2.56l-40,32A8,8,0,0,0,32,88v80a8,8,0,0,0,2.13,5.44l40,44A8,8,0,0,0,80,220h96a8,8,0,0,0,5.87-2.56l40-44A8,8,0,0,0,224,168V88A8,8,0,0,0,221.87,83.16ZM208,165.1l-36.42,40H84.42L48,165.1V90.9l36.42-26.9h87.16L208,90.9Z"/>
+      </g>
+      <text class="nid" y="42">CN-1</text>
+      <text class="nname"><tspan x="0" y="56">Automated provisioning</tspan></text>
+    </g>
+  </g>
+  
+  <g transform="translate(470 388)">
+    <g class="node support" style="--i:7">
+      
+      <circle r="24" fill="oklch(0.58 0.10 202)" stroke="oklch(0.48 0.10 202)" stroke-width="2.5"/>
+      <g transform="scale(0.1094) translate(-128 -128)" fill="#fff" opacity="0.97">
+        <path d="M221.87,83.16l-40-32A8,8,0,0,0,176,48H80a8,8,0,0,0-5.87,2.56l-40,32A8,8,0,0,0,32,88v80a8,8,0,0,0,2.13,5.44l40,44A8,8,0,0,0,80,220h96a8,8,0,0,0,5.87-2.56l40-44A8,8,0,0,0,224,168V88A8,8,0,0,0,221.87,83.16ZM208,165.1l-36.42,40H84.42L48,165.1V90.9l36.42-26.9h87.16L208,90.9Z"/>
+      </g>
+      <text class="nid" y="42">CN-2</text>
+      <text class="nname"><tspan x="0" y="56">Ready-to-run Hubot</tspan></text>
+    </g>
+  </g>
+  
+  <g transform="translate(208 340)">
+    <g class="node support" style="--i:8">
+      
+      <circle r="24" fill="oklch(0.58 0.10 202)" stroke="oklch(0.48 0.10 202)" stroke-width="2.5"/>
+      <g transform="scale(0.1094) translate(-128 -128)" fill="#fff" opacity="0.97">
+        <path d="M221.87,83.16l-40-32A8,8,0,0,0,176,48H80a8,8,0,0,0-5.87,2.56l-40,32A8,8,0,0,0,32,88v80a8,8,0,0,0,2.13,5.44l40,44A8,8,0,0,0,80,220h96a8,8,0,0,0,5.87-2.56l40-44A8,8,0,0,0,224,168V88A8,8,0,0,0,221.87,83.16ZM208,165.1l-36.42,40H84.42L48,165.1V90.9l36.42-26.9h87.16L208,90.9Z"/>
+      </g>
+      <text class="nid" y="42">CN-6</text>
+      <text class="nname"><tspan x="0" y="56">Documented lifecycle</tspan></text>
+    </g>
+  </g>
+  
+  <g transform="translate(258 230)">
+    <g class="node support" style="--i:9">
+      
+      <circle r="24" fill="oklch(0.56 0.16 266)" stroke="oklch(0.46 0.16 266)" stroke-width="2.5"/>
+      <g transform="scale(0.1094) translate(-128 -128)" fill="#fff" opacity="0.97">
+        <path d="M69.12,94.15,28.5,128l40.62,33.85a8,8,0,1,1-10.24,12.29l-48-40a8,8,0,0,1,0-12.29l48-40a8,8,0,0,1,10.24,12.29Zm176,27.7-48-40a8,8,0,1,0-10.24,12.29L227.5,128l-40.62,33.85a8,8,0,1,0,10.24,12.29l48-40a8,8,0,0,0,0-12.29ZM162.73,32.48a8,8,0,0,0-10.25,4.79l-64,176a8,8,0,0,0,4.79,10.26A8.14,8.14,0,0,0,96,224a8,8,0,0,0,7.52-5.27l64-176A8,8,0,0,0,162.73,32.48Z"/>
+      </g>
+      <text class="nid" y="42">FR-2</text>
+      <text class="nname"><tspan x="0" y="56">Chef Solo core stack</tspan></text>
+    </g>
+  </g>
+  
+  <g transform="translate(612 314)">
+    <g class="node support" style="--i:10">
+      
+      <circle r="24" fill="oklch(0.56 0.16 266)" stroke="oklch(0.46 0.16 266)" stroke-width="2.5"/>
+      <g transform="scale(0.1094) translate(-128 -128)" fill="#fff" opacity="0.97">
+        <path d="M69.12,94.15,28.5,128l40.62,33.85a8,8,0,1,1-10.24,12.29l-48-40a8,8,0,0,1,0-12.29l48-40a8,8,0,0,1,10.24,12.29Zm176,27.7-48-40a8,8,0,1,0-10.24,12.29L227.5,128l-40.62,33.85a8,8,0,1,0,10.24,12.29l48-40a8,8,0,0,0,0-12.29ZM162.73,32.48a8,8,0,0,0-10.25,4.79l-64,176a8,8,0,0,0,4.79,10.26A8.14,8.14,0,0,0,96,224a8,8,0,0,0,7.52-5.27l64-176A8,8,0,0,0,162.73,32.48Z"/>
+      </g>
+      <text class="nid" y="42">FR-9</text>
+      <text class="nname"><tspan x="0" y="56">Lifecycle scripts</tspan></text>
+    </g>
+  </g>
+  
+  <g transform="translate(610 452)">
+    <g class="node support" style="--i:11">
+      
+      <circle r="24" fill="oklch(0.56 0.16 266)" stroke="oklch(0.46 0.16 266)" stroke-width="2.5"/>
+      <g transform="scale(0.1094) translate(-128 -128)" fill="#fff" opacity="0.97">
+        <path d="M69.12,94.15,28.5,128l40.62,33.85a8,8,0,1,1-10.24,12.29l-48-40a8,8,0,0,1,0-12.29l48-40a8,8,0,0,1,10.24,12.29Zm176,27.7-48-40a8,8,0,1,0-10.24,12.29L227.5,128l-40.62,33.85a8,8,0,1,0,10.24,12.29l48-40a8,8,0,0,0,0-12.29ZM162.73,32.48a8,8,0,0,0-10.25,4.79l-64,176a8,8,0,0,0,4.79,10.26A8.14,8.14,0,0,0,96,224a8,8,0,0,0,7.52-5.27l64-176A8,8,0,0,0,162.73,32.48Z"/>
+      </g>
+      <text class="nid" y="42">FR-1</text>
+      <text class="nname"><tspan x="0" y="56">Vagrant VM</tspan></text>
+    </g>
+  </g>
+  
+  <g transform="translate(168 560)">
+    <g class="node support" style="--i:12">
+      
+      <circle r="24" fill="oklch(0.56 0.16 266)" stroke="oklch(0.46 0.16 266)" stroke-width="2.5"/>
+      <g transform="scale(0.1094) translate(-128 -128)" fill="#fff" opacity="0.97">
+        <path d="M69.12,94.15,28.5,128l40.62,33.85a8,8,0,1,1-10.24,12.29l-48-40a8,8,0,0,1,0-12.29l48-40a8,8,0,0,1,10.24,12.29Zm176,27.7-48-40a8,8,0,1,0-10.24,12.29L227.5,128l-40.62,33.85a8,8,0,1,0,10.24,12.29l48-40a8,8,0,0,0,0-12.29ZM162.73,32.48a8,8,0,0,0-10.25,4.79l-64,176a8,8,0,0,0,4.79,10.26A8.14,8.14,0,0,0,96,224a8,8,0,0,0,7.52-5.27l64-176A8,8,0,0,0,162.73,32.48Z"/>
+      </g>
+      <text class="nid" y="42">FR-4</text>
+      <text class="nname"><tspan x="0" y="56">Hubot via npm</tspan></text>
+    </g>
+  </g>
+  
+  <g transform="translate(430 150)">
+    <g class="node support" style="--i:13">
+      
+      <circle r="24" fill="oklch(0.54 0.15 320)" stroke="oklch(0.44 0.15 320)" stroke-width="2.5"/>
+      <g transform="scale(0.1094) translate(-128 -128)" fill="#fff" opacity="0.97">
+        <path d="M208,40H48A16,16,0,0,0,32,56v58.77c0,89.62,75.82,119.34,91,124.39a15.53,15.53,0,0,0,10,0c15.2-5.05,91-34.77,91-124.39V56A16,16,0,0,0,208,40Zm0,74.79c0,78.42-66.35,104.62-80,109.18-13.53-4.51-80-30.69-80-109.18V56H208ZM82.34,141.66a8,8,0,0,1,11.32-11.32L112,148.69l50.34-50.35a8,8,0,0,1,11.32,11.32l-56,56a8,8,0,0,1-11.32,0Z"/>
+      </g>
+      <text class="nid" y="42">NFR-3</text>
+      <text class="nname"><tspan x="0" y="56">CLI over SSH</tspan></text>
+    </g>
+  </g>
+  
+  <g transform="translate(74 318)">
+    <g class="node support" style="--i:14">
+      
+      <circle r="24" fill="oklch(0.54 0.15 320)" stroke="oklch(0.44 0.15 320)" stroke-width="2.5"/>
+      <g transform="scale(0.1094) translate(-128 -128)" fill="#fff" opacity="0.97">
+        <path d="M208,40H48A16,16,0,0,0,32,56v58.77c0,89.62,75.82,119.34,91,124.39a15.53,15.53,0,0,0,10,0c15.2-5.05,91-34.77,91-124.39V56A16,16,0,0,0,208,40Zm0,74.79c0,78.42-66.35,104.62-80,109.18-13.53-4.51-80-30.69-80-109.18V56H208ZM82.34,141.66a8,8,0,0,1,11.32-11.32L112,148.69l50.34-50.35a8,8,0,0,1,11.32,11.32l-56,56a8,8,0,0,1-11.32,0Z"/>
+      </g>
+      <text class="nid" y="42">NFR-5</text>
+      <text class="nname"><tspan x="0" y="56">Pinned versions</tspan></text>
+    </g>
+  </g>
+  
+  <g transform="translate(590 556)">
+    <g class="node support" style="--i:15">
+      
+      <circle r="24" fill="oklch(0.54 0.15 320)" stroke="oklch(0.44 0.15 320)" stroke-width="2.5"/>
+      <g transform="scale(0.1094) translate(-128 -128)" fill="#fff" opacity="0.97">
+        <path d="M208,40H48A16,16,0,0,0,32,56v58.77c0,89.62,75.82,119.34,91,124.39a15.53,15.53,0,0,0,10,0c15.2-5.05,91-34.77,91-124.39V56A16,16,0,0,0,208,40Zm0,74.79c0,78.42-66.35,104.62-80,109.18-13.53-4.51-80-30.69-80-109.18V56H208ZM82.34,141.66a8,8,0,0,1,11.32-11.32L112,148.69l50.34-50.35a8,8,0,0,1,11.32,11.32l-56,56a8,8,0,0,1-11.32,0Z"/>
+      </g>
+      <text class="nid" y="42">NFR-1</text>
+      <text class="nname"><tspan x="0" y="56">Cross-platform</tspan></text>
+    </g>
+  </g>
+</svg>

--- a/docs/index.html
+++ b/docs/index.html
@@ -18,7 +18,7 @@
         <div class="wrap">
             <div class="site-nav-id">
                 <a href="/" class="site-nav-brand" aria-label="Problem-Based SRS home">Problem-Based <span>SRS</span></a>
-                <a href="https://github.com/RafaelGorski/Problem-Based-SRS/releases" class="version-badge" target="_blank" rel="noopener" aria-label="Version 2.2, view releases">v2.2</a>
+                <a href="https://github.com/RafaelGorski/Problem-Based-SRS/releases" class="version-badge" target="_blank" rel="noopener" aria-label="Version 2.3, view releases">v2.3</a>
             </div>
             <ul class="site-nav-links">
                 <li><a href="#problem">The problem</a></li>
@@ -126,14 +126,29 @@
         <section id="problem" class="section">
             <div class="wrap">
                 <h2 class="reveal">Most requirements start in the wrong place</h2>
-                <div class="problem-before reveal">
-                    <p class="quote">"We need a reporting dashboard with 20 charts."</p>
-                    <p>You build it. Three weeks. Ship it. They use 3 of the 20 charts. The actual problem was slow data access, not visualization. Two weeks of engineering time, gone.</p>
-                </div>
-                <div class="problem-after reveal">
-                    <p>This methodology reverses the order. Instead of starting with the stakeholder's solution, you start with their problem:</p>
-                    <code class="cp">CP.01: "Managers must access sales data within 5 seconds to make decisions."</code>
-                    <p>From that problem, you derive the need (CN: real-time data access), then the requirement (FR: data API + 3 targeted charts). Built in one week. Solves what actually matters.</p>
+                <div class="problem-grid">
+                    <div class="problem-copy">
+                        <div class="problem-before reveal">
+                            <p class="quote">"We need a reporting dashboard with 20 charts."</p>
+                            <p>You build it. Three weeks. Ship it. They use 3 of the 20 charts. The actual problem was slow data access, not visualization. Two weeks of engineering time, gone.</p>
+                        </div>
+                        <div class="problem-after reveal">
+                            <p>This methodology reverses the order. Instead of starting with the stakeholder's solution, you start with their problem:</p>
+                            <code class="cp">CP.01: "Managers must access sales data within 5 seconds to make decisions."</code>
+                            <p>From that problem, you derive the need (CN: real-time data access), then the requirement (FR: data API + 3 targeted charts). Built in one week. Solves what actually matters.</p>
+                        </div>
+                    </div>
+                    <figure class="problem-figure reveal">
+                        <div class="app-frame">
+                            <div class="app-frame-bar">
+                                <div class="app-dots" aria-hidden="true"><span></span><span></span><span></span></div>
+                                <span class="app-frame-title">srs-navigator &middot; VagrantChefHubot</span>
+                            </div>
+                            <img src="assets/srs-problems.svg" width="720" height="640"
+                                 alt="The SRS Navigator graph of the VagrantChefHubot spec: the whole specification appears, then the Needs and Requirements dim while the five Customer Problems (CP-1 through CP-5) light up." />
+                        </div>
+                        <figcaption>Real spec, 28 nodes. Everything you build traces back to these <strong>five problems</strong>. That is where the work begins.</figcaption>
+                    </figure>
                 </div>
             </div>
         </section>
@@ -143,6 +158,23 @@
             <div class="wrap">
                 <h2 class="reveal">How it works</h2>
                 <p class="reveal" style="color: var(--muted); margin-bottom: var(--space-lg);">Six steps. Each builds on the previous. Your AI assistant guides the conversation.</p>
+
+                <div class="cli-sim reveal" role="img" aria-label="A Copilot CLI session calling each Problem-Based SRS skill in order: business-context, customer-problems, software-glance, customer-needs, software-vision, and functional-requirements, ending with 100% traceability from FR back to CN back to CP.">
+                    <div class="cli-bar">
+                        <div class="cli-dots" aria-hidden="true"><span></span><span></span><span></span></div>
+                        <span class="cli-title">copilot &middot; problem-based-srs</span>
+                    </div>
+                    <div class="cli-body" aria-hidden="true">
+                        <div class="cli-line cli-you" style="--i:0"><span class="cli-caret">&rsaquo;</span> Turn the outage postmortem into a spec</div>
+                        <div class="cli-line" style="--i:1"><span class="cli-cmd" style="--c: var(--step-context)">/business-context</span><span class="cli-out">project identity, constraints, success criteria</span></div>
+                        <div class="cli-line" style="--i:2"><span class="cli-cmd" style="--c: var(--step-why)">/customer-problems</span><span class="cli-out">CP&#8209;1&#8230;CP&#8209;5, classified by severity</span></div>
+                        <div class="cli-line" style="--i:3"><span class="cli-cmd" style="--c: var(--step-glance)">/software-glance</span><span class="cli-out">high-level solution sketch</span></div>
+                        <div class="cli-line" style="--i:4"><span class="cli-cmd" style="--c: var(--step-what)">/customer-needs</span><span class="cli-out">each CN traces to a CP</span></div>
+                        <div class="cli-line" style="--i:5"><span class="cli-cmd" style="--c: var(--step-vision)">/software-vision</span><span class="cli-out">architecture and approach</span></div>
+                        <div class="cli-line" style="--i:6"><span class="cli-cmd" style="--c: var(--step-how)">/functional-requirements</span><span class="cli-out">each FR traces to a CN and a CP</span></div>
+                        <div class="cli-line cli-done" style="--i:7"><span class="cli-check">&#10003;</span> 100% traceability &middot; FR &larr; CN &larr; CP<span class="cli-cursor"></span></div>
+                    </div>
+                </div>
 
                 <div class="flow">
                     <div class="flow-step reveal" style="--dot-color: var(--step-context)">
@@ -482,7 +514,7 @@ Our warehouse tracks everything in spreadsheets and loses $50k/month due to erro
 
     <footer class="site-footer">
         <div class="wrap">
-            <p>Problem-Based SRS · <a href="https://github.com/RafaelGorski/Problem-Based-SRS/releases" class="footer-version">v2.2</a> · Methodology by Gorski &amp; Stadzisz</p>
+            <p>Problem-Based SRS · <a href="https://github.com/RafaelGorski/Problem-Based-SRS/releases" class="footer-version">v2.3</a> · Methodology by Gorski &amp; Stadzisz</p>
             <p class="footer-links">
                 <a href="https://github.com/RafaelGorski/Problem-Based-SRS">GitHub</a>
                 <a href="https://github.com/RafaelGorski/Problem-Based-SRS/blob/main/CHANGELOG.md">Changelog</a>

--- a/scripts/build-problem-highlight.mjs
+++ b/scripts/build-problem-highlight.mjs
@@ -1,0 +1,247 @@
+// Generates docs/assets/srs-problems.svg — a self-contained ANIMATED IMAGE (SVG with
+// CSS keyframes) for the "Most requirements start in the wrong place" section.
+//
+// It mirrors the real SRS Navigator rendering the VagrantChefHubot example: the full
+// spec appears, then every support node (Needs, FRs, NFRs) dims and the 5 Customer
+// Problems light up — the visual argument that requirements should start at the problem.
+//
+// Node colors + Phosphor icons are sampled verbatim from
+// .github/extensions/srs-navigator/lib/renderer.mjs; the chrome mirrors the app on the
+// VagrantChefHubot spec. The canvas extension itself is not touched.
+//
+// Run: node scripts/build-problem-highlight.mjs
+
+import { writeFileSync, mkdirSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, resolve } from 'node:path';
+
+const root = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+const outPath = resolve(root, 'docs', 'assets', 'srs-problems.svg');
+
+// ── Node colors — sampled verbatim from renderer.mjs NODE_COLORS ──
+const COLORS = {
+  problem: { fill: 'oklch(0.61 0.18 48)', stroke: 'oklch(0.51 0.18 48)' },
+  need:    { fill: 'oklch(0.58 0.10 202)', stroke: 'oklch(0.48 0.10 202)' },
+  fr:      { fill: 'oklch(0.56 0.16 266)', stroke: 'oklch(0.46 0.16 266)' },
+  nfr:     { fill: 'oklch(0.54 0.15 320)', stroke: 'oklch(0.44 0.15 320)' },
+};
+
+// ── Phosphor icon paths — sampled verbatim from renderer.mjs NODE_ICONS (256 viewBox) ──
+const ICON = {
+  problem: 'M128,24A104,104,0,1,0,232,128,104.11,104.11,0,0,0,128,24Zm0,192a88,88,0,1,1,88-88A88.1,88.1,0,0,1,128,216ZM152,176a8,8,0,0,1-8,8H108a8,8,0,0,1-7.41-11l20-48H108a8,8,0,0,1,0-16h36a8,8,0,0,1,7.41,11l-20,48H144A8,8,0,0,1,152,176Z',
+  need: 'M221.87,83.16l-40-32A8,8,0,0,0,176,48H80a8,8,0,0,0-5.87,2.56l-40,32A8,8,0,0,0,32,88v80a8,8,0,0,0,2.13,5.44l40,44A8,8,0,0,0,80,220h96a8,8,0,0,0,5.87-2.56l40-44A8,8,0,0,0,224,168V88A8,8,0,0,0,221.87,83.16ZM208,165.1l-36.42,40H84.42L48,165.1V90.9l36.42-26.9h87.16L208,90.9Z',
+  fr: 'M69.12,94.15,28.5,128l40.62,33.85a8,8,0,1,1-10.24,12.29l-48-40a8,8,0,0,1,0-12.29l48-40a8,8,0,0,1,10.24,12.29Zm176,27.7-48-40a8,8,0,1,0-10.24,12.29L227.5,128l-40.62,33.85a8,8,0,1,0,10.24,12.29l48-40a8,8,0,0,0,0-12.29ZM162.73,32.48a8,8,0,0,0-10.25,4.79l-64,176a8,8,0,0,0,4.79,10.26A8.14,8.14,0,0,0,96,224a8,8,0,0,0,7.52-5.27l64-176A8,8,0,0,0,162.73,32.48Z',
+  nfr: 'M208,40H48A16,16,0,0,0,32,56v58.77c0,89.62,75.82,119.34,91,124.39a15.53,15.53,0,0,0,10,0c15.2-5.05,91-34.77,91-124.39V56A16,16,0,0,0,208,40Zm0,74.79c0,78.42-66.35,104.62-80,109.18-13.53-4.51-80-30.69-80-109.18V56H208ZM82.34,141.66a8,8,0,0,1,11.32-11.32L112,148.69l50.34-50.35a8,8,0,0,1,11.32,11.32l-56,56a8,8,0,0,1-11.32,0Z',
+};
+
+const GITHUB = 'M12 2C6.477 2 2 6.484 2 12.017c0 4.425 2.865 8.18 6.839 9.504.5.092.682-.217.682-.483 0-.237-.008-.868-.013-1.703-2.782.605-3.369-1.343-3.369-1.343-.454-1.158-1.11-1.466-1.11-1.466-.908-.62.069-.608.069-.608 1.003.07 1.531 1.032 1.531 1.032.892 1.53 2.341 1.088 2.91.832.092-.647.35-1.088.636-1.338-2.22-.253-4.555-1.113-4.555-4.951 0-1.093.39-1.988 1.029-2.688-.103-.253-.446-1.272.098-2.65 0 0 .84-.27 2.75 1.026A9.564 9.564 0 0112 6.844c.85.004 1.705.115 2.504.337 1.909-1.296 2.747-1.027 2.747-1.027.546 1.379.202 2.398.1 2.651.64.7 1.028 1.595 1.028 2.688 0 3.848-2.339 4.695-4.566 4.943.359.309.678.92.678 1.855 0 1.338-.012 2.419-.012 2.747 0 .268.18.58.688.482A10.019 10.019 0 0022 12.017C22 6.484 17.522 2 12 2z';
+
+// ── Design tokens (from docs/assets/site.css) ──
+const T = {
+  ink: 'oklch(0.30 0.012 264)',
+  inkHeading: 'oklch(0.19 0.018 264)',
+  muted: 'oklch(0.47 0.012 264)',
+  surface: 'oklch(0.965 0.004 240)',
+  surfaceBorder: 'oklch(0.900 0.006 240)',
+  primary: 'oklch(0.45 0.16 266)',
+  bg: 'oklch(1 0 0)',
+  link: 'oklch(0.74 0.02 262)',
+  cpAccent: 'oklch(0.55 0.17 50)',
+};
+
+const R = 24;                 // node radius
+const ICON_S = 28 / 256;      // icon scale into the node
+
+// VagrantChefHubot slice — the 5 Customer Problems (highlighted) plus a scatter of the
+// Needs / FRs / NFRs they trace to. IDs + the three visible CP titles are read from the
+// app screenshot; CP-4 / CP-5 (below the fold in that view) use the spec's own domain.
+const nodes = [
+  // Customer Problems (highlighted)
+  { id: 'CP-1', type: 'problem', cp: true, x: 168, y: 214, name: ['Slow, error-prone', 'Hubot + Skype setup'] },
+  { id: 'CP-2', type: 'problem', cp: true, x: 132, y: 452, name: ['Environments drift', 'between machines'] },
+  { id: 'CP-3', type: 'problem', cp: true, x: 470, y: 486, name: ['New devs can not ship', 'bot commands fast'] },
+  { id: 'CP-4', type: 'problem', cp: true, x: 566, y: 196, name: ['Rebuilding a broken', 'box costs a day'] },
+  { id: 'CP-5', type: 'problem', cp: true, x: 322, y: 320, name: ['Setup needs undocumented', 'prerequisites'] },
+  // Customer Needs (support)
+  { id: 'CN-3', type: 'need', x: 300, y: 150, name: ['All OS deps installed'] },
+  { id: 'CN-1', type: 'need', x: 452, y: 262, name: ['Automated provisioning'] },
+  { id: 'CN-2', type: 'need', x: 470, y: 388, name: ['Ready-to-run Hubot'] },
+  { id: 'CN-6', type: 'need', x: 208, y: 340, name: ['Documented lifecycle'] },
+  // Functional Requirements (support)
+  { id: 'FR-2', type: 'fr', x: 258, y: 230, name: ['Chef Solo core stack'] },
+  { id: 'FR-9', type: 'fr', x: 612, y: 314, name: ['Lifecycle scripts'] },
+  { id: 'FR-1', type: 'fr', x: 610, y: 452, name: ['Vagrant VM'] },
+  { id: 'FR-4', type: 'fr', x: 168, y: 560, name: ['Hubot via npm'] },
+  // Non-Functional Requirements (support)
+  { id: 'NFR-3', type: 'nfr', x: 430, y: 150, name: ['CLI over SSH'] },
+  { id: 'NFR-5', type: 'nfr', x: 74, y: 318, name: ['Pinned versions'] },
+  { id: 'NFR-1', type: 'nfr', x: 590, y: 556, name: ['Cross-platform'] },
+];
+
+// Faint traceability links (background). Plausible CP -> CN -> FR/NFR wiring.
+const links = [
+  { s: 'CP-1', t: 'CN-3' }, { s: 'CP-1', t: 'CN-1' },
+  { s: 'CP-5', t: 'CN-1' }, { s: 'CP-2', t: 'CN-6' },
+  { s: 'CP-3', t: 'CN-2' }, { s: 'CP-4', t: 'CN-1' },
+  { s: 'CN-1', t: 'FR-2' }, { s: 'CN-1', t: 'NFR-3' },
+  { s: 'CN-2', t: 'FR-1' }, { s: 'CN-6', t: 'FR-9' },
+  { s: 'CN-3', t: 'NFR-5' }, { s: 'CN-2', t: 'FR-9' },
+];
+const byId = Object.fromEntries(nodes.map((n) => [n.id, n]));
+
+const esc = (s) => String(s).replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+
+function linkPath(l) {
+  const s = byId[l.s], t = byId[l.t];
+  const dx = t.x - s.x, dy = t.y - s.y;
+  const len = Math.hypot(dx, dy) || 1;
+  const ux = dx / len, uy = dy / len;
+  const sx = s.x + ux * R, sy = s.y + uy * R;
+  const tx = t.x - ux * R, ty = t.y - uy * R;
+  const mx = (sx + tx) / 2 - uy * len * 0.10;
+  const my = (sy + ty) / 2 + ux * len * 0.10;
+  return `M${sx.toFixed(1)} ${sy.toFixed(1)} Q${mx.toFixed(1)} ${my.toFixed(1)} ${tx.toFixed(1)} ${ty.toFixed(1)}`;
+}
+
+function nodeGroup(n, i) {
+  const c = COLORS[n.type];
+  const idY = R + 18;
+  const nameStart = R + 32;
+  const nameTspans = n.name
+    .map((line, k) => `<tspan x="0" y="${nameStart + k * 12}">${esc(line)}</tspan>`)
+    .join('');
+  const cls = n.cp ? 'node cp' : 'node support';
+  const glow = n.cp
+    ? `<circle class="glow" r="${R}" fill="none" stroke="${c.fill}" stroke-width="3" style="--i:${i}"/>`
+    : '';
+  return `
+  <g transform="translate(${n.x} ${n.y})">
+    <g class="${cls}" style="--i:${i}">
+      ${glow}
+      <circle r="${R}" fill="${c.fill}" stroke="${c.stroke}" stroke-width="2.5"/>
+      <g transform="scale(${ICON_S.toFixed(4)}) translate(-128 -128)" fill="#fff" opacity="0.97">
+        <path d="${ICON[n.type]}"/>
+      </g>
+      <text class="nid" y="${idY}">${n.id}</text>
+      <text class="nname">${nameTspans}</text>
+    </g>
+  </g>`;
+}
+
+function legendItem(x, color, label) {
+  return `<circle cx="${x}" cy="86" r="6" fill="${color}"/><text class="legend" x="${x + 12}" y="90">${label}</text>`;
+}
+
+const W = 720, H = 640;
+const svg = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 ${W} ${H}" width="${W}" height="${H}" role="img" aria-labelledby="t d" preserveAspectRatio="xMidYMid meet">
+  <title id="t">The SRS Navigator highlighting five Customer Problems</title>
+  <desc id="d">The VagrantChefHubot specification appears in full, then the Needs, Functional and Non-Functional Requirements dim and the five Customer Problems light up, showing that every requirement traces back to a problem.</desc>
+  <style>
+    :root { color-scheme: light; }
+    svg { background: ${T.bg}; }
+    text { font-family: 'Figtree', system-ui, -apple-system, 'Segoe UI', Roboto, sans-serif; }
+    .wordmark { font-weight: 800; font-size: 16px; letter-spacing: -0.01em; }
+    .wordmark .accent { fill: ${T.primary}; }
+    .toggle-txt { font-size: 12px; font-weight: 650; text-anchor: middle; dominant-baseline: middle; }
+    .chip-txt { font-size: 11.5px; font-weight: 600; fill: ${T.ink}; dominant-baseline: middle; }
+    .badge-txt { font-family: 'JetBrains Mono', ui-monospace, monospace; font-size: 8px; font-weight: 700; letter-spacing: 0.04em; text-anchor: middle; dominant-baseline: middle; }
+    .stat { font-size: 11px; fill: ${T.muted}; dominant-baseline: middle; }
+    .stat b { font-weight: 700; fill: ${T.cpAccent}; }
+    .legend { font-size: 11px; fill: ${T.muted}; dominant-baseline: middle; }
+    .zoom-glyph { font-size: 14px; fill: ${T.muted}; text-anchor: middle; dominant-baseline: central; }
+    .nid { font-family: 'JetBrains Mono', ui-monospace, monospace; font-size: 11.5px; font-weight: 700; fill: ${T.inkHeading}; text-anchor: middle; }
+    .nname { font-size: 9.5px; fill: ${T.muted}; text-anchor: middle; }
+
+    /* Two-phase loop: (1) whole spec present, (2) support dims + CPs pulse. */
+    .node { transform-box: fill-box; transform-origin: center; }
+    .support { animation: dimCycle 9s ${'cubic-bezier(0.25,1,0.5,1)'} infinite both; }
+    .link { animation: linkCycle 9s ${'cubic-bezier(0.25,1,0.5,1)'} infinite both; }
+    .cp { animation: cpCycle 9s ${'cubic-bezier(0.25,1,0.5,1)'} infinite both; animation-delay: calc(var(--i) * 0.12s); }
+    .glow { opacity: 0; transform-box: fill-box; transform-origin: center;
+            animation: glowPulse 9s ease-out infinite both; animation-delay: calc(var(--i) * 0.12s); }
+
+    @keyframes dimCycle { 0%,32%{opacity:1} 46%,88%{opacity:0.28} 100%{opacity:1} }
+    @keyframes linkCycle { 0%{opacity:0} 10%,32%{opacity:0.8} 46%,88%{opacity:0.2} 100%{opacity:0} }
+    @keyframes cpCycle {
+      0%{opacity:0;transform:scale(0.6)} 9%{opacity:1;transform:scale(1)}
+      44%{transform:scale(1)} 52%{transform:scale(1.07)} 60%,88%{transform:scale(1)}
+      96%,100%{opacity:0;transform:scale(1)}
+    }
+    @keyframes glowPulse {
+      0%,42%{opacity:0;transform:scale(1)}
+      54%{opacity:0.55;transform:scale(1)}
+      72%{opacity:0;transform:scale(1.55)}
+      88%,100%{opacity:0;transform:scale(1.55)}
+    }
+
+    @media (prefers-reduced-motion: reduce) {
+      .support { animation: none; opacity: 0.32; }
+      .link { animation: none; opacity: 0.2; }
+      .cp { animation: none; opacity: 1; transform: none; }
+      .glow { animation: none; opacity: 0.5; transform: none; }
+    }
+  </style>
+
+  <defs>
+    <pattern id="dots" width="26" height="26" patternUnits="userSpaceOnUse">
+      <circle cx="1.5" cy="1.5" r="1.1" fill="${T.surfaceBorder}" opacity="0.55"/>
+    </pattern>
+  </defs>
+
+  <!-- canvas -->
+  <rect x="0" y="106" width="${W}" height="${H - 106}" fill="url(#dots)"/>
+
+  <!-- header chrome -->
+  <text class="wordmark" x="24" y="33"><tspan fill="${T.inkHeading}">Problem-Based </tspan><tspan class="accent">SRS</tspan></text>
+  <rect x="196" y="18" width="150" height="22" rx="11" fill="oklch(0.61 0.18 48 / 0.14)"/>
+  <text x="271" y="30" class="badge-txt" fill="${T.cpAccent}" style="font-size:9.5px; letter-spacing:0.02em;">5 Customer Problems</text>
+
+  <!-- Graph / Hierarchy toggle -->
+  <rect x="470" y="14" width="152" height="30" rx="9" fill="${T.surface}" stroke="${T.surfaceBorder}"/>
+  <rect x="474" y="18" width="74" height="22" rx="6" fill="${T.primary}"/>
+  <text class="toggle-txt" x="511" y="30" fill="#fff">Graph</text>
+  <text class="toggle-txt" x="588" y="30" fill="${T.muted}">Hierarchy</text>
+
+  <!-- github mark -->
+  <g transform="translate(666 18) scale(0.83)" fill="${T.muted}"><path d="${GITHUB}"/></g>
+
+  <!-- file chip -->
+  <rect x="24" y="58" width="164" height="26" rx="8" fill="${T.surface}" stroke="${T.surfaceBorder}"/>
+  <text class="chip-txt" x="40" y="72">VagrantChefHubot</text>
+
+  <!-- legend -->
+  ${legendItem(300, COLORS.problem.fill, 'Problem')}
+  ${legendItem(392, COLORS.need.fill, 'Need')}
+  ${legendItem(462, COLORS.fr.fill, 'FR')}
+  ${legendItem(514, COLORS.nfr.fill, 'NFR')}
+
+  <line x1="0" y1="94" x2="${W}" y2="94" stroke="${T.surfaceBorder}"/>
+  <!-- stats bar -->
+  <text class="stat" x="24" y="101">28 nodes</text>
+  <text class="stat" x="120" y="101">5 need clusters</text>
+  <text class="stat" x="232" y="101"><tspan>100% traceability</tspan></text>
+  <line x1="0" y1="106" x2="${W}" y2="106" stroke="${T.surfaceBorder}"/>
+
+  <!-- zoom controls -->
+  <g>
+    <rect x="24" y="132" width="28" height="86" rx="9" fill="${T.bg}" stroke="${T.surfaceBorder}"/>
+    <line x1="28" y1="161" x2="48" y2="161" stroke="${T.surfaceBorder}"/>
+    <line x1="28" y1="189" x2="48" y2="189" stroke="${T.surfaceBorder}"/>
+    <text class="zoom-glyph" x="38" y="147">+</text>
+    <text class="zoom-glyph" x="38" y="175">&#8722;</text>
+    <text class="zoom-glyph" x="38" y="204">&#8635;</text>
+  </g>
+
+  <!-- links (drawn behind nodes) -->
+  <g fill="none" stroke="${T.link}" stroke-width="1.6" stroke-dasharray="4 5" stroke-linecap="round">
+    ${links.map((l) => `<path class="link" d="${linkPath(l)}"/>`).join('\n    ')}
+  </g>
+
+  <!-- nodes -->
+  ${nodes.map((n, i) => nodeGroup(n, i)).join('\n  ')}
+</svg>
+`;
+
+mkdirSync(dirname(outPath), { recursive: true });
+writeFileSync(outPath, svg, 'utf8');
+console.log(`[problems] wrote ${outPath} (${svg.length} bytes, ${nodes.length} nodes, ${links.length} links)`);


### PR DESCRIPTION
Adds two app-faithful animated images to the GitHub Pages site and cuts a minor release (v2.3). The canvas extension is unchanged.

## What's new

**Section 1 — "Most requirements start in the wrong place"**
- Restructured into a two-column layout: copy on the left, an SRS Navigator graph of the **VagrantChefHubot** spec on the right (framed in the app window chrome).
- New generated image `docs/assets/srs-problems.svg`: the whole 28-node spec appears, then the Needs and Requirements dim while the **five Customer Problems (CP-1…CP-5)** light up with pulsing rings. It makes the section's argument visually: everything traces back to the problems, so that is where the work begins.
- Generator: `scripts/build-problem-highlight.mjs` (node colors + Phosphor icons sampled verbatim from the extension's `renderer.mjs`).

**Section 2 — "How it works"**
- Opens with a **CLI chat simulation**: a dark terminal mockup animates the Copilot CLI calling each methodology skill in order (`/business-context` → `/customer-problems` → `/software-glance` → `/customer-needs` → `/software-vision` → `/functional-requirements`), each command tinted with its step color, ending on `100% traceability · FR ← CN ← CP`.
- Pure CSS/HTML; the fully-assembled terminal is the default state, so it stays readable under reduced motion.

## Accessibility
Both animations honor `prefers-reduced-motion` (they settle on the final, fully-highlighted / fully-assembled state).

## Release
Bumps `plugin.json`, the README badge, and both site version badges to **v2.3**; adds a `[2.3]` CHANGELOG section. `python scripts/build-plugin.py build --version 2.3` passes (10 skills validated).

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>