### PR TITLE
Align the how-it-works CLI simulation to the right side

### DIFF
--- a/docs/assets/site.css
+++ b/docs/assets/site.css
@@ -288,6 +288,19 @@
         }
 
         /* ── Flow (methodology timeline) ── */
+        .method-grid {
+            display: grid; grid-template-columns: minmax(0, 1fr) minmax(0, 0.92fr);
+            gap: clamp(1.5rem, 1rem + 3vw, 3.5rem); align-items: start;
+        }
+        .method-aside { margin: var(--space-xl) 0 0; position: sticky; top: 2rem; }
+        .method-aside figcaption {
+            margin-top: var(--space-md); color: var(--muted);
+            font-size: var(--text-sm); max-width: 42ch;
+        }
+        @media (max-width: 860px) {
+            .method-grid { grid-template-columns: 1fr; }
+            .method-aside { position: static; margin-top: 0; }
+        }
         .flow { position: relative; padding-left: 2.5rem; margin: var(--space-xl) 0; }
         .flow::before {
             content: ''; position: absolute; left: 7px; top: 8px; bottom: 8px;
@@ -337,7 +350,7 @@
             border: 1px solid oklch(0.32 0.02 264);
             box-shadow: 0 2px 4px oklch(0.15 0.02 264 / 0.2),
                         0 22px 48px oklch(0.20 0.03 264 / 0.28);
-            margin-bottom: var(--space-xl); max-width: 760px;
+            max-width: 760px;
         }
         .cli-bar {
             display: flex; align-items: center; gap: 0.7rem;

--- a/docs/index.html
+++ b/docs/index.html
@@ -159,66 +159,71 @@
                 <h2 class="reveal">How it works</h2>
                 <p class="reveal" style="color: var(--muted); margin-bottom: var(--space-lg);">Six steps. Each builds on the previous. Your AI assistant guides the conversation.</p>
 
-                <div class="cli-sim reveal" role="img" aria-label="A Copilot CLI session calling each Problem-Based SRS skill in order: business-context, customer-problems, software-glance, customer-needs, software-vision, and functional-requirements, ending with 100% traceability from FR back to CN back to CP.">
-                    <div class="cli-bar">
-                        <div class="cli-dots" aria-hidden="true"><span></span><span></span><span></span></div>
-                        <span class="cli-title">copilot &middot; problem-based-srs</span>
+                <div class="method-grid">
+                    <div class="flow">
+                        <div class="flow-step reveal" style="--dot-color: var(--step-context)">
+                            <div class="flow-dot"></div>
+                            <div class="flow-name">Business Context</div>
+                            <p class="flow-question">What governs this project?</p>
+                            <p class="flow-desc">Project identity, constraints, success criteria. Establishes principles for all downstream decisions.</p>
+                            <span class="flow-cmd">/business-context</span>
+                        </div>
+                        <div class="flow-step reveal" style="--dot-color: var(--step-why)">
+                            <div class="flow-dot"></div>
+                            <div class="flow-name">Customer Problems</div>
+                            <p class="flow-question">What is broken, and for whom?</p>
+                            <p class="flow-desc">Identify and classify problems by severity: Obligation (must solve), Expectation (should solve), Hope (could solve).</p>
+                            <span class="flow-cmd">/customer-problems</span>
+                        </div>
+                        <div class="flow-step reveal" style="--dot-color: var(--step-glance)">
+                            <div class="flow-dot"></div>
+                            <div class="flow-name">Software Glance</div>
+                            <p class="flow-question">What might help?</p>
+                            <p class="flow-desc">High-level solution sketch. Components, boundaries, interfaces. Shared understanding before details.</p>
+                            <span class="flow-cmd">/software-glance</span>
+                        </div>
+                        <div class="flow-step reveal" style="--dot-color: var(--step-what)">
+                            <div class="flow-dot"></div>
+                            <div class="flow-name">Customer Needs</div>
+                            <p class="flow-question">What must the system deliver?</p>
+                            <p class="flow-desc">Required outcomes per problem. Measurable, testable, scoped. Each need traces to a specific problem.</p>
+                            <span class="flow-cmd">/customer-needs</span>
+                        </div>
+                        <div class="flow-step reveal" style="--dot-color: var(--step-vision)">
+                            <div class="flow-dot"></div>
+                            <div class="flow-name">Software Vision</div>
+                            <p class="flow-question">How will it work?</p>
+                            <p class="flow-desc">Architecture, technical approach, constraints, stakeholder alignment. The technical roadmap.</p>
+                            <span class="flow-cmd">/software-vision</span>
+                        </div>
+                        <div class="flow-step reveal" style="--dot-color: var(--step-how)">
+                            <div class="flow-dot"></div>
+                            <div class="flow-name">Functional Requirements</div>
+                            <p class="flow-question">What are the details?</p>
+                            <p class="flow-desc">Detailed, testable behavior specifications. Each requirement traces backward to a need and a problem.</p>
+                            <span class="flow-cmd">/functional-requirements</span>
+                        </div>
                     </div>
-                    <div class="cli-body" aria-hidden="true">
-                        <div class="cli-line cli-you" style="--i:0"><span class="cli-caret">&rsaquo;</span> Turn the outage postmortem into a spec</div>
-                        <div class="cli-line" style="--i:1"><span class="cli-cmd" style="--c: var(--step-context)">/business-context</span><span class="cli-out">project identity, constraints, success criteria</span></div>
-                        <div class="cli-line" style="--i:2"><span class="cli-cmd" style="--c: var(--step-why)">/customer-problems</span><span class="cli-out">CP&#8209;1&#8230;CP&#8209;5, classified by severity</span></div>
-                        <div class="cli-line" style="--i:3"><span class="cli-cmd" style="--c: var(--step-glance)">/software-glance</span><span class="cli-out">high-level solution sketch</span></div>
-                        <div class="cli-line" style="--i:4"><span class="cli-cmd" style="--c: var(--step-what)">/customer-needs</span><span class="cli-out">each CN traces to a CP</span></div>
-                        <div class="cli-line" style="--i:5"><span class="cli-cmd" style="--c: var(--step-vision)">/software-vision</span><span class="cli-out">architecture and approach</span></div>
-                        <div class="cli-line" style="--i:6"><span class="cli-cmd" style="--c: var(--step-how)">/functional-requirements</span><span class="cli-out">each FR traces to a CN and a CP</span></div>
-                        <div class="cli-line cli-done" style="--i:7"><span class="cli-check">&#10003;</span> 100% traceability &middot; FR &larr; CN &larr; CP<span class="cli-cursor"></span></div>
-                    </div>
-                </div>
 
-                <div class="flow">
-                    <div class="flow-step reveal" style="--dot-color: var(--step-context)">
-                        <div class="flow-dot"></div>
-                        <div class="flow-name">Business Context</div>
-                        <p class="flow-question">What governs this project?</p>
-                        <p class="flow-desc">Project identity, constraints, success criteria. Establishes principles for all downstream decisions.</p>
-                        <span class="flow-cmd">/business-context</span>
-                    </div>
-                    <div class="flow-step reveal" style="--dot-color: var(--step-why)">
-                        <div class="flow-dot"></div>
-                        <div class="flow-name">Customer Problems</div>
-                        <p class="flow-question">What is broken, and for whom?</p>
-                        <p class="flow-desc">Identify and classify problems by severity: Obligation (must solve), Expectation (should solve), Hope (could solve).</p>
-                        <span class="flow-cmd">/customer-problems</span>
-                    </div>
-                    <div class="flow-step reveal" style="--dot-color: var(--step-glance)">
-                        <div class="flow-dot"></div>
-                        <div class="flow-name">Software Glance</div>
-                        <p class="flow-question">What might help?</p>
-                        <p class="flow-desc">High-level solution sketch. Components, boundaries, interfaces. Shared understanding before details.</p>
-                        <span class="flow-cmd">/software-glance</span>
-                    </div>
-                    <div class="flow-step reveal" style="--dot-color: var(--step-what)">
-                        <div class="flow-dot"></div>
-                        <div class="flow-name">Customer Needs</div>
-                        <p class="flow-question">What must the system deliver?</p>
-                        <p class="flow-desc">Required outcomes per problem. Measurable, testable, scoped. Each need traces to a specific problem.</p>
-                        <span class="flow-cmd">/customer-needs</span>
-                    </div>
-                    <div class="flow-step reveal" style="--dot-color: var(--step-vision)">
-                        <div class="flow-dot"></div>
-                        <div class="flow-name">Software Vision</div>
-                        <p class="flow-question">How will it work?</p>
-                        <p class="flow-desc">Architecture, technical approach, constraints, stakeholder alignment. The technical roadmap.</p>
-                        <span class="flow-cmd">/software-vision</span>
-                    </div>
-                    <div class="flow-step reveal" style="--dot-color: var(--step-how)">
-                        <div class="flow-dot"></div>
-                        <div class="flow-name">Functional Requirements</div>
-                        <p class="flow-question">What are the details?</p>
-                        <p class="flow-desc">Detailed, testable behavior specifications. Each requirement traces backward to a need and a problem.</p>
-                        <span class="flow-cmd">/functional-requirements</span>
-                    </div>
+                    <figure class="method-aside reveal">
+                        <div class="cli-sim" role="img" aria-label="A Copilot CLI session calling each Problem-Based SRS skill in order: business-context, customer-problems, software-glance, customer-needs, software-vision, and functional-requirements, ending with 100% traceability from FR back to CN back to CP.">
+                            <div class="cli-bar">
+                                <div class="cli-dots" aria-hidden="true"><span></span><span></span><span></span></div>
+                                <span class="cli-title">copilot &middot; problem-based-srs</span>
+                            </div>
+                            <div class="cli-body" aria-hidden="true">
+                                <div class="cli-line cli-you" style="--i:0"><span class="cli-caret">&rsaquo;</span> Turn the outage postmortem into a spec</div>
+                                <div class="cli-line" style="--i:1"><span class="cli-cmd" style="--c: var(--step-context)">/business-context</span><span class="cli-out">project identity, constraints, success criteria</span></div>
+                                <div class="cli-line" style="--i:2"><span class="cli-cmd" style="--c: var(--step-why)">/customer-problems</span><span class="cli-out">CP&#8209;1&#8230;CP&#8209;5, classified by severity</span></div>
+                                <div class="cli-line" style="--i:3"><span class="cli-cmd" style="--c: var(--step-glance)">/software-glance</span><span class="cli-out">high-level solution sketch</span></div>
+                                <div class="cli-line" style="--i:4"><span class="cli-cmd" style="--c: var(--step-what)">/customer-needs</span><span class="cli-out">each CN traces to a CP</span></div>
+                                <div class="cli-line" style="--i:5"><span class="cli-cmd" style="--c: var(--step-vision)">/software-vision</span><span class="cli-out">architecture and approach</span></div>
+                                <div class="cli-line" style="--i:6"><span class="cli-cmd" style="--c: var(--step-how)">/functional-requirements</span><span class="cli-out">each FR traces to a CN and a CP</span></div>
+                                <div class="cli-line cli-done" style="--i:7"><span class="cli-check">&#10003;</span> 100% traceability &middot; FR &larr; CN &larr; CP<span class="cli-cursor"></span></div>
+                            </div>
+                        </div>
+                        <figcaption>Each step runs as a skill your assistant calls in the terminal.</figcaption>
+                    </figure>
                 </div>
 
                 <div class="flow-trace reveal">


### PR DESCRIPTION
Follow-up layout refinement to the v2.3 "How it works" section. Per request, the CLI chat simulation now sits on the **right side** instead of on top.

## Change
- Wrapped the six-step methodology timeline and the CLI terminal in a two-column grid (`.method-grid`): the timeline stays on the left, the terminal moves to the right as a sticky aside (`.method-aside`), so it stays in view while you scroll the steps.
- Added a short caption under the terminal.
- Collapses to a single column below 860px (timeline first, terminal below).

No version bump, no content/animation changes, canvas extension untouched. Verified desktop (right-aligned, sticky) and mobile (stacked) via headless screenshots.

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>