### PR TITLE
Unify SRS commands into /problem-based-srs and add skill eval harness (v2.4)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "problem-based-srs",
-  "version": "2.3.0",
+  "version": "2.4.0",
   "description": "Problem-Based Software Requirements Specification methodology for AI-assisted requirements engineering. Provides structured approach to capture Customer Problems (WHY), Customer Needs (WHAT), and Functional Requirements (HOW) with full traceability.",
   "author": {
     "name": "Rafael Gorski",

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -342,17 +342,19 @@ description: I help with requirements.
 
 ## Quick Reference
 
-### Problem-Based SRS Commands
+### Problem-Based SRS Command
+A single command, `/problem-based-srs`, dispatches to each step via an **action** argument:
 ```
-/business-context          # Establish Business Context
-/customer-problems        # Generate Customer Problems
-/software-glance          # Create Software Glance
-/customer-needs           # Generate Customer Needs
-/software-vision          # Build Software Vision
-/functional-requirements  # Specify Functional Requirements
-/zigzag-validator         # Validate traceability
-/problem-based-srs        # Full methodology orchestration
-/live                     # Launch the SRS Navigator canvas (visualize the spec)
+/problem-based-srs business-context        # Establish Business Context
+/problem-based-srs problems                # Generate Customer Problems
+/problem-based-srs software-glance         # Create Software Glance
+/problem-based-srs needs                   # Generate Customer Needs
+/problem-based-srs software-vision         # Build Software Vision
+/problem-based-srs functional-requirements # Specify Functional Requirements
+/problem-based-srs validate                # Validate traceability (ZigZag)
+/problem-based-srs complexity              # Optional: Axiomatic Design analysis
+/problem-based-srs                         # Full methodology orchestration (default)
+/live                                      # Launch the SRS Navigator canvas (visualize the spec)
 ```
 
 ### Traceability Chain

--- a/.github/extensions/srs-navigator/extension.mjs
+++ b/.github/extensions/srs-navigator/extension.mjs
@@ -86,78 +86,72 @@ async function loadSkillContentByFile(file) {
 const isProjectExtension = __dirname.includes(".github");
 const derivedWorkspacePath = isProjectExtension ? resolve(__dirname, "..", "..", "..") : null;
 
-// Skill definitions for tool registration
-const SKILLS = [
-    {
-        name: "business_context",
-        file: "business-context.md",
-        description: "Step 0: Establish structured business context and project principles before problem discovery. Use when starting requirements engineering to capture project identity, business principles, stakeholders, domain boundaries, and success criteria.",
-    },
-    {
-        name: "customer_problems",
-        file: "customer-problems.md",
-        description: "Step 1: Identify and document Customer Problems (CP) from business context. Use when stakeholders describe solutions instead of problems, or when starting requirements engineering.",
-    },
-    {
-        name: "software_glance",
-        file: "software-glance.md",
-        description: "Step 2: Create the first abstract representation of a software solution from Customer Problems. Use after identifying CPs to design high-level system boundaries and components.",
-    },
-    {
-        name: "customer_needs",
-        file: "customer-needs.md",
-        description: "Step 3: Specify Customer Needs (CN) that define WHAT outcomes software must provide to solve Customer Problems. Use after Software Glance to translate problems into needs.",
-    },
-    {
-        name: "software_vision",
-        file: "software-vision.md",
-        description: "Step 4: Transform Software Glance and Customer Needs into a detailed Software Vision with positioning, stakeholders, features, and architecture.",
-    },
-    {
-        name: "functional_requirements",
-        file: "functional-requirements.md",
-        description: "Step 5: Generate Functional Requirements (FR) and Non-Functional Requirements (NFR) from Customer Needs and Software Vision. Creates individual requirement files with traceability.",
-    },
-    {
-        name: "complexity_analysis",
-        file: "complexity-analysis.md",
-        description: "Optional: Analyze specification quality using Axiomatic Design principles. Evaluates independence, completeness, and information content of requirements.",
-    },
-    {
-        name: "problem_based_srs",
-        file: "problem-based-srs.md",
-        description: "Complete Problem-Based SRS methodology orchestrator. Use when you need to perform full requirements engineering from business problems to functional requirements with traceability.",
-    },
-    {
-        name: "zigzag_validator",
-        file: "zigzag-validator.md",
-        description: "Validate traceability and consistency across Customer Problems, Customer Needs, and Functional Requirements domains. Use to check completeness and identify gaps.",
-    },
+// Methodology action definitions. The Problem-Based SRS methodology is exposed
+// through a SINGLE tool/command (`problem_based_srs` / `/problem-based-srs`) that
+// dispatches to a step via an `action` argument, instead of one command per step.
+// Each action maps to the canonical skill markdown that backs it.
+const ACTIONS = [
+    { action: "business-context", file: "business-context.md" },
+    { action: "problems", file: "customer-problems.md" },
+    { action: "software-glance", file: "software-glance.md" },
+    { action: "needs", file: "customer-needs.md" },
+    { action: "software-vision", file: "software-vision.md" },
+    { action: "functional-requirements", file: "functional-requirements.md" },
+    { action: "validate", file: "zigzag-validator.md" },
+    { action: "complexity", file: "complexity-analysis.md" },
+    { action: "full", file: "problem-based-srs.md" },
 ];
 
-// Build tools array from skill definitions
-function buildSkillTools() {
-    return SKILLS.map((skill) => ({
-        name: skill.name,
-        description: skill.description,
+// Resolve the backing skill file for an action, defaulting to the full
+// orchestrator when the action is unknown or omitted.
+function fileForAction(action) {
+    const match = ACTIONS.find((a) => a.action === action);
+    return (match || ACTIONS.find((a) => a.action === "full")).file;
+}
+
+// Map a methodology action (e.g. "needs") to its slash-command form. The whole
+// methodology is a single command; the action is passed as an argument, so
+// "full" (the default) is just `/problem-based-srs`.
+function srsActionCommand(action) {
+    const a = String(action || "full").trim() || "full";
+    return a === "full" ? "/problem-based-srs" : `/problem-based-srs ${a}`;
+}
+
+// Build the single unified methodology tool. It replaces the former one-tool-per
+// -step registry: callers select a step with the `action` argument.
+function buildSrsTool() {
+    return {
+        name: "problem_based_srs",
+        description:
+            "Problem-Based SRS methodology — single entry point. Provide `action` to run a specific step: " +
+            "`business-context`, `problems`, `software-glance`, `needs`, `software-vision`, " +
+            "`functional-requirements`, `validate`, or `complexity`. Omit it (or use `full`) to run the " +
+            "complete methodology from business problems to functional requirements with full traceability.",
         parameters: {
             type: "object",
             properties: {
+                action: {
+                    type: "string",
+                    enum: ACTIONS.map((a) => a.action),
+                    description:
+                        "Which methodology step to run. Defaults to 'full' (complete orchestration).",
+                },
                 context: {
                     type: "string",
-                    description: "Optional: existing artifacts or business context to provide as input for this methodology step.",
+                    description:
+                        "Optional: existing artifacts or business context to provide as input for this methodology step.",
                 },
             },
         },
         handler: async (args) => {
-            const content = await loadSkillContentByFile(skill.file);
+            const content = await loadSkillContentByFile(fileForAction(args.action || "full"));
             let result = content;
             if (args.context) {
                 result += `\n\n---\n\n## User-Provided Context\n\n${args.context}`;
             }
             return result;
         },
-    }));
+    };
 }
 
 // Per-instance state: server + loaded graph data
@@ -336,17 +330,15 @@ const LOAD_PROMPT = [
     "Then use the `load_specification` canvas action to display it.",
 ].join("\n");
 
-// Map a skill tool name (e.g. "customer_needs") to its Problem-Based SRS
-// slash-command form (e.g. "/customer-needs"). Taskbar actions must run these
-// existing skills, never improvised free-text instructions.
-function skillCommand(skill) {
-    return "/" + String(skill || "").replace(/_/g, "-");
-}
+// Map a methodology action (e.g. "needs") to its Problem-Based SRS slash-command
+// form (e.g. "/problem-based-srs needs"). Taskbar actions must run the existing
+// methodology, never improvised free-text instructions. (Defined near the ACTIONS
+// registry as `srsActionCommand`.)
 
 function buildActionPrompt(action) {
-    // "Implement" is not a methodology skill — it asks the agent to turn a
+    // "Implement" is not a methodology step — it asks the agent to turn a
     // fully-specified requirement into real code, so it gets its own prompt
-    // instead of a skill slash-command.
+    // instead of a methodology slash-command.
     if (action.action === "implement") {
         const kind = action.nodeType === "nfr" ? "Non-Functional Requirement" : "Functional Requirement";
         return [
@@ -366,16 +358,16 @@ function buildActionPrompt(action) {
             "This is an implementation task, not a requirements-authoring task — do not rewrite the specification files. When done, briefly summarize what you built and where.",
         ].join("\n");
     }
-    const command = skillCommand(action.skill);
+    const command = srsActionCommand(action.srsAction);
     return [
-        `## Problem-Based SRS — run the ${command} skill`,
+        `## Problem-Based SRS — run ${command}`,
         "",
-        `Run the existing Problem-Based SRS **${command}** skill (the \`${action.skill}\` tool) and follow its methodology exactly. Do not improvise a generic answer — the skill defines the process you must use.`,
+        `Run the Problem-Based SRS **${command}** action (the \`problem_based_srs\` tool with \`action: "${action.srsAction}"\`) and follow its methodology exactly. Do not improvise a generic answer — the methodology defines the process you must use.`,
         "",
         `**Target node:** ${action.nodeId} (${action.nodeType}) — "${action.nodeLabel}"`,
         `**Request:** ${action.context}`,
         "",
-        `Apply the ${command} skill to the target node, using the request above as its input and preserving traceability to ${action.nodeId}. After the skill updates the specification, use the \`load_specification\` canvas action to refresh the graph.`,
+        `Apply the ${command} action to the target node, using the request above as its input and preserving traceability to ${action.nodeId}. After the methodology updates the specification, use the \`load_specification\` canvas action to refresh the graph.`,
     ].join("\n");
 }
 
@@ -521,7 +513,7 @@ function createCanvasServer(instanceId, fallbackHtml, workspacePath) {
 }
 
 const session = await joinSession({
-    tools: buildSkillTools(),
+    tools: [buildSrsTool()],
     canvases: [
         createCanvas({
             id: "srs-navigator",
@@ -720,7 +712,7 @@ const session = await joinSession({
                 },
                 {
                     name: "pending_actions",
-                    description: "Retrieve and consume pending actions queued from the canvas UI. When an engineer clicks an action button on a node (e.g., +CN, +FR, +NFR, decompose), the action is queued here with the skill name and context. The agent should invoke the corresponding skill tool with the provided context. Returns the queue and clears it.",
+                    description: "Retrieve and consume pending actions queued from the canvas UI. When an engineer clicks an action button on a node (e.g., +CN, +FR, +NFR, decompose), the action is queued here with its methodology action and context. The agent should invoke the problem_based_srs tool with the provided action and context. Returns the queue and clears it.",
                     handler: async (ctx) => {
                         const queue = pendingActions.get(ctx.instanceId) || [];
                         // Clear the queue after retrieval
@@ -730,26 +722,23 @@ const session = await joinSession({
                             return { actions: [], message: "No pending actions" };
                         }
 
-                        // Enrich each action with skill instructions
+                        // Enrich each action with methodology instructions
                         const enriched = await Promise.all(queue.map(async (action) => {
                             let skillContent = "";
                             try {
-                                const skillFile = SKILLS.find(s => s.name === action.skill)?.file;
-                                if (skillFile) {
-                                    skillContent = await loadSkillContentByFile(skillFile);
-                                }
+                                skillContent = await loadSkillContentByFile(fileForAction(action.srsAction));
                             } catch { /* skill file read failure is non-fatal */ }
 
                             return {
                                 ...action,
-                                instruction: `Run the existing ${skillCommand(action.skill)} skill (the "${action.skill}" tool) and follow its methodology exactly — do not improvise. Apply it to ${action.nodeId} using this request as input:\n\n${action.context}`,
+                                instruction: `Run the Problem-Based SRS ${srsActionCommand(action.srsAction)} action (the "problem_based_srs" tool with action "${action.srsAction}") and follow its methodology exactly — do not improvise. Apply it to ${action.nodeId} using this request as input:\n\n${action.context}`,
                                 skillContent,
                             };
                         }));
 
                         return {
                             actions: enriched,
-                            message: `${enriched.length} action(s) ready. For each action, run the existing Problem-Based SRS skill named in its instruction with the provided context — do not improvise generic answers.`,
+                            message: `${enriched.length} action(s) ready. For each action, run the Problem-Based SRS methodology action named in its instruction with the provided context — do not improvise generic answers.`,
                         };
                     }
                 },

--- a/.github/extensions/srs-navigator/lib/renderer.mjs
+++ b/.github/extensions/srs-navigator/lib/renderer.mjs
@@ -2405,36 +2405,37 @@ export function renderGraphHtml(graphData, options = {}) {
       submit: '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="M5 12h14"/><path d="m12 5 7 7-7 7"/></svg>',
     };
 
-    // Maps action bar buttons to their corresponding SRS methodology skills
-    // Each action maps to a skill tool name registered in the extension
+    // Maps action bar buttons to their Problem-Based SRS methodology action.
+    // Every button routes through the single problem_based_srs tool, selecting a
+    // step via its srsAction value (no more per-step tool names).
     const SKILL_MAP = {
-      decompose_problem: { skill: "customer_problems", label: "+Sub-CP", icon: "decompose" },
-      decompose_need: { skill: "customer_needs", label: "+Sub-CN", icon: "decompose" },
-      decompose_fr: { skill: "functional_requirements", label: "+Sub-FR", icon: "decompose" },
-      decompose_nfr: { skill: "functional_requirements", label: "+Sub-NFR", icon: "decompose" },
-      addCN: { skill: "customer_needs", label: "+CN", icon: "addCN" },
-      addFR: { skill: "functional_requirements", label: "+FR", icon: "addFR" },
-      addNFR: { skill: "functional_requirements", label: "+NFR", icon: "addNFR" },
-      addCP: { skill: "customer_problems", label: "+CP", icon: "addCP" },
+      decompose_problem: { srsAction: "problems", label: "+Sub-CP", icon: "decompose" },
+      decompose_need: { srsAction: "needs", label: "+Sub-CN", icon: "decompose" },
+      decompose_fr: { srsAction: "functional-requirements", label: "+Sub-FR", icon: "decompose" },
+      decompose_nfr: { srsAction: "functional-requirements", label: "+Sub-NFR", icon: "decompose" },
+      addCN: { srsAction: "needs", label: "+CN", icon: "addCN" },
+      addFR: { srsAction: "functional-requirements", label: "+FR", icon: "addFR" },
+      addNFR: { srsAction: "functional-requirements", label: "+NFR", icon: "addNFR" },
+      addCP: { srsAction: "problems", label: "+CP", icon: "addCP" },
     };
 
     function getActionsForType(type) {
       const actions = [];
       if (type === "problem") {
         // CP can derive CNs and decompose into sub-CPs
-        actions.push({ key: "addCN", label: "+CN", icon: ACTION_ICONS.addCN, skill: SKILL_MAP.addCN.skill });
-        actions.push({ key: "decompose_problem", label: "+Sub-CP", icon: ACTION_ICONS.decompose, skill: SKILL_MAP.decompose_problem.skill });
+        actions.push({ key: "addCN", label: "+CN", icon: ACTION_ICONS.addCN, srsAction: SKILL_MAP.addCN.srsAction });
+        actions.push({ key: "decompose_problem", label: "+Sub-CP", icon: ACTION_ICONS.decompose, srsAction: SKILL_MAP.decompose_problem.srsAction });
       } else if (type === "need") {
         // CN can derive FRs and decompose into sub-CNs
-        actions.push({ key: "addFR", label: "+FR", icon: ACTION_ICONS.addFR, skill: SKILL_MAP.addFR.skill });
-        actions.push({ key: "decompose_need", label: "+Sub-CN", icon: ACTION_ICONS.decompose, skill: SKILL_MAP.decompose_need.skill });
+        actions.push({ key: "addFR", label: "+FR", icon: ACTION_ICONS.addFR, srsAction: SKILL_MAP.addFR.srsAction });
+        actions.push({ key: "decompose_need", label: "+Sub-CN", icon: ACTION_ICONS.decompose, srsAction: SKILL_MAP.decompose_need.srsAction });
       } else if (type === "fr") {
         // FR can derive NFRs and decompose into sub-FRs
-        actions.push({ key: "addNFR", label: "+NFR", icon: ACTION_ICONS.addNFR, skill: SKILL_MAP.addNFR.skill });
-        actions.push({ key: "decompose_fr", label: "+Sub-FR", icon: ACTION_ICONS.decompose, skill: SKILL_MAP.decompose_fr.skill });
+        actions.push({ key: "addNFR", label: "+NFR", icon: ACTION_ICONS.addNFR, srsAction: SKILL_MAP.addNFR.srsAction });
+        actions.push({ key: "decompose_fr", label: "+Sub-FR", icon: ACTION_ICONS.decompose, srsAction: SKILL_MAP.decompose_fr.srsAction });
       } else if (type === "nfr") {
         // NFR can decompose
-        actions.push({ key: "decompose_nfr", label: "+Sub-NFR", icon: ACTION_ICONS.decompose, skill: SKILL_MAP.decompose_nfr.skill });
+        actions.push({ key: "decompose_nfr", label: "+Sub-NFR", icon: ACTION_ICONS.decompose, srsAction: SKILL_MAP.decompose_nfr.srsAction });
       }
       return actions;
     }
@@ -2463,11 +2464,11 @@ export function renderGraphHtml(graphData, options = {}) {
         btn.setAttribute("aria-label", action.label);
         btn.setAttribute("title", action.label);
         btn.dataset.action = action.key;
-        btn.dataset.skill = action.skill;
+        btn.dataset.srsAction = action.srsAction;
         btn.innerHTML = action.icon + '<span class="action-bar-btn-label">' + action.label + '</span>';
         btn.addEventListener("click", (e) => {
           e.stopPropagation();
-          handleActionBarAction(action.key, action.skill, node);
+          handleActionBarAction(action.key, action.srsAction, node);
         });
         actionBarActions.appendChild(btn);
       });
@@ -2533,8 +2534,8 @@ export function renderGraphHtml(graphData, options = {}) {
     // Thin wrapper kept for the hover action bar: reads its input, dispatches,
     // then resets the bar. The shared work lives in performNodeAction so the
     // in-panel composer can reuse the exact same flow.
-    function handleActionBarAction(actionKey, skillName, node) {
-      const dispatched = performNodeAction(actionKey, skillName, node, actionBarInput.value.trim());
+    function handleActionBarAction(actionKey, srsAction, node) {
+      const dispatched = performNodeAction(actionKey, srsAction, node, actionBarInput.value.trim());
       if (!dispatched) return;
       actionBarInput.value = "";
       actionBarLocked = false;
@@ -2561,7 +2562,7 @@ export function renderGraphHtml(graphData, options = {}) {
     // Dispatch a node action, mirror progress into the node's activity chat,
     // and open the detail panel so the user can watch it happen.
     // Returns true when an action was actually sent.
-    function performNodeAction(actionKey, skillName, node, prompt) {
+    function performNodeAction(actionKey, srsAction, node, prompt) {
       if (!node) return false;
       prompt = (prompt || "").trim();
 
@@ -2582,8 +2583,8 @@ export function renderGraphHtml(graphData, options = {}) {
       let context = "";
 
       if (actionKey === "submit") {
-        const typeSkillMap = { problem: "customer_problems", need: "customer_needs", fr: "functional_requirements", nfr: "functional_requirements" };
-        skillName = typeSkillMap[node.type] || "customer_problems";
+        const typeActionMap = { problem: "problems", need: "needs", fr: "functional-requirements", nfr: "functional-requirements" };
+        srsAction = typeActionMap[node.type] || "problems";
         context = "Regarding " + nodeLabel + " " + node.id + " (" + node.label + "): " + prompt;
       } else if (actionKey.startsWith("decompose")) {
         context = "Decompose " + nodeLabel + " " + node.id + " (" + node.label + ") into finer-grained sub-items of the same type. Additional context: " + prompt;
@@ -2600,7 +2601,7 @@ export function renderGraphHtml(graphData, options = {}) {
       }
 
       if (!context) return false;
-      if (actionKey !== "implement" && !skillName) return false;
+      if (actionKey !== "implement" && !srsAction) return false;
 
       // Open the panel for this node so the conversation is visible, then log
       // the ask and a pending agent reply that we mutate through to completion.
@@ -2615,7 +2616,7 @@ export function renderGraphHtml(graphData, options = {}) {
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({
           action: actionKey,
-          skill: skillName,
+          srsAction: srsAction,
           nodeId: node.id,
           nodeType: node.type,
           nodeLabel: node.label,
@@ -2809,7 +2810,7 @@ export function renderGraphHtml(graphData, options = {}) {
         chip.innerHTML = action.icon + '<span>' + action.label + '</span>';
         chip.setAttribute("aria-label", action.label + " for " + node.id);
         chip.addEventListener("click", () => {
-          performNodeAction(action.key, action.skill, node, composerInput.value.trim());
+          performNodeAction(action.key, action.srsAction, node, composerInput.value.trim());
           composerInput.value = "";
           clearComposerStage();
         });
@@ -2846,7 +2847,7 @@ export function renderGraphHtml(graphData, options = {}) {
       const text = composerInput.value.trim();
       if (composerStaged) {
         const stagedAction = getActionsForType(node.type).find(a => a.key === composerStaged.actionKey);
-        performNodeAction(composerStaged.actionKey, stagedAction ? stagedAction.skill : null, node, text);
+        performNodeAction(composerStaged.actionKey, stagedAction ? stagedAction.srsAction : null, node, text);
       } else {
         performNodeAction("submit", null, node, text);
       }
@@ -3522,7 +3523,7 @@ export function renderGraphHtml(graphData, options = {}) {
             var inp = document.getElementById("list-empty-input");
             var text = inp ? inp.value.trim() : "";
             if (!text) { if (inp) inp.focus(); return; }
-            performNodeAction("establish_context", "customer_problems", { id: "CONTEXT", type: "problem", label: "Business context", data: {} }, text);
+            performNodeAction("establish_context", "problems", { id: "CONTEXT", type: "problem", label: "Business context", data: {} }, text);
             if (inp) inp.value = "";
           });
           return;

--- a/.github/extensions/srs-navigator/skills/business-context.md
+++ b/.github/extensions/srs-navigator/skills/business-context.md
@@ -484,7 +484,7 @@ Summary:
 The Business Context provides structured foundation for problem discovery.
 
 → Next Step: 1 - Customer Problems
-→ Use skill: customer-problems
+→ Action: /problem-based-srs problems
 → Input: The Business Context above (especially Current Situation and Pain Points)
 ```
 

--- a/.github/extensions/srs-navigator/skills/complexity-analysis.md
+++ b/.github/extensions/srs-navigator/skills/complexity-analysis.md
@@ -273,4 +273,4 @@ CP.5     [ ]   [ ]   [ ]   [ ]   [ ]   [C]
 
 **Version:** 1.2  
 **Type:** Optional Advanced Validation Tool  
-**Command:** `/complexity-analysis`
+**Command:** `/problem-based-srs complexity`

--- a/.github/extensions/srs-navigator/skills/customer-needs.md
+++ b/.github/extensions/srs-navigator/skills/customer-needs.md
@@ -230,9 +230,9 @@ Summary:
 - [N] Construction needs
 - [N] Entertainment needs
 
-→ MANDATORY: Run zigzag-validator skill to validate CP → CN traceability
+→ MANDATORY: Run /problem-based-srs validate to validate CP → CN traceability
 → Next Step: 4 - Software Vision
-→ Use skill: software-vision
+→ Action: /problem-based-srs software-vision
 ```
 
 ---

--- a/.github/extensions/srs-navigator/skills/customer-problems.md
+++ b/.github/extensions/srs-navigator/skills/customer-problems.md
@@ -367,7 +367,7 @@ Artifacts:
 [List CP-IDs with brief titles]
 
 → Next Step: 2 - Software Glance
-→ Use skill: software-glance
+→ Action: /problem-based-srs software-glance
 → Input: The CPs documented above
 ```
 

--- a/.github/extensions/srs-navigator/skills/functional-requirements.md
+++ b/.github/extensions/srs-navigator/skills/functional-requirements.md
@@ -476,7 +476,7 @@ After completing this step:
 
 📁 Updated: traceability-matrix.md
 
-→ MANDATORY: Run zigzag-validator skill for full chain verification
+→ MANDATORY: Run /problem-based-srs validate for full chain verification
 → Engineers can now pick individual FR files to implement
 ```
 
@@ -488,4 +488,4 @@ Based on Problem-Based SRS methodology (Gorski & Stadzisz, 2016)
 
 **Version:** 1.2  
 **Step:** 5 of 5  
-**Validation:** zigzag-validator skill
+**Validation:** `/problem-based-srs validate`

--- a/.github/extensions/srs-navigator/skills/problem-based-srs.md
+++ b/.github/extensions/srs-navigator/skills/problem-based-srs.md
@@ -22,32 +22,32 @@ Orchestrate requirements engineering using the Problem-Based SRS methodology (Go
 Stakeholder Input
        ↓
 ┌──────────────────┐
-│ Step 0: BC       │ → Use skill: business-context
+│ Step 0: BC       │ → /problem-based-srs business-context
 │ Business Context │
 └────────┬─────────┘
          ↓
 ┌──────────────────┐
-│ Step 1: CP       │ → Use skill: customer-problems
+│ Step 1: CP       │ → /problem-based-srs problems
 │ Customer Problems│
 └────────┬─────────┘
          ↓
 ┌──────────────────┐
-│ Step 2: SG       │ → Use skill: software-glance
+│ Step 2: SG       │ → /problem-based-srs software-glance
 │ Software Glance  │
 └────────┬─────────┘
          ↓
 ┌──────────────────┐
-│ Step 3: CN       │ → Use skill: customer-needs
+│ Step 3: CN       │ → /problem-based-srs needs
 │ Customer Needs   │
 └────────┬─────────┘
          ↓
 ┌──────────────────┐
-│ Step 4: SV       │ → Use skill: software-vision
+│ Step 4: SV       │ → /problem-based-srs software-vision
 │ Software Vision  │
 └────────┬─────────┘
          ↓
 ┌──────────────────┐
-│ Step 5: FR/NFR   │ → Use skill: functional-requirements
+│ Step 5: FR/NFR   │ → /problem-based-srs functional-requirements
 │ Requirements     │
 └──────────────────┘
 ```
@@ -61,20 +61,23 @@ Stakeholder Input
 | **WHAT** | Customer Needs (CN) | What outcomes must the software provide? |
 | **HOW** | Functional Requirements (FR) | How will the system behave? |
 
-## Available Skills
+## Available Actions
 
-This orchestrator coordinates the following skills:
+The Problem-Based SRS methodology is driven by a **single command** — `/problem-based-srs` —
+that dispatches to a step via an **action** argument. Run `/problem-based-srs` with no
+action (or `full`) to orchestrate the complete methodology end-to-end.
 
-| Skill | Command | Purpose |
-|-------|---------|---------|
-| `business-context` | `/business-context` | Step 0: Establish structured business context and principles |
-| `customer-problems` | `/customer-problems` | Step 1: Identify and classify customer problems |
-| `software-glance` | `/software-glance` | Step 2: Create high-level solution view |
-| `customer-needs` | `/customer-needs` | Step 3: Specify customer needs (outcomes) |
-| `software-vision` | `/software-vision` | Step 4: Define software vision and architecture |
-| `functional-requirements` | `/functional-requirements` | Step 5: Generate functional requirements |
-| `zigzag-validator` | `/zigzag-validator` | Validate traceability across domains |
-| `complexity-analysis` | `/complexity-analysis` | Optional: Axiomatic Design quality analysis |
+| Action | Command | Purpose |
+|--------|---------|---------|
+| `business-context` | `/problem-based-srs business-context` | Step 0: Establish structured business context and principles |
+| `problems` | `/problem-based-srs problems` | Step 1: Identify and classify customer problems |
+| `software-glance` | `/problem-based-srs software-glance` | Step 2: Create high-level solution view |
+| `needs` | `/problem-based-srs needs` | Step 3: Specify customer needs (outcomes) |
+| `software-vision` | `/problem-based-srs software-vision` | Step 4: Define software vision and architecture |
+| `functional-requirements` | `/problem-based-srs functional-requirements` | Step 5: Generate functional requirements |
+| `validate` | `/problem-based-srs validate` | Validate traceability across domains (ZigZag) |
+| `complexity` | `/problem-based-srs complexity` | Optional: Axiomatic Design quality analysis |
+| `full` | `/problem-based-srs` | Run the complete methodology (Step 0 → Step 5) |
 
 ## 📁 Saving Progress (CRITICAL)
 
@@ -252,10 +255,10 @@ The business context captures: project identity, business principles (Mandatory/
 ### Starting Fresh
 When user provides business context or problem description:
 1. **Ask where to save artifacts** (if not already specified)
-2. **Start with Step 0** — Use `business-context` skill to establish structured context
+2. **Start with Step 0** — Use the `business-context` action to establish structured context
 3. **Save `00-business-context.md`** with the structured business context
 4. Detect current step (see Detection Heuristics below)
-5. Invoke the appropriate skill
+5. Invoke the appropriate action
 6. Follow instructions from that skill
 7. **Save output to the corresponding file(s)**
 8. Guide user through the process
@@ -266,24 +269,24 @@ If user has existing artifacts (CPs, CNs, etc.):
 2. **Read existing files** to understand current state
 3. Identify what they have
 4. Jump to appropriate step
-5. Invoke that step's skill
+5. Invoke that step's action
 6. Continue from there, **updating files as needed**
 
 ### Validation
-At any point, use zigzag-validator skill to check consistency.
+At any point, use `/problem-based-srs validate` to check consistency.
 
 ## Detection Heuristics
 
 Determine current step by checking what artifacts exist:
 
-| If user has... | Current Step | Use Skill | Save To |
-|----------------|--------------|-----------|---------|
-| Nothing / business idea only | 0 | business-context | 00-business-context.md |
-| Business Context (BC) | 1 | customer-problems | 01-customer-problems.md |
-| Customer Problems (CPs) | 2 | software-glance | 02-software-glance.md |
-| CPs + Software Glance | 3 | customer-needs | 03-customer-needs.md |
-| CPs + CNs + Software Glance | 4 | software-vision | 04-software-vision.md |
-| CPs + CNs + Software Vision | 5 | functional-requirements | functional-requirements/*.md |
+| If user has... | Current Step | Action | Save To |
+|----------------|--------------|--------|---------|
+| Nothing / business idea only | 0 | `business-context` | 00-business-context.md |
+| Business Context (BC) | 1 | `problems` | 01-customer-problems.md |
+| Customer Problems (CPs) | 2 | `software-glance` | 02-software-glance.md |
+| CPs + Software Glance | 3 | `needs` | 03-customer-needs.md |
+| CPs + CNs + Software Glance | 4 | `software-vision` | 04-software-vision.md |
+| CPs + CNs + Software Vision | 5 | `functional-requirements` | functional-requirements/*.md |
 
 ## The Steps (Quick Reference)
 
@@ -292,7 +295,7 @@ Determine current step by checking what artifacts exist:
 **Input:** Stakeholder conversations, project briefs, existing documentation
 **Output:** Business context document with identity, principles, stakeholders, boundaries, constraints, success criteria
 **Save to:** `00-business-context.md`
-**Skill:** business-context
+**Action:** `/problem-based-srs business-context`
 
 ### Step 1: Customer Problems (CP)
 **Purpose:** Identify and document business problems
@@ -300,14 +303,14 @@ Determine current step by checking what artifacts exist:
 **Output:** List of CPs classified as Obligation/Expectation/Hope
 **Syntax:** `[Subject] [must/expects/hopes] [Object] [Penalty]`
 **Save to:** `01-customer-problems.md`
-**Skill:** customer-problems
+**Action:** `/problem-based-srs problems`
 
 ### Step 2: Software Glance (SG)
 **Purpose:** Create initial abstract solution view  
 **Input:** Customer Problems  
 **Output:** High-level system description with boundaries and components  
 **Save to:** `02-software-glance.md`  
-**Skill:** software-glance
+**Action:** `/problem-based-srs software-glance`
 
 ### Step 3: Customer Needs (CN)
 **Purpose:** Specify outcomes software must provide  
@@ -315,14 +318,14 @@ Determine current step by checking what artifacts exist:
 **Output:** CNs with outcome classes (Information/Control/Construction/Entertainment)  
 **Syntax:** `[Subject] needs [system] to [Verb] [Object] [Condition]`  
 **Save to:** `03-customer-needs.md`  
-**Skill:** customer-needs
+**Action:** `/problem-based-srs needs`
 
 ### Step 4: Software Vision (SV)
 **Purpose:** Define high-level scope and positioning  
 **Input:** CNs + Software Glance  
 **Output:** Vision document with stakeholders, features, architecture  
 **Save to:** `04-software-vision.md`  
-**Skill:** software-vision
+**Action:** `/problem-based-srs software-vision`
 
 ### Step 5: Functional Requirements (FR) & Non-Functional Requirements (NFR)
 **Purpose:** Generate detailed requirements  
@@ -330,11 +333,11 @@ Determine current step by checking what artifacts exist:
 **Output:** Individual FR and NFR files with traceability  
 **Syntax FR:** `The [System] shall [Verb] [Object] [Constraint] [Condition]`  
 **Save to:** `functional-requirements/FR-XXX.md` and `non-functional-requirements/NFR-XXX.md`  
-**Skill:** functional-requirements
+**Action:** `/problem-based-srs functional-requirements`
 
 ## Quality Gates
 
-**IMPORTANT:** Zigzag validation using zigzag-validator skill is **MANDATORY** after Steps 3 and 5 to verify traceability and identify gaps.
+**IMPORTANT:** Zigzag validation using the `/problem-based-srs validate` action is **MANDATORY** after Steps 3 and 5 to verify traceability and identify gaps.
 
 ### After Step 0 (BC)
 - [ ] Project identity complete (name, domain, purpose)
@@ -397,13 +400,13 @@ If user attempts to skip to solutions, redirect:
 I notice you're describing a solution. Let's first understand the problem.
 
 Before we design [mentioned solution], help me understand:
-1. What is the business context? (→ business-context skill)
+1. What is the business context? (→ `business-context` action)
 2. What business obligation, expectation, or hope drives this need?
 3. What negative consequences occur without this?
 4. Who is impacted?
 
-→ Loading: business-context skill (if no BC exists)
-→ Loading: customer-problems skill (if BC exists)
+→ Loading: `business-context` action (if no BC exists)
+→ Loading: `problems` action (if BC exists)
 ```
 
 ## Quick Syntax Reference
@@ -463,7 +466,7 @@ Complete initial pass, then iterate on specific steps as understanding improves.
 **Remember:** Update existing files rather than creating new ones.
 
 ### Pattern 4: Validation Only
-Use zigzag-validator skill to check existing artifacts without generating new ones.
+Use the `/problem-based-srs validate` action to check existing artifacts without generating new ones.
 
 ### Pattern 5: Independent Development
 After Step 5, engineers can pick up individual FR files and develop independently.
@@ -474,7 +477,7 @@ Use Problem-Based SRS iteratively within agile workflows:
 - **Sprint 0:** Steps 0-2 (BC + CPs + Software Glance) for product vision
 - **Sprint 1+:** Steps 3-5 for specific feature sets
 - **Per Feature:** Complete CP→CN→FR chain for one feature at a time
-- **Validation:** Run zigzag-validator after each sprint to ensure traceability
+- **Validation:** Run `/problem-based-srs validate` after each sprint to ensure traceability
 
 ### Pattern 7: Minimal Viable SRS
 For quick prototypes or MVPs:
@@ -484,20 +487,20 @@ For quick prototypes or MVPs:
 4. Generate only critical FRs
 5. Skip detailed validation until expansion
 
-## When to Use Each Skill
+## When to Use Each Action
 
-- **business-context:** User is starting a new project and needs to establish structured context
-- **customer-problems:** User has business context but no structured problems
-- **software-glance:** User has CPs and needs high-level solution view
-- **customer-needs:** User has CPs + SG and needs to specify outcomes
-- **software-vision:** User has CNs and needs detailed vision document
-- **functional-requirements:** User has CNs + SV and needs functional requirements
-- **zigzag-validator:** User needs to check traceability or consistency
-- **complexity-analysis:** User explicitly requests Axiomatic Design analysis
+- **`business-context`:** User is starting a new project and needs to establish structured context
+- **`problems`:** User has business context but no structured problems
+- **`software-glance`:** User has CPs and needs high-level solution view
+- **`needs`:** User has CPs + SG and needs to specify outcomes
+- **`software-vision`:** User has CNs and needs detailed vision document
+- **`functional-requirements`:** User has CNs + SV and needs functional requirements
+- **`validate`:** User needs to check traceability or consistency
+- **`complexity`:** User explicitly requests Axiomatic Design analysis
 
 ## Optional: Complexity Analysis
 
-For deeper quality analysis, users can explicitly invoke the `complexity-analysis` skill for Axiomatic Design-based specification quality analysis. Use for critical systems, large specifications, or formal reviews. This is **NOT** part of the standard flow.
+For deeper quality analysis, users can explicitly invoke the `/problem-based-srs complexity` action for Axiomatic Design-based specification quality analysis. Use for critical systems, large specifications, or formal reviews. This is **NOT** part of the standard flow.
 
 ## Examples
 
@@ -505,4 +508,4 @@ For complete walkthroughs, see:
 - [CRM Example](references/crm-example.md) — Business domain (Customer Relationship Management)
 - [MicroER Example](references/microer-example.md) — Technical domain (Renewable Energy System)
 
-**Use skills individually** based on current step to minimize context usage.
+**Run actions individually** based on current step to minimize context usage.

--- a/.github/extensions/srs-navigator/skills/software-glance.md
+++ b/.github/extensions/srs-navigator/skills/software-glance.md
@@ -174,7 +174,7 @@ After generating the Software Glance, instruct the user:
 
 > ✅ **Software Glance complete.** To continue the Problem-Based SRS process:
 > 
-> **Next Step:** Use `customer-needs` skill to specify Customer Needs based on this Software Glance and the Customer Problems.
+> **Next Step:** Run `/problem-based-srs needs` to specify Customer Needs based on this Software Glance and the Customer Problems.
 > 
 > The Software Glance provides boundaries and direction for identifying what outcomes the software must provide.
 
@@ -299,7 +299,7 @@ Before accepting the Software Glance output:
 | 4 | [software-vision](../software-vision/SKILL.md) | 🔗 Drills down from this glance |
 | 5 | functional-requirements | |
 
-**Next:** Use the Software Glance output with `customer-needs` skill to specify what outcomes the software must provide.
+**Next:** Use the Software Glance output with `/problem-based-srs needs` to specify what outcomes the software must provide.
 
 ---
 

--- a/.github/extensions/srs-navigator/skills/software-vision.md
+++ b/.github/extensions/srs-navigator/skills/software-vision.md
@@ -258,7 +258,7 @@ Summary:
 - Architecture overview complete
 
 → Next Step: 5 - Functional Requirements
-→ Use skill: functional-requirements
+→ Action: /problem-based-srs functional-requirements
 → Input: Customer Needs + Software Vision
 ```
 

--- a/.github/extensions/srs-navigator/skills/zigzag-validator.md
+++ b/.github/extensions/srs-navigator/skills/zigzag-validator.md
@@ -252,7 +252,7 @@ Use **C** (Complete) and **P** (Partial) markers to indicate how well each eleme
 ### Uncovered Customer Problems
 | CP | Statement | Suggested Action |
 |----|-----------|------------------|
-| CP.3 | [statement] | Generate CN using customer-needs skill |
+| CP.3 | [statement] | Generate CN using /problem-based-srs needs |
 
 ### Orphan Items
 | Item | Type | Issue | Suggested Action |

--- a/.github/extensions/srs-navigator/tests/action-bar.test.mjs
+++ b/.github/extensions/srs-navigator/tests/action-bar.test.mjs
@@ -48,11 +48,17 @@ describe("Action Bar: Renderer output", () => {
     assert.ok(html.includes(".action-bar-submit"));
   });
 
-  it("includes SKILL_MAP with correct skill associations", () => {
+  it("includes SKILL_MAP mapping actions to the unified srsAction vocabulary", () => {
     assert.ok(html.includes("SKILL_MAP"));
-    assert.ok(html.includes('"customer_needs"'));
-    assert.ok(html.includes('"customer_problems"'));
-    assert.ok(html.includes('"functional_requirements"'));
+    // The action bar no longer references individual skill tool names; every
+    // button maps to a `srsAction` handled by the single problem_based_srs tool.
+    assert.ok(html.includes("srsAction"));
+    assert.ok(html.includes('"needs"'));
+    assert.ok(html.includes('"problems"'));
+    assert.ok(html.includes('"functional-requirements"'));
+    assert.ok(!html.includes('"customer_needs"'));
+    assert.ok(!html.includes('"customer_problems"'));
+    assert.ok(!html.includes('"functional_requirements"'));
   });
 
   it("includes getActionsForType function", () => {
@@ -83,7 +89,7 @@ describe("Action Bar: Renderer output", () => {
   });
 
   it("includes handleActionBarAction that posts to /api/invoke-skill", () => {
-    assert.ok(html.includes("function handleActionBarAction(actionKey, skillName, node)"));
+    assert.ok(html.includes("function handleActionBarAction(actionKey, srsAction, node)"));
     assert.ok(html.includes("/api/invoke-skill"));
   });
 
@@ -172,7 +178,7 @@ describe("Action Bar: /api/invoke-skill endpoint", () => {
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({
         action: "addCN",
-        skill: "customer_needs",
+        srsAction: "needs",
         nodeId: "CP-1",
         nodeType: "problem",
         nodeLabel: "Track Customers",
@@ -191,7 +197,7 @@ describe("Action Bar: /api/invoke-skill endpoint", () => {
     assert.ok(data.actions.length >= 1);
     const last = data.actions[data.actions.length - 1];
     assert.equal(last.action, "addCN");
-    assert.equal(last.skill, "customer_needs");
+    assert.equal(last.srsAction, "needs");
     assert.equal(last.nodeId, "CP-1");
     assert.equal(last.nodeType, "problem");
     assert.equal(last.context, "Derive a CN from CP-1");
@@ -219,9 +225,9 @@ describe("Action Bar: /api/invoke-skill endpoint", () => {
 
   it("queues multiple actions from different node types", async () => {
     const actions = [
-      { action: "addFR", skill: "functional_requirements", nodeId: "CN-1", nodeType: "need", nodeLabel: "Need 1", context: "Derive FR" },
-      { action: "addNFR", skill: "functional_requirements", nodeId: "FR-1", nodeType: "fr", nodeLabel: "Req 1", context: "Derive NFR" },
-      { action: "decompose_problem", skill: "customer_problems", nodeId: "CP-2", nodeType: "problem", nodeLabel: "Problem 2", context: "Decompose" },
+      { action: "addFR", srsAction: "functional-requirements", nodeId: "CN-1", nodeType: "need", nodeLabel: "Need 1", context: "Derive FR" },
+      { action: "addNFR", srsAction: "functional-requirements", nodeId: "FR-1", nodeType: "fr", nodeLabel: "Req 1", context: "Derive NFR" },
+      { action: "decompose_problem", srsAction: "problems", nodeId: "CP-2", nodeType: "problem", nodeLabel: "Problem 2", context: "Decompose" },
     ];
 
     for (const action of actions) {
@@ -238,42 +244,43 @@ describe("Action Bar: /api/invoke-skill endpoint", () => {
     // Should have original + 3 new
     assert.ok(data.actions.length >= 4);
 
-    const skills = data.actions.map(a => a.skill);
-    assert.ok(skills.includes("customer_needs"));
-    assert.ok(skills.includes("functional_requirements"));
-    assert.ok(skills.includes("customer_problems"));
+    const srsActions = data.actions.map(a => a.srsAction);
+    assert.ok(srsActions.includes("needs"));
+    assert.ok(srsActions.includes("functional-requirements"));
+    assert.ok(srsActions.includes("problems"));
   });
 });
 
 // --- Skill Mapping Correctness Tests ---
 
-describe("Action Bar: Skill mapping correctness", () => {
-  // Verify the SKILL_MAP entries match the registered skill tool names
-  const REGISTERED_SKILLS = [
-    "business_context",
-    "customer_problems",
-    "software_glance",
-    "customer_needs",
-    "software_vision",
-    "functional_requirements",
-    "complexity_analysis",
-    "problem_based_srs",
-    "zigzag_validator",
+describe("Action Bar: Action mapping correctness", () => {
+  // Verify the SKILL_MAP entries map to the unified srsAction vocabulary handled
+  // by the single problem_based_srs tool (no more per-step tool names).
+  const REGISTERED_ACTIONS = [
+    "business-context",
+    "problems",
+    "software-glance",
+    "needs",
+    "software-vision",
+    "functional-requirements",
+    "complexity",
+    "full",
+    "validate",
   ];
 
   const EXPECTED_MAPPINGS = {
-    problem: { addCN: "customer_needs", decompose_problem: "customer_problems" },
-    need: { addFR: "functional_requirements", decompose_need: "customer_needs" },
-    fr: { addNFR: "functional_requirements", decompose_fr: "functional_requirements" },
-    nfr: { decompose_nfr: "functional_requirements" },
+    problem: { addCN: "needs", decompose_problem: "problems" },
+    need: { addFR: "functional-requirements", decompose_need: "needs" },
+    fr: { addNFR: "functional-requirements", decompose_fr: "functional-requirements" },
+    nfr: { decompose_nfr: "functional-requirements" },
   };
 
   for (const [nodeType, actions] of Object.entries(EXPECTED_MAPPINGS)) {
-    for (const [actionKey, skillName] of Object.entries(actions)) {
-      it(`${nodeType} → ${actionKey} maps to registered skill "${skillName}"`, () => {
+    for (const [actionKey, srsAction] of Object.entries(actions)) {
+      it(`${nodeType} → ${actionKey} maps to registered action "${srsAction}"`, () => {
         assert.ok(
-          REGISTERED_SKILLS.includes(skillName),
-          `Skill "${skillName}" for action "${actionKey}" on "${nodeType}" is not in the registered skills list`
+          REGISTERED_ACTIONS.includes(srsAction),
+          `Action "${srsAction}" for button "${actionKey}" on "${nodeType}" is not in the registered actions list`
         );
       });
     }
@@ -325,8 +332,8 @@ describe("Action Bar: Queue consume-once semantics", () => {
 
     // Queue two actions
     queues.set(instanceId, [
-      { id: "a1", skill: "customer_needs", action: "addCN" },
-      { id: "a2", skill: "functional_requirements", action: "addFR" },
+      { id: "a1", srsAction: "needs", action: "addCN" },
+      { id: "a2", srsAction: "functional-requirements", action: "addFR" },
     ]);
 
     // First retrieval returns both and clears
@@ -342,8 +349,8 @@ describe("Action Bar: Queue consume-once semantics", () => {
   it("actions from different instances are isolated", () => {
     const queues = new Map();
 
-    queues.set("inst-a", [{ id: "1", skill: "customer_needs" }]);
-    queues.set("inst-b", [{ id: "2", skill: "functional_requirements" }, { id: "3", skill: "customer_problems" }]);
+    queues.set("inst-a", [{ id: "1", srsAction: "needs" }]);
+    queues.set("inst-b", [{ id: "2", srsAction: "functional-requirements" }, { id: "3", srsAction: "problems" }]);
 
     assert.equal(queues.get("inst-a").length, 1);
     assert.equal(queues.get("inst-b").length, 2);
@@ -361,7 +368,7 @@ describe("Action Bar: Queue consume-once semantics", () => {
 
     // Simulate rapid writes
     for (let i = 0; i < 5; i++) {
-      queues.get(instanceId).push({ id: `action-${i}`, skill: "customer_needs" });
+      queues.get(instanceId).push({ id: `action-${i}`, srsAction: "needs" });
     }
 
     const retrieved = queues.get(instanceId) || [];
@@ -391,6 +398,53 @@ describe("List View: implement action prompt", () => {
   it("implement prompt preserves traceability to the requirement", () => {
     assert.ok(extSource.includes("Preserve traceability"));
     assert.ok(extSource.includes("${action.nodeId}"));
+  });
+});
+
+// --- Unified single-command model (problem_based_srs with action arg) ---
+
+describe("Unified command: single problem_based_srs tool", () => {
+  const extSource = readFileSync(join(__dirname, "..", "extension.mjs"), "utf8");
+
+  it("registers a single problem_based_srs tool", () => {
+    assert.ok(extSource.includes('name: "problem_based_srs"'),
+      "extension must register the unified problem_based_srs tool");
+  });
+
+  it("no longer registers per-step skill tools", () => {
+    for (const legacy of [
+      'name: "customer_problems"',
+      'name: "customer_needs"',
+      'name: "functional_requirements"',
+      'name: "business_context"',
+      'name: "software_glance"',
+      'name: "software_vision"',
+      'name: "zigzag_validator"',
+      'name: "complexity_analysis"',
+    ]) {
+      assert.ok(!extSource.includes(legacy),
+        `legacy skill tool ${legacy} must be removed in favor of an action arg`);
+    }
+  });
+
+  it("exposes the action vocabulary on the tool", () => {
+    for (const action of ["problems", "needs", "functional-requirements", "business-context", "validate"]) {
+      assert.ok(extSource.includes(`"${action}"`),
+        `action "${action}" must be part of the unified tool's vocabulary`);
+    }
+  });
+
+  it("builds slash-command prompts as /problem-based-srs <action>", () => {
+    assert.ok(extSource.includes("/problem-based-srs"),
+      "action prompts must route through the single /problem-based-srs command");
+    // The old per-skill slash mapping (name.replace(_ -> -)) must be gone.
+    assert.ok(!extSource.includes('"/" + String(skill'),
+      "the legacy per-skill slash command builder must be removed");
+  });
+
+  it("action prompts reference the srsAction field, not a skill tool name", () => {
+    assert.ok(extSource.includes("action.srsAction"),
+      "server prompts must read the srsAction field from queued actions");
   });
 });
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,45 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.4] - 2026-07-02
+
+### Added
+
+- **New `evals/` harness for testing and evaluating the methodology skills using the
+  GitHub Copilot CLI SDK.** Two tiers: deterministic offline tests (`evals/tests/*.test.mjs`,
+  57 tests via `node --test`) covering the headless Copilot SDK wrapper, the SKILL.md
+  loader/graders, and static skill evals over every `skills/<slug>/SKILL.md` (name/dir
+  match, description contract, body line cap, link resolution, methodology tokens, and a
+  regression guard proving the unified `/problem-based-srs <action>` refactor left no
+  legacy per-step commands or `Use skill:` handoffs); and opt-in live LLM evals
+  (`evals/cases/*.case.mjs` + `evals/run-evals.mjs`) that run each skill through the real
+  model and grade it with a rubric plus an optional LLM judge. Includes PowerShell runners
+  `evals/scripts/run-tests.ps1` and `evals/scripts/run-evals.ps1` for manual verification.
+- **Verbose eval output.** `evals/run-evals.mjs` gains `--verbose`/`-v` and `-vv`
+  (surfaced as `-Detailed`/`-Trace` in `run-evals.ps1`) to print the built prompt, run
+  metadata (exit code, duration, token usage, loaded skills, tool calls, stderr), the full
+  model artifact, and every rubric check (passing and failing) for troubleshooting.
+- **Repo-root `run-tests.ps1`** that runs all offline suites in sequence — plugin
+  validation, the canvas extension tests, and the deterministic skill evals — with a
+  pass/fail summary and `-SkipValidate` / `-SkipCanvas` / `-SkipEvals` switches.
+
+### Changed
+
+- **Unified the nine per-step commands into a single `/problem-based-srs` command
+  with an `action` argument.** Instead of `/customer-problems`, `/customer-needs`,
+  `/functional-requirements`, etc., the methodology is now driven by one command that
+  dispatches to a step: `/problem-based-srs problems`, `/problem-based-srs needs`,
+  `/problem-based-srs functional-requirements`, `/problem-based-srs business-context`,
+  `/problem-based-srs software-glance`, `/problem-based-srs software-vision`,
+  `/problem-based-srs validate`, `/problem-based-srs complexity`, and
+  `/problem-based-srs` (full run, the default). Applied consistently across the CLI
+  skills/agent, the SRS Navigator canvas extension (a single `problem_based_srs` tool
+  replaces the nine per-step tools; action-bar payloads now carry an `srsAction`
+  field), and the project webpage. The eight step content files under `skills/<slug>/`
+  are retained as the backing methodology library.
+
+[2.4]: https://github.com/RafaelGorski/Problem-Based-SRS/releases/tag/v2.4
+
 ## [2.3] - 2026-07-01
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -53,16 +53,16 @@ graph LR
 
 | Step | Command | You answer | You get |
 |------|---------|------------|---------|
-| 0. Business Context | `/business-context` | Project identity, constraints, success criteria | Governing principles for all decisions |
-| 1. Customer Problems | `/customer-problems` | What's broken and for whom | Prioritized problems (Obligation / Expectation / Hope) |
-| 2. Software Glance | `/software-glance` | High-level solution direction | Shared understanding of scope and boundaries |
-| 3. Customer Needs | `/customer-needs` | Required outcomes per problem | Measurable success criteria |
-| 4. Software Vision | `/software-vision` | Architecture and technical approach | Technical roadmap with stakeholder alignment |
-| 5. Functional Requirements | `/functional-requirements` | Detailed behavior specs | Testable requirements traced to problems |
+| 0. Business Context | `/problem-based-srs business-context` | Project identity, constraints, success criteria | Governing principles for all decisions |
+| 1. Customer Problems | `/problem-based-srs problems` | What's broken and for whom | Prioritized problems (Obligation / Expectation / Hope) |
+| 2. Software Glance | `/problem-based-srs software-glance` | High-level solution direction | Shared understanding of scope and boundaries |
+| 3. Customer Needs | `/problem-based-srs needs` | Required outcomes per problem | Measurable success criteria |
+| 4. Software Vision | `/problem-based-srs software-vision` | Architecture and technical approach | Technical roadmap with stakeholder alignment |
+| 5. Functional Requirements | `/problem-based-srs functional-requirements` | Detailed behavior specs | Testable requirements traced to problems |
 
 Every requirement traces backward: **FR → CN → CP**. You can always answer *"Why are we building this?"*
 
-Use `/zigzag-validator` at any point to verify the chain is complete.
+Use `/problem-based-srs validate` at any point to verify the chain is complete.
 
 ### Problem classification
 
@@ -128,17 +128,20 @@ Every FR traces to a CN, which traces to a CP. The $50k problem is the root. Not
 
 ## Commands
 
+The methodology is driven by a **single command**, `/problem-based-srs`, with an
+**action** argument. Run it with no action (or `full`) for the complete walkthrough.
+
 | Command | Purpose |
 |---------|---------|
 | `/problem-based-srs` | Full methodology, all steps |
-| `/business-context` | Step 0: project identity and constraints |
-| `/customer-problems` | Step 1: identify and classify problems |
-| `/software-glance` | Step 2: sketch solution approach |
-| `/customer-needs` | Step 3: define required outcomes |
-| `/software-vision` | Step 4: architecture and scope |
-| `/functional-requirements` | Step 5: detailed, testable requirements |
-| `/zigzag-validator` | Verify traceability across all artifacts |
-| `/complexity-analysis` | Optional: Axiomatic Design quality analysis |
+| `/problem-based-srs business-context` | Step 0: project identity and constraints |
+| `/problem-based-srs problems` | Step 1: identify and classify problems |
+| `/problem-based-srs software-glance` | Step 2: sketch solution approach |
+| `/problem-based-srs needs` | Step 3: define required outcomes |
+| `/problem-based-srs software-vision` | Step 4: architecture and scope |
+| `/problem-based-srs functional-requirements` | Step 5: detailed, testable requirements |
+| `/problem-based-srs validate` | Verify traceability across all artifacts |
+| `/problem-based-srs complexity` | Optional: Axiomatic Design quality analysis |
 | `/live` | Launch the **SRS Navigator** canvas to visualize the spec as an interactive graph |
 
 ## Visualize it live

--- a/agents/problem-based-srs/AGENT.md
+++ b/agents/problem-based-srs/AGENT.md
@@ -22,32 +22,32 @@ Orchestrate requirements engineering using the Problem-Based SRS methodology (Go
 Stakeholder Input
        ↓
 ┌──────────────────┐
-│ Step 0: BC       │ → Use skill: business-context
+│ Step 0: BC       │ → /problem-based-srs business-context
 │ Business Context │
 └────────┬─────────┘
          ↓
 ┌──────────────────┐
-│ Step 1: CP       │ → Use skill: customer-problems
+│ Step 1: CP       │ → /problem-based-srs problems
 │ Customer Problems│
 └────────┬─────────┘
          ↓
 ┌──────────────────┐
-│ Step 2: SG       │ → Use skill: software-glance
+│ Step 2: SG       │ → /problem-based-srs software-glance
 │ Software Glance  │
 └────────┬─────────┘
          ↓
 ┌──────────────────┐
-│ Step 3: CN       │ → Use skill: customer-needs
+│ Step 3: CN       │ → /problem-based-srs needs
 │ Customer Needs   │
 └────────┬─────────┘
          ↓
 ┌──────────────────┐
-│ Step 4: SV       │ → Use skill: software-vision
+│ Step 4: SV       │ → /problem-based-srs software-vision
 │ Software Vision  │
 └────────┬─────────┘
          ↓
 ┌──────────────────┐
-│ Step 5: FR/NFR   │ → Use skill: functional-requirements
+│ Step 5: FR/NFR   │ → /problem-based-srs functional-requirements
 │ Requirements     │
 └──────────────────┘
 ```
@@ -61,20 +61,22 @@ Stakeholder Input
 | **WHAT** | Customer Needs (CN) | What outcomes MUST the software provide? |
 | **HOW** | Functional Requirements (FR) | How will the system behave? |
 
-## Available Skills
+## Available Actions
 
-This agent orchestrates the following skills:
+This agent drives the methodology through a **single command**, `/problem-based-srs`,
+dispatching to a step via an **action** argument:
 
-| Skill | Command | Purpose |
-|-------|---------|---------|
-| `business-context` | `/business-context` | Step 0: Establish structured business context and principles |
-| `customer-problems` | `/customer-problems` | Step 1: Identify and classify customer problems |
-| `software-glance` | `/software-glance` | Step 2: Create high-level solution view |
-| `customer-needs` | `/customer-needs` | Step 3: Specify customer needs (outcomes) |
-| `software-vision` | `/software-vision` | Step 4: Define software vision and architecture |
-| `functional-requirements` | `/functional-requirements` | Step 5: Generate functional requirements |
-| `zigzag-validator` | `/zigzag-validator` | Validate traceability across domains |
-| `complexity-analysis` | `/complexity-analysis` | Optional: Axiomatic Design quality analysis |
+| Action | Command | Purpose |
+|--------|---------|---------|
+| `business-context` | `/problem-based-srs business-context` | Step 0: Establish structured business context and principles |
+| `problems` | `/problem-based-srs problems` | Step 1: Identify and classify customer problems |
+| `software-glance` | `/problem-based-srs software-glance` | Step 2: Create high-level solution view |
+| `needs` | `/problem-based-srs needs` | Step 3: Specify customer needs (outcomes) |
+| `software-vision` | `/problem-based-srs software-vision` | Step 4: Define software vision and architecture |
+| `functional-requirements` | `/problem-based-srs functional-requirements` | Step 5: Generate functional requirements |
+| `validate` | `/problem-based-srs validate` | Validate traceability across domains (ZigZag) |
+| `complexity` | `/problem-based-srs complexity` | Optional: Axiomatic Design quality analysis |
+| `full` | `/problem-based-srs` | Run the complete methodology (Step 0 → Step 5) |
 
 ## How to Use This Agent
 
@@ -85,10 +87,10 @@ This agent orchestrates the following skills:
 ### Starting Fresh
 When user provides business context or problem description:
 1. **Ask where to save artifacts** (if not already specified)
-2. **Start with Step 0** — Use `business-context` skill to establish structured context
+2. **Start with Step 0** — Use the `business-context` action to establish structured context
 3. **Save `00-business-context.md`** with the structured business context
 4. Detect current step (see Detection Heuristics below)
-5. Invoke the appropriate skill
+5. Invoke the appropriate action
 6. Guide user through the process
 7. **Save output to the corresponding file(s)** (one file at a time)
 
@@ -98,28 +100,28 @@ If user has existing artifacts (CPs, CNs, etc.):
 2. **Read existing files** to understand current state
 3. Identify what they have
 4. Jump to appropriate step
-5. Invoke that step's skill
+5. Invoke that step's action
 6. Continue from there, **updating files as needed**
 
 ### Validation
-At any point, use the `zigzag-validator` skill to check consistency.
+At any point, use the `/problem-based-srs validate` action to check consistency.
 
 ## Detection Heuristics
 
 Determine current step by checking what artifacts exist:
 
-| If user has... | Current Step | Invoke Skill | Save To |
-|----------------|--------------|--------------|---------|
-| Nothing / business idea only | 0 | business-context | 00-business-context.md |
-| Business Context (BC) | 1 | customer-problems | 01-customer-problems.md |
-| Customer Problems (CPs) | 2 | software-glance | 02-software-glance.md |
-| CPs + Software Glance | 3 | customer-needs | 03-customer-needs.md |
-| CPs + CNs + Software Glance | 4 | software-vision | 04-software-vision.md |
-| CPs + CNs + Software Vision | 5 | functional-requirements | functional-requirements/*.md |
+| If user has... | Current Step | Action | Save To |
+|----------------|--------------|--------|---------|
+| Nothing / business idea only | 0 | `business-context` | 00-business-context.md |
+| Business Context (BC) | 1 | `problems` | 01-customer-problems.md |
+| Customer Problems (CPs) | 2 | `software-glance` | 02-software-glance.md |
+| CPs + Software Glance | 3 | `needs` | 03-customer-needs.md |
+| CPs + CNs + Software Glance | 4 | `software-vision` | 04-software-vision.md |
+| CPs + CNs + Software Vision | 5 | `functional-requirements` | functional-requirements/*.md |
 
 ## Quality Gates
 
-**IMPORTANT:** Zigzag validation using `zigzag-validator` skill is **MANDATORY** after Steps 3 and 5 to verify traceability and identify gaps.
+**IMPORTANT:** Zigzag validation using the `/problem-based-srs validate` action is **MANDATORY** after Steps 3 and 5 to verify traceability and identify gaps.
 
 ### After Step 0 (BC)
 - [ ] Project identity complete (name, domain, purpose)
@@ -156,13 +158,13 @@ If user attempts to skip to solutions, redirect:
 I notice you're describing a solution. Let's first understand the problem.
 
 Before we design [mentioned solution], help me understand:
-1. What is the business context? (→ business-context skill)
+1. What is the business context? (→ `business-context` action)
 2. What business obligation, expectation, or hope drives this need?
 3. What negative consequences occur without this?
 4. Who is impacted?
 
-→ Invoking: business-context skill (if no BC exists)
-→ Invoking: customer-problems skill (if BC exists)
+→ Invoking: `business-context` action (if no BC exists)
+→ Invoking: `problems` action (if BC exists)
 ```
 
 ## Usage Patterns
@@ -177,7 +179,7 @@ Detect what artifacts exist, skip completed steps, resume at current step.
 Complete initial pass, then iterate on specific steps as understanding improves.
 
 ### Pattern 4: Validation Only
-Use zigzag-validator skill to check existing artifacts without generating new ones.
+Use the `/problem-based-srs validate` action to check existing artifacts without generating new ones.
 
 ### Pattern 5: Agile/Sprint Integration
 - **Sprint 0:** Steps 0-2 (BC + CPs + Software Glance) for product vision

--- a/docs/index.html
+++ b/docs/index.html
@@ -164,63 +164,63 @@
                             <div class="flow-name">Business Context</div>
                             <p class="flow-question">What governs this project?</p>
                             <p class="flow-desc">Project identity, constraints, success criteria. Establishes principles for all downstream decisions.</p>
-                            <span class="flow-cmd">/business-context</span>
+                            <span class="flow-cmd">/problem-based-srs business-context</span>
                         </div>
                         <div class="flow-step reveal" style="--dot-color: var(--step-why)">
                             <div class="flow-dot"></div>
                             <div class="flow-name">Customer Problems</div>
                             <p class="flow-question">What is broken, and for whom?</p>
                             <p class="flow-desc">Identify and classify problems by severity: Obligation (must solve), Expectation (should solve), Hope (could solve).</p>
-                            <span class="flow-cmd">/customer-problems</span>
+                            <span class="flow-cmd">/problem-based-srs problems</span>
                         </div>
                         <div class="flow-step reveal" style="--dot-color: var(--step-glance)">
                             <div class="flow-dot"></div>
                             <div class="flow-name">Software Glance</div>
                             <p class="flow-question">What might help?</p>
                             <p class="flow-desc">High-level solution sketch. Components, boundaries, interfaces. Shared understanding before details.</p>
-                            <span class="flow-cmd">/software-glance</span>
+                            <span class="flow-cmd">/problem-based-srs software-glance</span>
                         </div>
                         <div class="flow-step reveal" style="--dot-color: var(--step-what)">
                             <div class="flow-dot"></div>
                             <div class="flow-name">Customer Needs</div>
                             <p class="flow-question">What must the system deliver?</p>
                             <p class="flow-desc">Required outcomes per problem. Measurable, testable, scoped. Each need traces to a specific problem.</p>
-                            <span class="flow-cmd">/customer-needs</span>
+                            <span class="flow-cmd">/problem-based-srs needs</span>
                         </div>
                         <div class="flow-step reveal" style="--dot-color: var(--step-vision)">
                             <div class="flow-dot"></div>
                             <div class="flow-name">Software Vision</div>
                             <p class="flow-question">How will it work?</p>
                             <p class="flow-desc">Architecture, technical approach, constraints, stakeholder alignment. The technical roadmap.</p>
-                            <span class="flow-cmd">/software-vision</span>
+                            <span class="flow-cmd">/problem-based-srs software-vision</span>
                         </div>
                         <div class="flow-step reveal" style="--dot-color: var(--step-how)">
                             <div class="flow-dot"></div>
                             <div class="flow-name">Functional Requirements</div>
                             <p class="flow-question">What are the details?</p>
                             <p class="flow-desc">Detailed, testable behavior specifications. Each requirement traces backward to a need and a problem.</p>
-                            <span class="flow-cmd">/functional-requirements</span>
+                            <span class="flow-cmd">/problem-based-srs functional-requirements</span>
                         </div>
                     </div>
 
                     <figure class="method-aside reveal">
-                        <div class="cli-sim" role="img" aria-label="A Copilot CLI session calling each Problem-Based SRS skill in order: business-context, customer-problems, software-glance, customer-needs, software-vision, and functional-requirements, ending with 100% traceability from FR back to CN back to CP.">
+                        <div class="cli-sim" role="img" aria-label="A Copilot CLI session calling the Problem-Based SRS command for each step in order: business-context, problems, software-glance, needs, software-vision, and functional-requirements, ending with 100% traceability from FR back to CN back to CP.">
                             <div class="cli-bar">
                                 <div class="cli-dots" aria-hidden="true"><span></span><span></span><span></span></div>
                                 <span class="cli-title">copilot &middot; problem-based-srs</span>
                             </div>
                             <div class="cli-body" aria-hidden="true">
                                 <div class="cli-line cli-you" style="--i:0"><span class="cli-caret">&rsaquo;</span> Turn the outage postmortem into a spec</div>
-                                <div class="cli-line" style="--i:1"><span class="cli-cmd" style="--c: var(--step-context)">/business-context</span><span class="cli-out">project identity, constraints, success criteria</span></div>
-                                <div class="cli-line" style="--i:2"><span class="cli-cmd" style="--c: var(--step-why)">/customer-problems</span><span class="cli-out">CP&#8209;1&#8230;CP&#8209;5, classified by severity</span></div>
-                                <div class="cli-line" style="--i:3"><span class="cli-cmd" style="--c: var(--step-glance)">/software-glance</span><span class="cli-out">high-level solution sketch</span></div>
-                                <div class="cli-line" style="--i:4"><span class="cli-cmd" style="--c: var(--step-what)">/customer-needs</span><span class="cli-out">each CN traces to a CP</span></div>
-                                <div class="cli-line" style="--i:5"><span class="cli-cmd" style="--c: var(--step-vision)">/software-vision</span><span class="cli-out">architecture and approach</span></div>
-                                <div class="cli-line" style="--i:6"><span class="cli-cmd" style="--c: var(--step-how)">/functional-requirements</span><span class="cli-out">each FR traces to a CN and a CP</span></div>
+                                <div class="cli-line" style="--i:1"><span class="cli-cmd" style="--c: var(--step-context)">/problem-based-srs business-context</span><span class="cli-out">project identity, constraints, success criteria</span></div>
+                                <div class="cli-line" style="--i:2"><span class="cli-cmd" style="--c: var(--step-why)">/problem-based-srs problems</span><span class="cli-out">CP&#8209;1&#8230;CP&#8209;5, classified by severity</span></div>
+                                <div class="cli-line" style="--i:3"><span class="cli-cmd" style="--c: var(--step-glance)">/problem-based-srs software-glance</span><span class="cli-out">high-level solution sketch</span></div>
+                                <div class="cli-line" style="--i:4"><span class="cli-cmd" style="--c: var(--step-what)">/problem-based-srs needs</span><span class="cli-out">each CN traces to a CP</span></div>
+                                <div class="cli-line" style="--i:5"><span class="cli-cmd" style="--c: var(--step-vision)">/problem-based-srs software-vision</span><span class="cli-out">architecture and approach</span></div>
+                                <div class="cli-line" style="--i:6"><span class="cli-cmd" style="--c: var(--step-how)">/problem-based-srs functional-requirements</span><span class="cli-out">each FR traces to a CN and a CP</span></div>
                                 <div class="cli-line cli-done" style="--i:7"><span class="cli-check">&#10003;</span> 100% traceability &middot; FR &larr; CN &larr; CP<span class="cli-cursor"></span></div>
                             </div>
                         </div>
-                        <figcaption>Each step runs as a skill your assistant calls in the terminal.</figcaption>
+                        <figcaption>Each step runs as an action of the single <code>/problem-based-srs</code> command your assistant calls in the terminal.</figcaption>
                     </figure>
                 </div>
 
@@ -297,7 +297,8 @@ Our warehouse tracks everything in spreadsheets and loses $50k/month due to erro
         <!-- Commands -->
         <section id="commands" class="section">
             <div class="wrap">
-                <h2 class="reveal">Commands</h2>
+                <h2 class="reveal">Command &amp; actions</h2>
+                <p class="reveal" style="color: var(--muted); margin-bottom: var(--space-md);">One command, <code>/problem-based-srs</code>, drives the whole methodology. Pass an action to run a single step, or run it with no action for the full walkthrough.</p>
                 <div class="table-scroll reveal">
                 <table class="cmd-table">
                     <thead>
@@ -314,42 +315,42 @@ Our warehouse tracks everything in spreadsheets and loses $50k/month due to erro
                             <td style="color: var(--muted);">All</td>
                         </tr>
                         <tr>
-                            <td class="cmd-name">/business-context</td>
+                            <td class="cmd-name">/problem-based-srs business-context</td>
                             <td>Project identity and constraints</td>
                             <td style="color: var(--muted);">0</td>
                         </tr>
                         <tr>
-                            <td class="cmd-name">/customer-problems</td>
+                            <td class="cmd-name">/problem-based-srs problems</td>
                             <td>Identify and classify problems</td>
                             <td style="color: var(--muted);">1</td>
                         </tr>
                         <tr>
-                            <td class="cmd-name">/software-glance</td>
+                            <td class="cmd-name">/problem-based-srs software-glance</td>
                             <td>Sketch solution approach</td>
                             <td style="color: var(--muted);">2</td>
                         </tr>
                         <tr>
-                            <td class="cmd-name">/customer-needs</td>
+                            <td class="cmd-name">/problem-based-srs needs</td>
                             <td>Define required outcomes</td>
                             <td style="color: var(--muted);">3</td>
                         </tr>
                         <tr>
-                            <td class="cmd-name">/software-vision</td>
+                            <td class="cmd-name">/problem-based-srs software-vision</td>
                             <td>Architecture and scope</td>
                             <td style="color: var(--muted);">4</td>
                         </tr>
                         <tr>
-                            <td class="cmd-name">/functional-requirements</td>
+                            <td class="cmd-name">/problem-based-srs functional-requirements</td>
                             <td>Detailed, testable requirements</td>
                             <td style="color: var(--muted);">5</td>
                         </tr>
                         <tr>
-                            <td class="cmd-name">/zigzag-validator</td>
+                            <td class="cmd-name">/problem-based-srs validate</td>
                             <td>Verify traceability across artifacts</td>
                             <td style="color: var(--muted);">Validate</td>
                         </tr>
                         <tr>
-                            <td class="cmd-name">/complexity-analysis</td>
+                            <td class="cmd-name">/problem-based-srs complexity</td>
                             <td>Axiomatic Design quality analysis</td>
                             <td style="color: var(--muted);">Optional</td>
                         </tr>

--- a/evals/README.md
+++ b/evals/README.md
@@ -1,0 +1,146 @@
+# Problem-Based SRS — Skill Evals
+
+A separate, self-contained harness that tests and evaluates the methodology
+**skills** (`skills/<slug>/SKILL.md`), driven by the **GitHub Copilot CLI SDK**
+(`@github/copilot` in headless mode).
+
+This is intentionally decoupled from the canvas app's own suite in
+`.github/extensions/srs-navigator/tests/` (which tests UI/renderer code). This
+folder tests the *skill content and the methodology behavior* instead.
+
+## Two tiers
+
+| Tier | Location | Model calls? | When it runs |
+|------|----------|--------------|--------------|
+| **Deterministic tests** | `tests/*.test.mjs` | No | Always (offline, CI-safe) |
+| **Live LLM evals** | `cases/*.case.mjs` + `run-evals.mjs` | Yes | Opt-in only |
+
+### 1. Deterministic tests (offline)
+
+Pure `node --test` files with no external dependencies:
+
+- `tests/copilot-sdk.test.mjs` — the headless Copilot CLI wrapper (JSONL parsing,
+  arg building, timeout handling) using a fake spawn.
+- `tests/lib.test.mjs` — the SKILL.md loader/parser and the rubric graders.
+- `tests/skills-static.test.mjs` — **the flagship regression guard.** Asserts, over
+  every real `skills/<slug>/SKILL.md`:
+  - `name` frontmatter matches the directory,
+  - a description contract and a body line cap,
+  - **no legacy slash-commands** (`/customer-problems`, `/customer-needs`, …) and
+    no `Use skill:` handoffs — i.e. the unified `/problem-based-srs <action>`
+    refactor did not regress,
+  - all relative links resolve on disk,
+  - per-skill methodology tokens are present, and the orchestrator lists all 8
+    named actions.
+
+Run them:
+
+```bash
+npm test                 # from evals/
+# or
+node --test tests/
+```
+
+PowerShell helper:
+
+```powershell
+pwsh evals/scripts/run-tests.ps1
+pwsh evals/scripts/run-tests.ps1 -File skills-static.test.mjs
+```
+
+### 2. Live LLM evals (opt-in)
+
+Each `cases/*.case.mjs` builds a **hermetic prompt** that injects the skill's own
+`SKILL.md` plus a fixture brief, runs it through the Copilot CLI, and grades the
+result with a deterministic rubric and (optionally) an LLM judge.
+
+They are **opt-in** because they call the real model and may consume premium
+requests. They require the `copilot` CLI to be installed and authenticated.
+
+Run them:
+
+```bash
+RUN_SKILL_EVALS=1 node run-evals.mjs
+node run-evals.mjs --force                 # ignore the env gate
+node run-evals.mjs customer-needs          # a single case
+node run-evals.mjs --no-judge              # rubric only
+node run-evals.mjs --verbose               # show prompt, run metadata, artifact, every check
+node run-evals.mjs -vv                      # even more verbose (no truncation)
+```
+
+PowerShell helper:
+
+```powershell
+pwsh evals/scripts/run-evals.ps1
+pwsh evals/scripts/run-evals.ps1 -Case customer-needs
+pwsh evals/scripts/run-evals.ps1 -NoJudge -Model gpt-5.4
+pwsh evals/scripts/run-evals.ps1 -Case customer-problems -Detailed   # verbose troubleshooting
+pwsh evals/scripts/run-evals.ps1 -Trace                              # full prompt + full artifact
+```
+
+When `-Detailed`/`--verbose` is set the runner prints, per case: the built prompt,
+the CLI exit code / duration / token usage / loaded skills / tool calls / stderr, the
+full model artifact, and **every** rubric check (passing and failing) — so a failing
+eval can be diagnosed without re-running.
+
+## Running everything
+
+A repo-root `run-tests.ps1` runs all offline suites in sequence — plugin validation,
+the canvas extension tests, and the deterministic skill evals:
+
+```powershell
+pwsh run-tests.ps1
+pwsh run-tests.ps1 -SkipCanvas -SkipValidate   # skill evals only
+```
+
+Live LLM evals are **not** part of `run-tests.ps1` (they call the model); run them
+explicitly with `evals/scripts/run-evals.ps1`.
+
+## The "SDK"
+
+`lib/copilot-sdk.mjs` wraps the `@github/copilot` CLI in headless mode:
+
+```
+copilot -p "<prompt>" --allow-all-tools --output-format json
+```
+
+It parses the JSONL event stream (`session.skills_loaded`, `assistant.message`,
+`result`, …) into a structured `{ text, events, skills, toolCalls, result }`
+object. Every process-boundary function accepts an injectable `spawnImpl` /
+`execFileImpl` so the deterministic tests never touch a real process.
+
+## Layout
+
+```
+evals/
+├── lib/
+│   ├── copilot-sdk.mjs      # headless Copilot CLI wrapper + JSONL parsers
+│   ├── skills.mjs           # SKILL.md loader/parser
+│   └── graders.mjs          # rubric grading + LLM judge
+├── tests/                   # deterministic node --test files (offline)
+├── cases/                   # live eval cases (opt-in)
+│   ├── _shared.mjs
+│   └── *.case.mjs
+├── fixtures/                # input briefs for live evals
+├── scripts/                 # run-tests.ps1, run-evals.ps1
+├── run-evals.mjs            # live eval runner
+├── package.json
+└── README.md
+```
+
+## Adding a new eval case
+
+Create `cases/<name>.case.mjs` with a default export:
+
+```js
+export default {
+  name: "my-skill",
+  skill: "my-skill",            // skills/<slug>
+  threshold: 0.7,
+  async buildPrompt(skillText) { /* return the prompt string */ },
+  rubric: [ /* graders.check(...) entries */ ],
+  judgeCriteria: [ "…qualitative criterion…" ],
+};
+```
+
+The runner discovers it automatically.

--- a/evals/cases/_shared.mjs
+++ b/evals/cases/_shared.mjs
@@ -1,0 +1,49 @@
+// Shared helpers for live eval cases.
+//
+// Each case injects a skill's full SKILL.md into the prompt as the operating
+// instructions, then applies it to a fixture. This tests the skill *content*
+// directly and hermetically — independent of how/whether the skill is installed
+// in the local Copilot CLI.
+
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const HERE = path.dirname(fileURLToPath(import.meta.url));
+
+export function fixturePath(name) {
+  return path.resolve(HERE, "..", "fixtures", name);
+}
+
+export async function readFixture(name) {
+  return readFile(fixturePath(name), "utf8");
+}
+
+/**
+ * Build a hermetic execution prompt: run the given skill against the input and
+ * emit ONLY the resulting artifact markdown (no file writes, no preamble).
+ * @param {object} args
+ * @param {string} args.skillText  full SKILL.md content
+ * @param {string} args.input      the fixture / upstream artifact
+ * @param {string} args.task       one-line instruction of what to produce
+ * @returns {string}
+ */
+export function buildExecutionPrompt({ skillText, input, task }) {
+  return [
+    "You are executing a single step of the Problem-Based SRS methodology.",
+    "Follow the SKILL instructions below EXACTLY, including its notation and ID formats.",
+    "",
+    "IMPORTANT output rules:",
+    "- Do NOT create, edit, or write any files. Do NOT run tools.",
+    "- Reply with ONLY the resulting artifact as markdown, nothing else.",
+    `- Task: ${task}`,
+    "",
+    "===== SKILL START =====",
+    skillText,
+    "===== SKILL END =====",
+    "",
+    "===== INPUT START =====",
+    input,
+    "===== INPUT END =====",
+  ].join("\n");
+}

--- a/evals/cases/customer-needs.case.mjs
+++ b/evals/cases/customer-needs.case.mjs
@@ -1,0 +1,53 @@
+// Eval case: the customer-needs skill (Step 3, WHAT).
+// Given Customer Problems, the skill must produce Customer Needs in CN notation,
+// each tracing back to a CP, expressed as outcomes (not implementations).
+
+import { patternCheck, check } from "../lib/graders.mjs";
+import { buildExecutionPrompt } from "./_shared.mjs";
+
+// A compact, well-formed CP artifact used as upstream input so this case does
+// not depend on the output of the customer-problems case.
+const UPSTREAM_CPS = `# Customer Problems — RelayDesk
+
+- **CP-1 (Obligation):** High-priority tickets breach the contractual 4-hour
+  first-response SLA ~15% of the time, causing service-credit payouts (~$180k last
+  quarter). There is no early warning before a breach.
+- **CP-2 (Expectation):** The same customer questions are answered repeatedly from
+  scratch; there is no shared trustworthy answer, so new hires take 6 weeks to ramp.
+- **CP-3 (Obligation):** Ticket edits overwrite each other; the company cannot
+  reconstruct who changed what, violating a 7-year auditable-history requirement.
+`;
+
+export default {
+  name: "customer-needs",
+  skill: "customer-needs",
+  threshold: 0.75,
+
+  async buildPrompt(skillText) {
+    return buildExecutionPrompt({
+      skillText,
+      input: UPSTREAM_CPS,
+      task: "Produce the Customer Needs (CN) artifact, tracing each CN to a CP.",
+    });
+  },
+
+  rubric: [
+    patternCheck("cn-ids", "uses CN notation (CN-1 / CN.1.1)", /\bCN[-.]\s?\d/i, { min: 3, required: true }),
+    patternCheck("cp-traceability", "each need references a CP", /\bCP[-.]\s?\d/i, { min: 3, required: true }),
+    patternCheck("sla-need", "need addressing early SLA warning", /warn|alert|before.*breach|at[- ]risk/i, { min: 1 }),
+    patternCheck("knowledge-need", "need addressing shared knowledge", /knowledge|reuse|shared answer|canonical/i, { min: 1 }),
+    patternCheck("audit-need", "need addressing auditable history", /audit|history|immutable|trail/i, { min: 1 }),
+    check("outcome-not-implementation", "needs are outcomes, not tech choices", (t) => {
+      // Penalize obvious implementation nouns appearing as the need itself.
+      const techLeak = /\b(React|Postgres|Kafka|microservice|REST API|Redis)\b/i.test(t);
+      return { pass: !techLeak, detail: techLeak ? "contains implementation tech" : "outcome-focused" };
+    }),
+  ],
+
+  judgeCriteria: [
+    "Each Customer Need describes WHAT outcome is required, not HOW to build it.",
+    "Every CN explicitly traces to at least one CP (e.g. CN-1 -> CP-1).",
+    "The needs cover SLA early-warning, knowledge reuse, and auditable history.",
+    "No CN is actually a solution/technology choice in disguise.",
+  ],
+};

--- a/evals/cases/customer-problems.case.mjs
+++ b/evals/cases/customer-problems.case.mjs
@@ -1,0 +1,46 @@
+// Eval case: the customer-problems skill (Step 1, WHY).
+// Given a messy business brief, the skill must extract classified Customer
+// Problems in CP notation — and must NOT smuggle in solutions.
+
+import { patternCheck, absenceCheck, check } from "../lib/graders.mjs";
+import { buildExecutionPrompt, readFixture } from "./_shared.mjs";
+
+export default {
+  name: "customer-problems",
+  skill: "customer-problems",
+  fixture: "relaydesk-brief.md",
+  threshold: 0.75,
+
+  async buildPrompt(skillText) {
+    const input = await readFixture(this.fixture);
+    return buildExecutionPrompt({
+      skillText,
+      input,
+      task: "Produce the Customer Problems (CP) artifact for this business brief.",
+    });
+  },
+
+  // Deterministic structural rubric applied to the model output.
+  rubric: [
+    patternCheck("cp-ids", "uses CP notation (CP-1 / CP.01)", /\bCP[-.]\s?\d+/i, { min: 3, required: true }),
+    patternCheck("classification", "classifies as Obligation/Expectation/Hope", /Obligation|Expectation|Hope/, { min: 2, required: true }),
+    patternCheck("sla-problem", "captures the SLA-breach problem", /SLA|first[- ]response|breach/i, { min: 1 }),
+    patternCheck("knowledge-problem", "captures the tribal-knowledge problem", /knowledge|onboard|ramp|new[- ]hire/i, { min: 1 }),
+    patternCheck("audit-problem", "captures the audit/history problem", /audit|history|7[- ]year|reconstruct/i, { min: 1 }),
+    absenceCheck("no-chatbot-solution", "does not adopt the 'AI chatbot' solution as a problem", /\b(build|add|implement)\s+(an?\s+)?(AI\s+)?chatbot\b/i),
+    absenceCheck("no-mobile-solution", "does not adopt the 'mobile app' solution as a problem", /\b(build|add|implement)\s+(a\s+)?mobile app\b/i),
+    check("dashboard-deprioritized", "treats the live dashboard as low priority / nice-to-have", (t) => {
+      // Either it is absent, or explicitly marked as a Hope / low priority.
+      const mentions = /dashboard/i.test(t);
+      if (!mentions) return { pass: true, detail: "not elevated to a problem" };
+      return { pass: /Hope|nice[- ]to[- ]have|low priority/i.test(t), detail: "mentioned; check it's a Hope/low-pri" };
+    }),
+  ],
+
+  judgeCriteria: [
+    "Every listed item is a genuine PROBLEM (a negative outcome), not a solution or feature.",
+    "Problems are classified by severity (Obligation vs Expectation vs Hope) sensibly.",
+    "The SLA-breach, tribal-knowledge, and audit-trail problems are all present.",
+    "Solution ideas from the brief (AI chatbot, mobile app) are not restated as problems.",
+  ],
+};

--- a/evals/cases/functional-requirements.case.mjs
+++ b/evals/cases/functional-requirements.case.mjs
@@ -1,0 +1,51 @@
+// Eval case: the functional-requirements skill (Step 5, HOW).
+// Given Customer Needs, the skill must produce Functional Requirements in FR
+// notation with a full traceability chain FR -> CN -> CP.
+
+import { patternCheck, check } from "../lib/graders.mjs";
+import { buildExecutionPrompt } from "./_shared.mjs";
+
+const UPSTREAM_CNS = `# Customer Needs — RelayDesk
+
+- **CN-1** (traces to CP-1): Support leadership needs to be warned before a
+  high-priority ticket is at risk of breaching the 4-hour first-response SLA.
+- **CN-2** (traces to CP-2): Agents need a single trustworthy, reusable answer
+  for recurring questions so knowledge is not re-derived per ticket.
+- **CN-3** (traces to CP-3): The organization needs a complete, tamper-evident
+  history of every change to a ticket, retained for 7 years.
+`;
+
+export default {
+  name: "functional-requirements",
+  skill: "functional-requirements",
+  threshold: 0.75,
+
+  async buildPrompt(skillText) {
+    return buildExecutionPrompt({
+      skillText,
+      input: UPSTREAM_CNS,
+      task: "Produce Functional Requirements (FR) with a traceability chain FR -> CN -> CP.",
+    });
+  },
+
+  rubric: [
+    patternCheck("fr-ids", "uses FR notation (FR-1 / FR.1.1.1)", /\bFR[-.]\s?\d/i, { min: 3, required: true }),
+    patternCheck("cn-traceability", "each FR references a CN", /\bCN[-.]\s?\d/i, { min: 3, required: true }),
+    patternCheck("cp-traceability", "traceability reaches back to a CP", /\bCP[-.]\s?\d/i, { min: 1, required: true }),
+    patternCheck("shall-language", "uses testable 'shall/must' requirement language", /\b(shall|must)\b/i, { min: 3 }),
+    check("addresses-all-needs", "at least one FR per upstream CN", (t) => {
+      const c1 = /CN[-.]\s?1\b/i.test(t);
+      const c2 = /CN[-.]\s?2\b/i.test(t);
+      const c3 = /CN[-.]\s?3\b/i.test(t);
+      const n = [c1, c2, c3].filter(Boolean).length;
+      return { pass: n === 3, detail: `${n}/3 CNs referenced` };
+    }),
+  ],
+
+  judgeCriteria: [
+    "Each Functional Requirement is specific and testable (uses shall/must).",
+    "Every FR traces to a CN, and the chain reaches a CP (FR -> CN -> CP).",
+    "All three upstream Customer Needs are covered by at least one FR.",
+    "Requirements describe system behavior, not vague aspirations.",
+  ],
+};

--- a/evals/fixtures/relaydesk-brief.md
+++ b/evals/fixtures/relaydesk-brief.md
@@ -1,0 +1,41 @@
+# Business Brief — "RelayDesk" Customer Support Platform
+
+RelayDesk is a mid-sized B2B SaaS company selling a customer-support ticketing
+product to other businesses. This brief is deliberately written the way a
+stakeholder would speak — a mix of problems, complaints, and half-formed
+solution ideas — so the methodology can separate problems from solutions.
+
+## Context
+
+- Support agents handle tickets from email, chat, and a web form.
+- The company has grown from 20 to 120 agents in 18 months.
+- Leadership wants to "add an AI chatbot and a mobile app" to fix things.
+
+## What stakeholders are saying
+
+- **Head of Support:** "Agents miss our contractual 4-hour first-response SLA on
+  about 15% of high-priority tickets. When we breach, we owe service credits, and
+  last quarter that cost us $180k in credits. I have no early warning before a
+  breach happens."
+- **Senior Agent:** "The same customer question arrives five times and each agent
+  answers from scratch. There's no shared, trustworthy answer. New hires take
+  6 weeks to get productive because knowledge lives in people's heads."
+- **Compliance Officer:** "We are contractually and legally required to keep an
+  auditable record of every change to a ticket for 7 years. Today edits overwrite
+  each other and we cannot reconstruct who changed what."
+- **CFO:** "Whatever we build must not increase per-agent licensing cost; margins
+  are already thin."
+- **VP Product:** "It would be nice if managers could see a live dashboard of team
+  workload, but that's not why customers churn."
+
+## Constraints
+
+- Must integrate with the existing email and chat providers.
+- Data residency: EU customer data must stay in the EU.
+- Rollout target: usable by all 120 agents within two quarters.
+
+## Success signals leadership named
+
+- Cut SLA breaches on high-priority tickets by at least half.
+- New-hire ramp time down from 6 weeks to 3.
+- Zero audit findings on ticket history in the annual review.

--- a/evals/lib/copilot-sdk.mjs
+++ b/evals/lib/copilot-sdk.mjs
@@ -1,0 +1,201 @@
+// Thin wrapper around the GitHub Copilot CLI (`@github/copilot`) used as a
+// programmatic SDK for skill evaluations. The CLI runs headlessly via
+//   copilot -p "<prompt>" --allow-all-tools --output-format json
+// and streams newline-delimited JSON (JSONL) events on stdout. This module
+// turns that stream into structured results.
+//
+// Every function that touches the process boundary accepts an injectable
+// implementation (spawnImpl / execFileImpl) so the harness is unit-testable
+// without invoking the real CLI.
+
+import { spawn, execFileSync } from "node:child_process";
+
+/**
+ * Parse a JSONL stream (one JSON object per line) into an array of events.
+ * Non-JSON lines (banners, blank lines, partial writes) are ignored.
+ * @param {string} text
+ * @returns {object[]}
+ */
+export function parseJsonl(text) {
+  const events = [];
+  for (const rawLine of String(text ?? "").split(/\r?\n/)) {
+    const line = rawLine.trim();
+    if (!line || line[0] !== "{") continue;
+    try {
+      events.push(JSON.parse(line));
+    } catch {
+      // Ignore non-JSON / partially-flushed lines.
+    }
+  }
+  return events;
+}
+
+/**
+ * Extract the assistant's final answer text from parsed events. Prefers the
+ * non-ephemeral `assistant.message` events (which carry the complete content)
+ * and falls back to concatenating streamed `assistant.message_delta` chunks.
+ * @param {object[]} events
+ * @returns {string}
+ */
+export function extractAssistantText(events) {
+  const finals = (events ?? [])
+    .filter((e) => e && e.type === "assistant.message" && e.data && typeof e.data.content === "string")
+    .map((e) => e.data.content);
+  if (finals.length) return finals.join("\n").trim();
+
+  const deltas = (events ?? [])
+    .filter((e) => e && e.type === "assistant.message_delta" && e.data && typeof e.data.deltaContent === "string")
+    .map((e) => e.data.deltaContent);
+  return deltas.join("").trim();
+}
+
+/**
+ * Return the skills the CLI loaded for the session. The CLI may emit
+ * `session.skills_loaded` multiple times as sources resolve; the last one wins.
+ * @param {object[]} events
+ * @returns {Array<{name:string, description?:string, source?:string, enabled?:boolean, path?:string}>}
+ */
+export function extractLoadedSkills(events) {
+  let skills = [];
+  for (const e of events ?? []) {
+    if (e && e.type === "session.skills_loaded" && e.data && Array.isArray(e.data.skills)) {
+      skills = e.data.skills;
+    }
+  }
+  return skills;
+}
+
+/**
+ * Collect every tool request the assistant issued during the run.
+ * @param {object[]} events
+ * @returns {object[]}
+ */
+export function extractToolCalls(events) {
+  const calls = [];
+  for (const e of events ?? []) {
+    if (e && e.type === "assistant.message" && e.data && Array.isArray(e.data.toolRequests)) {
+      for (const req of e.data.toolRequests) calls.push(req);
+    }
+  }
+  return calls;
+}
+
+/**
+ * Return the terminal `result` event (usage, exitCode, sessionId), if present.
+ * @param {object[]} events
+ * @returns {object|null}
+ */
+export function extractResult(events) {
+  const list = events ?? [];
+  for (let i = list.length - 1; i >= 0; i--) {
+    if (list[i] && list[i].type === "result") return list[i];
+  }
+  return null;
+}
+
+/**
+ * Build the argv for a headless copilot invocation.
+ * @param {string} prompt
+ * @param {{model?:string, outputFormat?:"json"|"text", extraArgs?:string[]}} [opts]
+ * @returns {string[]}
+ */
+export function buildCopilotArgs(prompt, opts = {}) {
+  const { model, outputFormat = "json", extraArgs = [] } = opts;
+  const args = ["-p", String(prompt ?? ""), "--allow-all-tools", "--no-color", "--output-format", outputFormat];
+  if (model) args.push("--model", model);
+  return args.concat(extraArgs);
+}
+
+/**
+ * Detect whether the copilot CLI is on PATH and runnable.
+ * @param {{execFileImpl?:Function, command?:string}} [opts]
+ * @returns {boolean}
+ */
+export function isCopilotAvailable(opts = {}) {
+  const { execFileImpl = execFileSync, command = "copilot" } = opts;
+  try {
+    execFileImpl(command, ["--version"], { stdio: "ignore" });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Run a headless copilot prompt and return a structured result.
+ *
+ * @param {string} prompt
+ * @param {object} [opts]
+ * @param {string} [opts.cwd]
+ * @param {string} [opts.model]
+ * @param {number} [opts.timeoutMs]
+ * @param {"json"|"text"} [opts.outputFormat]
+ * @param {string[]} [opts.extraArgs]
+ * @param {Function} [opts.spawnImpl]   injectable child_process.spawn
+ * @param {string} [opts.command]
+ * @param {NodeJS.ProcessEnv} [opts.env]
+ * @returns {Promise<{code:number|null, stdout:string, stderr:string, events:object[], text:string, result:object|null, skills:object[], toolCalls:object[], durationMs:number}>}
+ */
+export function runCopilot(prompt, opts = {}) {
+  const {
+    cwd = process.cwd(),
+    model,
+    timeoutMs = 180000,
+    outputFormat = "json",
+    extraArgs = [],
+    spawnImpl = spawn,
+    command = "copilot",
+    env = process.env,
+  } = opts;
+
+  const args = buildCopilotArgs(prompt, { model, outputFormat, extraArgs });
+
+  return new Promise((resolve, reject) => {
+    const started = Date.now();
+    let settled = false;
+    const settle = (fn) => (arg) => { if (!settled) { settled = true; fn(arg); } };
+    const done = settle(resolve);
+    const fail = settle(reject);
+
+    let child;
+    try {
+      child = spawnImpl(command, args, { cwd, env, shell: false });
+    } catch (err) {
+      fail(err);
+      return;
+    }
+
+    let stdout = "";
+    let stderr = "";
+
+    const timer = setTimeout(() => {
+      try { child.kill("SIGTERM"); } catch { /* already gone */ }
+      fail(new Error(`copilot timed out after ${timeoutMs}ms`));
+    }, timeoutMs);
+
+    child.stdout?.on("data", (d) => { stdout += d.toString(); });
+    child.stderr?.on("data", (d) => { stderr += d.toString(); });
+
+    child.on("error", (err) => {
+      clearTimeout(timer);
+      fail(err);
+    });
+
+    child.on("close", (code) => {
+      clearTimeout(timer);
+      const events = outputFormat === "json" ? parseJsonl(stdout) : [];
+      const text = outputFormat === "json" ? extractAssistantText(events) : stdout.trim();
+      done({
+        code,
+        stdout,
+        stderr,
+        events,
+        text,
+        result: extractResult(events),
+        skills: extractLoadedSkills(events),
+        toolCalls: extractToolCalls(events),
+        durationMs: Date.now() - started,
+      });
+    });
+  });
+}

--- a/evals/lib/graders.mjs
+++ b/evals/lib/graders.mjs
@@ -1,0 +1,193 @@
+// Grading utilities for skill evaluations.
+//
+// A "rubric" is an array of checks. Each check produces a pass/fail with a
+// weight, and gradeRubric() aggregates them into a normalized score. Checks are
+// plain functions of the artifact text, so both the deterministic static evals
+// and the live LLM evals share the same grading core.
+//
+// An optional LLM judge (llmJudge) grades qualitative criteria by delegating to
+// an injected `invoke` function (normally runCopilot) — injectable so it can be
+// unit-tested with a stub.
+
+function escapeRegExp(str) {
+  return String(str).replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+function clamp01(n) {
+  const x = Number(n);
+  if (!Number.isFinite(x)) return 0;
+  return Math.max(0, Math.min(1, x));
+}
+
+/**
+ * Count non-overlapping matches of a pattern in text.
+ * @param {string} text
+ * @param {string|RegExp} pattern
+ * @returns {number}
+ */
+export function countMatches(text, pattern) {
+  const src = pattern instanceof RegExp ? pattern.source : escapeRegExp(pattern);
+  const flags = pattern instanceof RegExp && pattern.flags.includes("g")
+    ? pattern.flags
+    : ((pattern instanceof RegExp ? pattern.flags : "") + "g");
+  const re = new RegExp(src, flags);
+  const matches = String(text ?? "").match(re);
+  return matches ? matches.length : 0;
+}
+
+/**
+ * True when text contains the pattern (substring case-insensitive, or RegExp).
+ * @param {string} text
+ * @param {string|RegExp} pattern
+ * @returns {boolean}
+ */
+export function includesPattern(text, pattern) {
+  if (pattern instanceof RegExp) return pattern.test(String(text ?? ""));
+  return String(text ?? "").toLowerCase().includes(String(pattern).toLowerCase());
+}
+
+/**
+ * Build a check from an arbitrary predicate.
+ * @param {string} id
+ * @param {string} description
+ * @param {(text:string)=>(boolean|{pass:boolean, detail?:string})} run
+ * @param {{weight?:number, required?:boolean}} [opts]
+ */
+export function check(id, description, run, opts = {}) {
+  return { id, description, run, weight: opts.weight ?? 1, required: !!opts.required };
+}
+
+/**
+ * A check that passes when the pattern appears at least `min` times.
+ * @param {string} id
+ * @param {string} description
+ * @param {string|RegExp} pattern
+ * @param {{min?:number, weight?:number, required?:boolean}} [opts]
+ */
+export function patternCheck(id, description, pattern, opts = {}) {
+  const min = opts.min ?? 1;
+  return check(id, description, (text) => {
+    const n = countMatches(text, pattern);
+    return { pass: n >= min, detail: `found ${n} (need >= ${min})` };
+  }, opts);
+}
+
+/**
+ * A check that passes when the (anti-)pattern is ABSENT — for catching
+ * forbidden content such as solution language or legacy commands.
+ * @param {string} id
+ * @param {string} description
+ * @param {string|RegExp} pattern
+ * @param {{weight?:number, required?:boolean}} [opts]
+ */
+export function absenceCheck(id, description, pattern, opts = {}) {
+  return check(id, description, (text) => {
+    const n = countMatches(text, pattern);
+    return { pass: n === 0, detail: n === 0 ? "absent" : `found ${n} forbidden` };
+  }, opts);
+}
+
+/**
+ * Grade text against a rubric (array of checks).
+ * @param {string} text
+ * @param {Array} rubric
+ * @param {{threshold?:number}} [opts]
+ * @returns {{score:number, maxScore:number, ratio:number, passed:boolean, results:Array, requiredFailures:Array}}
+ */
+export function gradeRubric(text, rubric, opts = {}) {
+  const threshold = opts.threshold ?? 0.7;
+  const results = (rubric ?? []).map((c) => {
+    let raw;
+    try {
+      raw = c.run(text);
+    } catch (e) {
+      raw = { pass: false, detail: `error: ${e.message}` };
+    }
+    const norm = typeof raw === "boolean" ? { pass: raw } : (raw || { pass: false });
+    return {
+      id: c.id,
+      description: c.description,
+      weight: c.weight ?? 1,
+      required: !!c.required,
+      pass: !!norm.pass,
+      detail: norm.detail ?? "",
+    };
+  });
+
+  const maxScore = results.reduce((a, r) => a + r.weight, 0);
+  const score = results.reduce((a, r) => a + (r.pass ? r.weight : 0), 0);
+  const ratio = maxScore === 0 ? 0 : score / maxScore;
+  const requiredFailures = results.filter((r) => r.required && !r.pass);
+  const passed = requiredFailures.length === 0 && ratio >= threshold;
+  return { score, maxScore, ratio, passed, results, requiredFailures };
+}
+
+/**
+ * Build the prompt that asks a model to grade an artifact against qualitative
+ * criteria and reply with a JSON verdict.
+ * @param {string} artifact
+ * @param {string[]} criteria
+ * @returns {string}
+ */
+export function buildJudgePrompt(artifact, criteria) {
+  const list = (criteria ?? []).map((c, i) => `${i + 1}. ${c}`).join("\n");
+  return [
+    "You are a strict evaluator for a requirements-engineering methodology.",
+    "Grade the ARTIFACT below against these CRITERIA:",
+    list,
+    "",
+    "Respond with ONLY a single JSON object on one line, no prose, of the form:",
+    '{"score": <number 0..1>, "reasoning": "<one sentence>"}',
+    "score is the fraction of criteria the artifact satisfies.",
+    "",
+    "=== ARTIFACT START ===",
+    String(artifact ?? ""),
+    "=== ARTIFACT END ===",
+  ].join("\n");
+}
+
+/**
+ * Parse a judge verdict from model text. Accepts a JSON object with a `score`
+ * field, or falls back to an `N/M` fraction or a bare 0..1 number.
+ * @param {string} text
+ * @returns {{score:number, reasoning:string}}
+ */
+export function parseJudgeVerdict(text) {
+  const s = String(text ?? "");
+  const obj = s.match(/\{[^{}]*"score"[^{}]*\}/);
+  if (obj) {
+    try {
+      const parsed = JSON.parse(obj[0]);
+      return { score: clamp01(parsed.score), reasoning: String(parsed.reasoning ?? "") };
+    } catch {
+      // fall through
+    }
+  }
+  const frac = s.match(/(\d+(?:\.\d+)?)\s*\/\s*(\d+(?:\.\d+)?)/);
+  if (frac) {
+    const denom = Number(frac[2]);
+    return { score: denom ? clamp01(Number(frac[1]) / denom) : 0, reasoning: "parsed fraction" };
+  }
+  const num = s.match(/\b(0(?:\.\d+)?|1(?:\.0+)?)\b/);
+  if (num) return { score: clamp01(num[1]), reasoning: "parsed number" };
+  return { score: 0, reasoning: "unparseable verdict" };
+}
+
+/**
+ * Grade an artifact with an LLM judge.
+ * @param {string} artifact
+ * @param {object} opts
+ * @param {string[]} opts.criteria
+ * @param {(prompt:string, o?:object)=>Promise<{text:string}|string>} opts.invoke
+ * @param {string} [opts.model]
+ * @param {number} [opts.threshold]
+ * @returns {Promise<{score:number, reasoning:string, passed:boolean}>}
+ */
+export async function llmJudge(artifact, opts) {
+  const { criteria, invoke, model, threshold = 0.7 } = opts;
+  const prompt = buildJudgePrompt(artifact, criteria);
+  const res = await invoke(prompt, { model });
+  const text = typeof res === "string" ? res : (res && res.text) || "";
+  const verdict = parseJudgeVerdict(text);
+  return { ...verdict, passed: verdict.score >= threshold };
+}

--- a/evals/lib/skills.mjs
+++ b/evals/lib/skills.mjs
@@ -1,0 +1,145 @@
+// Loading and structural parsing of the canonical methodology skills at
+// skills/<slug>/SKILL.md. Pure/functional helpers so they can be unit-tested
+// with in-memory strings, plus filesystem loaders that accept injectable impls.
+
+import { readFile, readdir } from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+/**
+ * Parse YAML-ish front matter delimited by `---` fences, tolerating a leading
+ * HTML comment (the sync banner) and a BOM. Only top-level `key: value` pairs
+ * are captured; nested/indented lines are ignored.
+ * @param {string} text
+ * @returns {{frontmatter: Record<string,string>, body: string}}
+ */
+export function parseFrontmatter(text) {
+  const s = String(text ?? "").replace(/^\uFEFF/, "");
+  const m = s.match(/^(?:<!--[\s\S]*?-->\s*)?---\r?\n([\s\S]*?)\r?\n---[ \t]*\r?\n?/);
+  if (!m) return { frontmatter: {}, body: s };
+
+  const frontmatter = {};
+  for (const line of m[1].split(/\r?\n/)) {
+    const kv = line.match(/^([A-Za-z0-9_-]+):[ \t]*(.*)$/);
+    if (kv) frontmatter[kv[1]] = kv[2].trim();
+  }
+  const body = s.slice(m[0].length).replace(/^(?:[ \t]*\r?\n)+/, "");
+  return { frontmatter, body };
+}
+
+/**
+ * Split a markdown body into flat heading sections.
+ * @param {string} body
+ * @returns {Array<{level:number, title:string, body:string}>}
+ */
+export function extractSections(body) {
+  const sections = [];
+  let current = null;
+  for (const line of String(body ?? "").split(/\r?\n/)) {
+    const h = line.match(/^(#{1,6})[ \t]+(.*)$/);
+    if (h) {
+      if (current) sections.push(current);
+      current = { level: h[1].length, title: h[2].trim(), body: "" };
+    } else if (current) {
+      current.body += line + "\n";
+    }
+  }
+  if (current) sections.push(current);
+  return sections;
+}
+
+function titleMatches(title, pattern) {
+  if (pattern instanceof RegExp) return pattern.test(title);
+  return String(title).toLowerCase().includes(String(pattern).toLowerCase());
+}
+
+/**
+ * True when the body contains a heading whose title matches `pattern`
+ * (substring, case-insensitive) or a RegExp.
+ * @param {string} body
+ * @param {string|RegExp} pattern
+ * @returns {boolean}
+ */
+export function hasSection(body, pattern) {
+  return extractSections(body).some((s) => titleMatches(s.title, pattern));
+}
+
+/**
+ * Count the non-empty lines of markdown body (front matter excluded by the
+ * caller). Used to enforce the AgentSkills "< 500 lines" guidance.
+ * @param {string} text
+ * @returns {number}
+ */
+export function countLines(text) {
+  const s = String(text ?? "");
+  if (s === "") return 0;
+  return s.split(/\r?\n/).length;
+}
+
+/**
+ * Parse SKILL.md text into a structured object.
+ * @param {string} text
+ */
+export function parseSkill(text) {
+  const { frontmatter, body } = parseFrontmatter(text);
+  return { frontmatter, body, sections: extractSections(body) };
+}
+
+/**
+ * Extract relative markdown link targets: `[label](path)` where path is not an
+ * absolute URL or anchor. Returns { target, line } records.
+ * @param {string} text
+ * @returns {Array<{target:string}>}
+ */
+export function extractRelativeLinks(text) {
+  const links = [];
+  const re = /\[[^\]]*\]\(([^)]+)\)/g;
+  let m;
+  while ((m = re.exec(String(text ?? ""))) !== null) {
+    const target = m[1].trim();
+    if (/^[a-z]+:\/\//i.test(target)) continue; // http(s):// mailto: etc.
+    if (target.startsWith("#")) continue; // in-page anchor
+    links.push({ target: target.split("#")[0] });
+  }
+  return links;
+}
+
+/** Absolute path to the repo's canonical skills/ directory. */
+export function defaultSkillsRoot(metaUrl = import.meta.url) {
+  const here = path.dirname(fileURLToPath(metaUrl));
+  return path.resolve(here, "..", "..", "skills");
+}
+
+/**
+ * List skill slugs (subdirectory names) under a skills root.
+ * @param {string} skillsRoot
+ * @param {{readdirImpl?:Function}} [opts]
+ * @returns {Promise<string[]>}
+ */
+export async function listSkillSlugs(skillsRoot, opts = {}) {
+  const { readdirImpl = readdir } = opts;
+  const entries = await readdirImpl(skillsRoot, { withFileTypes: true });
+  return entries.filter((e) => e.isDirectory()).map((e) => e.name).sort();
+}
+
+/**
+ * Load and parse a single skill.
+ * @param {string} slug
+ * @param {{skillsRoot?:string, readFileImpl?:Function}} [opts]
+ */
+export async function loadSkill(slug, opts = {}) {
+  const { skillsRoot = defaultSkillsRoot(), readFileImpl = readFile } = opts;
+  const file = path.join(skillsRoot, slug, "SKILL.md");
+  const text = await readFileImpl(file, "utf8");
+  return { slug, file, text, ...parseSkill(text) };
+}
+
+/**
+ * Load and parse every skill under the skills root.
+ * @param {{skillsRoot?:string, readFileImpl?:Function, readdirImpl?:Function}} [opts]
+ */
+export async function loadAllSkills(opts = {}) {
+  const { skillsRoot = defaultSkillsRoot() } = opts;
+  const slugs = await listSkillSlugs(skillsRoot, opts);
+  return Promise.all(slugs.map((slug) => loadSkill(slug, { skillsRoot, ...opts })));
+}

--- a/evals/run-evals.mjs
+++ b/evals/run-evals.mjs
@@ -1,0 +1,203 @@
+#!/usr/bin/env node
+// Live skill-eval runner.
+//
+// For each case in cases/*.case.mjs it:
+//   1. loads the canonical skill markdown (skills/<slug>/SKILL.md),
+//   2. builds a hermetic prompt and runs it through the Copilot CLI (headless),
+//   3. grades the output with a deterministic rubric, and
+//   4. optionally asks an LLM judge to score qualitative criteria.
+//
+// These evals call the real model, so they are OPT-IN. They run only when the
+// copilot CLI is available AND either RUN_SKILL_EVALS=1 is set or --force is passed.
+//
+// Usage:
+//   node run-evals.mjs                 # run all cases (needs RUN_SKILL_EVALS=1)
+//   node run-evals.mjs --force         # run even without the env flag
+//   node run-evals.mjs customer-needs  # run one case by name
+//   node run-evals.mjs --no-judge      # skip the LLM judge, rubric only
+//   node run-evals.mjs --model gpt-5.4 # choose the model
+
+import { readdir } from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+import { runCopilot, isCopilotAvailable } from "./lib/copilot-sdk.mjs";
+import { loadSkill, defaultSkillsRoot } from "./lib/skills.mjs";
+import { gradeRubric, llmJudge } from "./lib/graders.mjs";
+
+const HERE = path.dirname(fileURLToPath(import.meta.url));
+const CASES_DIR = path.join(HERE, "cases");
+
+function parseArgs(argv) {
+  const opts = { force: false, judge: true, model: undefined, timeoutMs: 240000, verbose: 0, filters: [] };
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i];
+    if (a === "--force") opts.force = true;
+    else if (a === "--no-judge") opts.judge = false;
+    else if (a === "--model") opts.model = argv[++i];
+    else if (a === "--timeout") opts.timeoutMs = Number(argv[++i]) * 1000;
+    else if (a === "--verbose" || a === "-v") opts.verbose += 1;
+    else if (a === "-vv") opts.verbose += 2;
+    else if (!a.startsWith("--")) opts.filters.push(a);
+  }
+  return opts;
+}
+
+async function loadCases(filters) {
+  const files = (await readdir(CASES_DIR)).filter((f) => f.endsWith(".case.mjs"));
+  const cases = [];
+  for (const f of files) {
+    const mod = await import(pathToFileURL(path.join(CASES_DIR, f)).href);
+    const c = mod.default;
+    if (!c || !c.name) continue;
+    if (filters.length && !filters.includes(c.name)) continue;
+    cases.push(c);
+  }
+  return cases.sort((a, b) => a.name.localeCompare(b.name));
+}
+
+function fmtPct(x) {
+  return `${(x * 100).toFixed(0)}%`;
+}
+
+function truncate(text, max) {
+  const s = String(text ?? "");
+  if (s.length <= max) return s;
+  return s.slice(0, max) + `\n… [truncated ${s.length - max} more chars]`;
+}
+
+function indent(text, pad = "      ") {
+  return String(text ?? "")
+    .split("\n")
+    .map((l) => pad + l)
+    .join("\n");
+}
+
+function logVerboseInputs(c, prompt, skill, opts) {
+  if (opts.verbose < 1) return;
+  console.log(`\n----- [${c.name}] inputs -----`);
+  console.log(`  skill:      ${c.skill} (${skill.text.length} chars)`);
+  console.log(`  fixture:    ${c.fixture ?? "(none)"}`);
+  console.log(`  threshold:  ${c.threshold ?? 0.7}`);
+  console.log(`  rubric:     ${c.rubric?.length ?? 0} checks` +
+    (c.judgeCriteria?.length ? `, judge: ${c.judgeCriteria.length} criteria` : ""));
+  const promptCap = opts.verbose >= 2 ? 1e9 : 1200;
+  console.log(`  prompt (${prompt.length} chars):`);
+  console.log(indent(truncate(prompt, promptCap)));
+}
+
+function logVerboseRun(c, run, opts) {
+  if (opts.verbose < 1) return;
+  console.log(`\n----- [${c.name}] run -----`);
+  console.log(`  exit code:  ${run.code}`);
+  console.log(`  duration:   ${(run.durationMs / 1000).toFixed(1)}s`);
+  console.log(`  model:      ${run.result?.model ?? "(unknown)"}`);
+  if (run.result?.usage) console.log(`  usage:      ${JSON.stringify(run.result.usage)}`);
+  if (run.skills?.length) console.log(`  skills:     ${run.skills.map((s) => s.name).join(", ")}`);
+  if (run.toolCalls?.length) {
+    console.log(`  tool calls: ${run.toolCalls.length}`);
+    for (const t of run.toolCalls) console.log(`      - ${t.name ?? t.tool ?? JSON.stringify(t)}`);
+  }
+  if (run.stderr && run.stderr.trim()) {
+    console.log(`  stderr:`);
+    console.log(indent(truncate(run.stderr, opts.verbose >= 2 ? 1e9 : 800)));
+  }
+  const artifactCap = opts.verbose >= 2 ? 1e9 : 2000;
+  console.log(`  artifact (${(run.text || "").length} chars):`);
+  console.log(indent(truncate(run.text || "(empty)", artifactCap)));
+}
+
+async function runCase(c, opts, skillsRoot) {
+  const skill = await loadSkill(c.skill, { skillsRoot });
+  const prompt = await c.buildPrompt(skill.text);
+  logVerboseInputs(c, prompt, skill, opts);
+
+  const run = await runCopilot(prompt, { model: opts.model, timeoutMs: opts.timeoutMs, cwd: HERE });
+  const artifact = run.text || "";
+  logVerboseRun(c, run, opts);
+
+  const rubric = gradeRubric(artifact, c.rubric, { threshold: c.threshold ?? 0.7 });
+
+  let judge = null;
+  if (opts.judge && Array.isArray(c.judgeCriteria) && c.judgeCriteria.length) {
+    try {
+      judge = await llmJudge(artifact, {
+        criteria: c.judgeCriteria,
+        threshold: c.threshold ?? 0.7,
+        model: opts.model,
+        invoke: (p, o) => runCopilot(p, { ...o, timeoutMs: opts.timeoutMs, cwd: HERE }),
+      });
+    } catch (err) {
+      judge = { score: 0, reasoning: `judge error: ${err.message}`, passed: false };
+    }
+  }
+
+  const passed = rubric.passed && (judge ? judge.passed : true);
+  return { name: c.name, artifact, rubric, judge, passed, durationMs: run.durationMs, usage: run.result?.usage };
+}
+
+function printReport(results, opts = { verbose: 0 }) {
+  console.log("\n================ Skill Eval Report ================\n");
+  for (const r of results) {
+    const status = r.passed ? "PASS" : "FAIL";
+    console.log(`[${status}] ${r.name}  rubric=${fmtPct(r.rubric.ratio)} (${r.rubric.score}/${r.rubric.maxScore})` +
+      (r.judge ? `  judge=${fmtPct(r.judge.score)}` : "") +
+      `  ${(r.durationMs / 1000).toFixed(1)}s`);
+    for (const item of r.rubric.results) {
+      // In verbose mode show every check; otherwise only failures.
+      if (!item.pass || opts.verbose >= 1) {
+        const mark = item.pass ? "ok " : (item.required ? "REQ" : "x  ");
+        const tag = item.required ? " (required)" : "";
+        console.log(`      [${mark}] ${item.id}${tag}: ${item.description} — ${item.detail}`);
+      }
+    }
+    if (r.judge && (opts.verbose >= 1 || !r.judge.passed)) {
+      console.log(`       judge (${fmtPct(r.judge.score)}): ${r.judge.reasoning}`);
+    }
+  }
+  const passCount = results.filter((r) => r.passed).length;
+  console.log(`\n${passCount}/${results.length} cases passed.\n`);
+}
+
+async function main() {
+  const opts = parseArgs(process.argv.slice(2));
+  const gate = opts.force || process.env.RUN_SKILL_EVALS === "1";
+
+  if (!isCopilotAvailable()) {
+    console.error("copilot CLI not found on PATH. Install @github/copilot to run live evals.");
+    process.exit(2);
+  }
+  if (!gate) {
+    console.log("Live skill evals are opt-in (they call the model).");
+    console.log("Run with RUN_SKILL_EVALS=1 or pass --force. Use scripts\\run-evals.ps1 for convenience.");
+    process.exit(0);
+  }
+
+  const skillsRoot = defaultSkillsRoot();
+  const cases = await loadCases(opts.filters);
+  if (!cases.length) {
+    console.error("No matching eval cases found.");
+    process.exit(2);
+  }
+
+  console.log(`Running ${cases.length} skill eval(s)${opts.model ? ` on ${opts.model}` : ""}...`);
+  const results = [];
+  for (const c of cases) {
+    process.stdout.write(`  • ${c.name} ... `);
+    try {
+      const r = await runCase(c, opts, skillsRoot);
+      console.log(r.passed ? "pass" : "fail");
+      results.push(r);
+    } catch (err) {
+      console.log(`error: ${err.message}`);
+      results.push({ name: c.name, passed: false, rubric: { ratio: 0, score: 0, maxScore: 0, results: [] }, judge: null, durationMs: 0 });
+    }
+  }
+
+  printReport(results, opts);
+  process.exit(results.every((r) => r.passed) ? 0 : 1);
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/evals/scripts/run-evals.ps1
+++ b/evals/scripts/run-evals.ps1
@@ -1,0 +1,73 @@
+# Run the live LLM skill evals through the GitHub Copilot CLI (opt-in).
+#
+#   pwsh evals/scripts/run-evals.ps1                    # all cases
+#   pwsh evals/scripts/run-evals.ps1 -Case customer-needs
+#   pwsh evals/scripts/run-evals.ps1 -NoJudge          # rubric only, skip LLM judge
+#   pwsh evals/scripts/run-evals.ps1 -Model gpt-5.4
+#   pwsh evals/scripts/run-evals.ps1 -Detailed      # verbose: show prompt, artifact, every check
+#   pwsh evals/scripts/run-evals.ps1 -Trace         # extra verbose: full prompt + full artifact
+#
+# WARNING: these call the real model and may consume premium requests.
+# They require the `copilot` CLI to be installed and authenticated.
+
+[CmdletBinding()]
+param(
+    # Run only the named case (e.g. customer-problems, customer-needs, functional-requirements).
+    [string]$Case,
+    # Skip the qualitative LLM judge; grade with the deterministic rubric only.
+    [switch]$NoJudge,
+    # Model override passed to the Copilot CLI.
+    [string]$Model,
+    # Per-call timeout in seconds.
+    [int]$TimeoutSec = 240,
+    # Verbose eval output: prompt, run metadata (usage/tools/stderr), artifact, and every rubric check.
+    [switch]$Detailed,
+    # Even more verbose: do not truncate the prompt or the artifact.
+    [switch]$Trace
+)
+
+$ErrorActionPreference = 'Stop'
+
+$EvalsDir = Split-Path -Parent $PSScriptRoot
+Push-Location $EvalsDir
+try {
+    $node = Get-Command node -ErrorAction SilentlyContinue
+    if (-not $node) {
+        Write-Error 'Node.js is required but was not found on PATH.'
+        exit 127
+    }
+
+    $copilot = Get-Command copilot -ErrorAction SilentlyContinue
+    if (-not $copilot) {
+        Write-Error 'The `copilot` CLI (@github/copilot) was not found on PATH. Install and authenticate it to run live evals.'
+        exit 127
+    }
+
+    Write-Host "==> Running LIVE skill evals via the Copilot CLI" -ForegroundColor Cyan
+    Write-Host "    These call the real model and may consume premium requests.`n" -ForegroundColor Yellow
+
+    # Opt-in gate consumed by run-evals.mjs.
+    $env:RUN_SKILL_EVALS = '1'
+
+    $argsList = @('run-evals.mjs', '--force')
+    if ($Case)    { $argsList += $Case }
+    if ($NoJudge) { $argsList += '--no-judge' }
+    if ($Model)   { $argsList += @('--model', $Model) }
+    if ($Trace)   { $argsList += '-vv' }
+    elseif ($Detailed) { $argsList += '--verbose' }
+    $argsList += @('--timeout', "$TimeoutSec")
+
+    node @argsList
+    $code = $LASTEXITCODE
+
+    Write-Host ''
+    if ($code -eq 0) {
+        Write-Host '==> All evals passed.' -ForegroundColor Green
+    } else {
+        Write-Host "==> Evals failed (exit $code)." -ForegroundColor Red
+    }
+    exit $code
+}
+finally {
+    Pop-Location
+}

--- a/evals/scripts/run-tests.ps1
+++ b/evals/scripts/run-tests.ps1
@@ -1,0 +1,50 @@
+# Run the deterministic skill tests (offline, no model calls).
+#
+#   pwsh evals/scripts/run-tests.ps1
+#   pwsh evals/scripts/run-tests.ps1 -File skills-static.test.mjs
+#
+# These cover the Copilot SDK wrapper, the SKILL.md loader/graders, and the
+# static skill evals over every skills/<slug>/SKILL.md. No Copilot login needed.
+
+[CmdletBinding()]
+param(
+    # Optional single test file (relative to evals/tests) to run.
+    [string]$File,
+    # Per-test timeout in milliseconds.
+    [int]$TimeoutMs = 20000
+)
+
+$ErrorActionPreference = 'Stop'
+
+# evals/ root (parent of this scripts/ folder).
+$EvalsDir = Split-Path -Parent $PSScriptRoot
+Push-Location $EvalsDir
+try {
+    $node = Get-Command node -ErrorAction SilentlyContinue
+    if (-not $node) {
+        Write-Error 'Node.js is required but was not found on PATH.'
+        exit 127
+    }
+
+    Write-Host "==> Running deterministic skill tests" -ForegroundColor Cyan
+    Write-Host "    dir: $EvalsDir`n" -ForegroundColor DarkGray
+
+    if ($File) {
+        $targets = @((Join-Path 'tests' $File))
+    } else {
+        $targets = Get-ChildItem -Path 'tests' -Filter '*.test.mjs' | ForEach-Object { Join-Path 'tests' $_.Name }
+    }
+    node --test "--test-timeout=$TimeoutMs" @targets
+    $code = $LASTEXITCODE
+
+    Write-Host ''
+    if ($code -eq 0) {
+        Write-Host '==> All tests passed.' -ForegroundColor Green
+    } else {
+        Write-Host "==> Tests failed (exit $code)." -ForegroundColor Red
+    }
+    exit $code
+}
+finally {
+    Pop-Location
+}

--- a/evals/tests/copilot-sdk.test.mjs
+++ b/evals/tests/copilot-sdk.test.mjs
@@ -1,0 +1,161 @@
+// Unit tests for the Copilot SDK wrapper. These are fully deterministic: they
+// feed captured/synthetic JSONL through the parsers and drive runCopilot with a
+// fake spawn implementation. No real `copilot` process is started.
+
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { EventEmitter } from "node:events";
+import {
+  parseJsonl,
+  extractAssistantText,
+  extractLoadedSkills,
+  extractToolCalls,
+  extractResult,
+  buildCopilotArgs,
+  isCopilotAvailable,
+  runCopilot,
+} from "../lib/copilot-sdk.mjs";
+
+// A representative slice of real `copilot --output-format json` output.
+const SAMPLE_JSONL = [
+  '{"type":"session.skills_loaded","data":{"skills":[{"name":"customer-problems","description":"Identify CP","enabled":true}]}}',
+  'not json — should be ignored',
+  '{"type":"user.message","data":{"content":"hello"}}',
+  '{"type":"assistant.message_delta","data":{"messageId":"m1","deltaContent":"PO"}}',
+  '{"type":"assistant.message_delta","data":{"messageId":"m1","deltaContent":"NG"}}',
+  '{"type":"assistant.message","data":{"messageId":"m1","content":"PONG","toolRequests":[{"name":"view"}]}}',
+  '{"type":"result","exitCode":0,"usage":{"premiumRequests":15}}',
+].join("\n");
+
+describe("parseJsonl", () => {
+  it("parses only valid JSON object lines and skips noise", () => {
+    const events = parseJsonl(SAMPLE_JSONL);
+    assert.equal(events.length, 6);
+    assert.equal(events[0].type, "session.skills_loaded");
+  });
+  it("handles empty / null input", () => {
+    assert.deepEqual(parseJsonl(""), []);
+    assert.deepEqual(parseJsonl(null), []);
+  });
+});
+
+describe("extractAssistantText", () => {
+  it("prefers the final assistant.message content", () => {
+    assert.equal(extractAssistantText(parseJsonl(SAMPLE_JSONL)), "PONG");
+  });
+  it("falls back to concatenated deltas when no final message", () => {
+    const events = parseJsonl([
+      '{"type":"assistant.message_delta","data":{"deltaContent":"Hel"}}',
+      '{"type":"assistant.message_delta","data":{"deltaContent":"lo"}}',
+    ].join("\n"));
+    assert.equal(extractAssistantText(events), "Hello");
+  });
+  it("returns empty string when there is nothing", () => {
+    assert.equal(extractAssistantText([]), "");
+  });
+});
+
+describe("extractLoadedSkills / toolCalls / result", () => {
+  const events = parseJsonl(SAMPLE_JSONL);
+  it("extracts loaded skills", () => {
+    const skills = extractLoadedSkills(events);
+    assert.equal(skills.length, 1);
+    assert.equal(skills[0].name, "customer-problems");
+  });
+  it("extracts tool calls from assistant messages", () => {
+    assert.deepEqual(extractToolCalls(events), [{ name: "view" }]);
+  });
+  it("extracts the terminal result event", () => {
+    assert.equal(extractResult(events).exitCode, 0);
+    assert.equal(extractResult(events).usage.premiumRequests, 15);
+  });
+  it("last session.skills_loaded wins", () => {
+    const staged = parseJsonl([
+      '{"type":"session.skills_loaded","data":{"skills":[]}}',
+      '{"type":"session.skills_loaded","data":{"skills":[{"name":"a"},{"name":"b"}]}}',
+    ].join("\n"));
+    assert.equal(extractLoadedSkills(staged).length, 2);
+  });
+});
+
+describe("buildCopilotArgs", () => {
+  it("builds headless json args with allow-all-tools", () => {
+    const args = buildCopilotArgs("do it");
+    assert.deepEqual(args, ["-p", "do it", "--allow-all-tools", "--no-color", "--output-format", "json"]);
+  });
+  it("adds model and extra args", () => {
+    const args = buildCopilotArgs("x", { model: "gpt-5.4", outputFormat: "text", extraArgs: ["--enable-memory"] });
+    assert.ok(args.includes("--model") && args.includes("gpt-5.4"));
+    assert.ok(args.includes("text"));
+    assert.ok(args.includes("--enable-memory"));
+  });
+});
+
+describe("isCopilotAvailable", () => {
+  it("true when exec succeeds", () => {
+    assert.equal(isCopilotAvailable({ execFileImpl: () => Buffer.from("1.0.0") }), true);
+  });
+  it("false when exec throws", () => {
+    assert.equal(isCopilotAvailable({ execFileImpl: () => { throw new Error("ENOENT"); } }), false);
+  });
+});
+
+// A fake child process that emits scripted stdout then closes.
+function makeFakeSpawn(stdoutChunks, { code = 0, emitError = null } = {}) {
+  return () => {
+    const child = new EventEmitter();
+    child.stdout = new EventEmitter();
+    child.stderr = new EventEmitter();
+    child.kill = () => {};
+    setImmediate(() => {
+      if (emitError) {
+        child.emit("error", emitError);
+        return;
+      }
+      for (const chunk of stdoutChunks) child.stdout.emit("data", Buffer.from(chunk));
+      child.emit("close", code);
+    });
+    return child;
+  };
+}
+
+describe("runCopilot (with fake spawn)", () => {
+  it("resolves structured result from JSONL stdout", async () => {
+    const res = await runCopilot("ping", { spawnImpl: makeFakeSpawn([SAMPLE_JSONL]) });
+    assert.equal(res.code, 0);
+    assert.equal(res.text, "PONG");
+    assert.equal(res.skills[0].name, "customer-problems");
+    assert.equal(res.result.exitCode, 0);
+    assert.ok(res.durationMs >= 0);
+  });
+
+  it("supports text output mode (stdout passthrough)", async () => {
+    const res = await runCopilot("ping", {
+      outputFormat: "text",
+      spawnImpl: makeFakeSpawn(["just some text\n"]),
+    });
+    assert.equal(res.text, "just some text");
+    assert.deepEqual(res.events, []);
+  });
+
+  it("rejects on spawn error", async () => {
+    await assert.rejects(
+      runCopilot("x", { spawnImpl: makeFakeSpawn([], { emitError: new Error("spawn failed") }) }),
+      /spawn failed/,
+    );
+  });
+
+  it("rejects on timeout", async () => {
+    const neverCloses = () => {
+      const child = new EventEmitter();
+      child.stdout = new EventEmitter();
+      child.stderr = new EventEmitter();
+      child.kill = () => {};
+      return child; // never emits close
+    };
+    await assert.rejects(
+      runCopilot("x", { spawnImpl: neverCloses, timeoutMs: 20 }),
+      /timed out/,
+    );
+  });
+});

--- a/evals/tests/lib.test.mjs
+++ b/evals/tests/lib.test.mjs
@@ -1,0 +1,203 @@
+// Unit tests for the skills loader/parser and the graders. Deterministic.
+
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import {
+  parseFrontmatter,
+  extractSections,
+  hasSection,
+  countLines,
+  parseSkill,
+  extractRelativeLinks,
+  listSkillSlugs,
+  loadSkill,
+} from "../lib/skills.mjs";
+import {
+  countMatches,
+  includesPattern,
+  patternCheck,
+  absenceCheck,
+  check,
+  gradeRubric,
+  buildJudgePrompt,
+  parseJudgeVerdict,
+  llmJudge,
+} from "../lib/graders.mjs";
+
+const SKILL = `<!-- Built from SKILL.src.md -->
+---
+name: customer-problems
+description: Identify and document Customer Problems (CP) from business context.
+license: MIT
+metadata:
+  version: "1.0"
+---
+
+# Customer Problems
+
+Intro paragraph.
+
+## Notation
+
+Use CP-1, CP-2 format.
+
+## Handoff to Next Step
+
+→ Action: /problem-based-srs software-glance
+See [Software Glance](../software-glance/SKILL.md) and [ext](https://x.com).
+`;
+
+describe("parseFrontmatter", () => {
+  it("parses top-level keys, ignoring the sync banner and nested keys", () => {
+    const { frontmatter, body } = parseFrontmatter(SKILL);
+    assert.equal(frontmatter.name, "customer-problems");
+    assert.equal(frontmatter.license, "MIT");
+    assert.ok(frontmatter.description.startsWith("Identify"));
+    assert.equal(frontmatter.version, undefined); // nested under metadata
+    assert.ok(body.startsWith("# Customer Problems"));
+  });
+  it("returns empty frontmatter when there is no fence", () => {
+    const { frontmatter, body } = parseFrontmatter("# Just a doc\ntext");
+    assert.deepEqual(frontmatter, {});
+    assert.ok(body.includes("Just a doc"));
+  });
+});
+
+describe("extractSections / hasSection", () => {
+  it("splits headings into sections", () => {
+    const { body } = parseFrontmatter(SKILL);
+    const sections = extractSections(body);
+    const titles = sections.map((s) => s.title);
+    assert.ok(titles.includes("Customer Problems"));
+    assert.ok(titles.includes("Notation"));
+    assert.ok(titles.includes("Handoff to Next Step"));
+  });
+  it("hasSection matches by substring and RegExp", () => {
+    const { body } = parseFrontmatter(SKILL);
+    assert.equal(hasSection(body, "handoff"), true);
+    assert.equal(hasSection(body, /^Notation$/), true);
+    assert.equal(hasSection(body, "nonexistent"), false);
+  });
+});
+
+describe("countLines", () => {
+  it("counts lines and handles empty", () => {
+    assert.equal(countLines("a\nb\nc"), 3);
+    assert.equal(countLines(""), 0);
+  });
+});
+
+describe("extractRelativeLinks", () => {
+  it("returns only relative markdown links, stripping anchors and URLs", () => {
+    const links = extractRelativeLinks(SKILL).map((l) => l.target);
+    assert.ok(links.includes("../software-glance/SKILL.md"));
+    assert.ok(!links.some((t) => t.startsWith("http")));
+  });
+});
+
+describe("parseSkill", () => {
+  it("returns frontmatter, body and sections together", () => {
+    const parsed = parseSkill(SKILL);
+    assert.equal(parsed.frontmatter.name, "customer-problems");
+    assert.ok(parsed.sections.length >= 3);
+  });
+});
+
+describe("listSkillSlugs / loadSkill (injected fs)", () => {
+  it("lists only directories, sorted", async () => {
+    const readdirImpl = async () => ([
+      { name: "customer-needs", isDirectory: () => true },
+      { name: "business-context", isDirectory: () => true },
+      { name: "README.md", isDirectory: () => false },
+    ]);
+    assert.deepEqual(await listSkillSlugs("/skills", { readdirImpl }), ["business-context", "customer-needs"]);
+  });
+  it("loads and parses a skill from an injected reader", async () => {
+    const readFileImpl = async () => SKILL;
+    const skill = await loadSkill("customer-problems", { skillsRoot: "/skills", readFileImpl });
+    assert.equal(skill.slug, "customer-problems");
+    assert.equal(skill.frontmatter.name, "customer-problems");
+    assert.match(skill.file.replace(/\\/g, "/"), /\/skills\/customer-problems\/SKILL\.md$/);
+  });
+});
+
+describe("countMatches / includesPattern", () => {
+  it("counts pattern occurrences (string auto-global)", () => {
+    assert.equal(countMatches("CP-1 CP-2 CP-3", /CP-\d+/), 3);
+    assert.equal(countMatches("a a a", "a"), 3);
+  });
+  it("includesPattern works for string and regex", () => {
+    assert.equal(includesPattern("Hello World", "world"), true);
+    assert.equal(includesPattern("Hello", /^H/), true);
+    assert.equal(includesPattern("Hello", "zzz"), false);
+  });
+});
+
+describe("gradeRubric", () => {
+  const rubric = [
+    patternCheck("has-cp", "mentions CP ids", /CP-\d+/, { min: 2, required: true }),
+    absenceCheck("no-solution", "no solution language", /\buse React\b/i, { weight: 1 }),
+    check("long-enough", "at least 20 chars", (t) => t.length >= 20, { weight: 2 }),
+  ];
+
+  it("scores a passing artifact", () => {
+    const g = gradeRubric("Problem statements CP-1 and CP-2 with plenty of detail here.", rubric, { threshold: 0.7 });
+    assert.equal(g.passed, true);
+    assert.equal(g.requiredFailures.length, 0);
+    assert.equal(g.maxScore, 4);
+    assert.equal(g.score, 4);
+    assert.equal(g.ratio, 1);
+  });
+
+  it("fails when a required check fails", () => {
+    const g = gradeRubric("only CP-1 mentioned, and quite long text here too", rubric, { threshold: 0.5 });
+    assert.equal(g.passed, false); // required has-cp needs >= 2
+    assert.equal(g.requiredFailures[0].id, "has-cp");
+  });
+
+  it("fails when below threshold even with no required failures", () => {
+    const soft = [
+      patternCheck("a", "a", /A/, { weight: 1 }),
+      patternCheck("b", "b", /B/, { weight: 1 }),
+      patternCheck("c", "c", /C/, { weight: 1 }),
+    ];
+    const g = gradeRubric("only A here", soft, { threshold: 0.7 });
+    assert.equal(g.ratio, 1 / 3);
+    assert.equal(g.passed, false);
+  });
+
+  it("captures errors thrown by a check as a failure", () => {
+    const g = gradeRubric("x", [check("boom", "throws", () => { throw new Error("nope"); })]);
+    assert.equal(g.results[0].pass, false);
+    assert.match(g.results[0].detail, /error: nope/);
+  });
+});
+
+describe("llm judge", () => {
+  it("buildJudgePrompt lists criteria and includes the artifact", () => {
+    const p = buildJudgePrompt("ARTIFACT_BODY", ["c1", "c2"]);
+    assert.ok(p.includes("1. c1"));
+    assert.ok(p.includes("2. c2"));
+    assert.ok(p.includes("ARTIFACT_BODY"));
+    assert.ok(p.includes('"score"'));
+  });
+
+  it("parseJudgeVerdict reads JSON, fractions, and bare numbers", () => {
+    assert.equal(parseJudgeVerdict('{"score":0.9,"reasoning":"good"}').score, 0.9);
+    assert.equal(parseJudgeVerdict("verdict: 3/4 criteria met").score, 0.75);
+    assert.equal(parseJudgeVerdict("0.5").score, 0.5);
+    assert.equal(parseJudgeVerdict("no verdict here").score, 0);
+    assert.equal(parseJudgeVerdict('{"score":5}').score, 1); // clamped
+  });
+
+  it("llmJudge delegates to injected invoke and applies threshold", async () => {
+    const invoke = async () => ({ text: '{"score":0.8,"reasoning":"solid"}' });
+    const res = await llmJudge("artifact", { criteria: ["c1"], invoke, threshold: 0.7 });
+    assert.equal(res.score, 0.8);
+    assert.equal(res.passed, true);
+
+    const invokeLow = async () => "score 0.4";
+    const res2 = await llmJudge("artifact", { criteria: ["c1"], invoke: invokeLow, threshold: 0.7 });
+    assert.equal(res2.passed, false);
+  });
+});

--- a/evals/tests/skills-static.test.mjs
+++ b/evals/tests/skills-static.test.mjs
@@ -1,0 +1,204 @@
+// Static skill evals — deterministic, offline assertions over every canonical
+// skills/<slug>/SKILL.md. These run with `node --test` and need no Copilot
+// process, so they are fast and always executed. They give the methodology
+// skills the regression coverage the canvas-app tests never provided, and they
+// guard the "single /problem-based-srs command" refactor.
+
+import { describe, it, before } from "node:test";
+import assert from "node:assert/strict";
+import { existsSync } from "node:fs";
+import path from "node:path";
+import { loadAllSkills, defaultSkillsRoot, countLines, hasSection, extractRelativeLinks } from "../lib/skills.mjs";
+import { countMatches } from "../lib/graders.mjs";
+
+const SKILLS_ROOT = defaultSkillsRoot();
+
+// Body must stay maintainable. AgentSkills guidance is "< 500 lines"; we use a
+// slightly higher hard cap as a regression guard so borderline existing files
+// pass while genuine bloat fails.
+const MAX_BODY_LINES = 600;
+
+// Legacy per-step slash commands removed by the unified-command refactor. None
+// of these may reappear in any skill (the new form is `/problem-based-srs <action>`).
+// The leading boundary (start-of-line, whitespace, or backtick) ensures we match
+// the slash-COMMAND form and not artifact folder paths like `.spec/functional-requirements/`.
+const LEGACY_COMMANDS = /(?<=^|[\s`(])\/(customer-problems|customer-needs|business-context|software-glance|software-vision|functional-requirements|zigzag-validator|complexity-analysis)\b/gm;
+
+// Per-skill required content tokens (verified present in the current sources).
+// Each entry is [id, RegExp]. Keep these robust to avoid brittle failures.
+const REQUIRED_TOKENS = {
+  "business-context": [
+    ["stakeholders", /stakeholder/i],
+    ["principles", /principle/i],
+    ["success-criteria", /success/i],
+  ],
+  "customer-problems": [
+    ["cp-notation", /CP[-.]/],
+    ["classification", /Obligation|Expectation|Hope/],
+  ],
+  "software-glance": [
+    ["boundaries", /boundar/i],
+    ["cp-reference", /CP[-.]/],
+  ],
+  "customer-needs": [
+    ["cn-notation", /CN[-.]/],
+    ["cp-traceability", /CP[-.]/],
+    ["traceability", /traceab/i],
+  ],
+  "software-vision": [
+    ["architecture", /architect/i],
+    ["vision", /vision/i],
+  ],
+  "functional-requirements": [
+    ["fr-notation", /FR[-.]/],
+    ["cn-reference", /CN[-.]/],
+    ["traceability", /traceab/i],
+  ],
+  "zigzag-validator": [
+    ["zigzag", /zig ?zag/i],
+    ["traceability", /traceab/i],
+  ],
+  "complexity-analysis": [
+    ["axiomatic", /axiomatic/i],
+    ["command-footer", /\/problem-based-srs complexity/],
+  ],
+  "problem-based-srs": [
+    ["traceability", /traceab/i],
+    ["unified-command", /\/problem-based-srs/],
+  ],
+  "live": [
+    ["live-command", /\/live/],
+    ["canvas", /canvas/i],
+  ],
+};
+
+// Every action the unified orchestrator must advertise.
+const ORCHESTRATOR_ACTIONS = [
+  "business-context", "problems", "software-glance", "needs",
+  "software-vision", "functional-requirements", "validate", "complexity",
+];
+
+let skills = [];
+let bySlug = new Map();
+
+before(async () => {
+  skills = await loadAllSkills({ skillsRoot: SKILLS_ROOT });
+  bySlug = new Map(skills.map((s) => [s.slug, s]));
+});
+
+describe("skills/ directory", () => {
+  it("discovers all ten methodology skills", () => {
+    assert.equal(skills.length, 10);
+    for (const slug of Object.keys(REQUIRED_TOKENS)) {
+      assert.ok(bySlug.has(slug), `missing skill directory: ${slug}`);
+    }
+  });
+});
+
+describe("frontmatter contract (every skill)", () => {
+  it("name matches its directory name", () => {
+    for (const s of skills) {
+      assert.equal(s.frontmatter.name, s.slug, `${s.slug}: name "${s.frontmatter.name}" != dir`);
+    }
+  });
+
+  it("has a non-empty description within 1024 chars", () => {
+    for (const s of skills) {
+      const d = s.frontmatter.description || "";
+      assert.ok(d.length > 0, `${s.slug}: missing description`);
+      assert.ok(d.length <= 1024, `${s.slug}: description too long (${d.length})`);
+    }
+  });
+
+  it("description is written in third person (not I / You)", () => {
+    for (const s of skills) {
+      const d = s.frontmatter.description || "";
+      assert.ok(!/^\s*(I |You |We )/i.test(d), `${s.slug}: description not third-person`);
+    }
+  });
+});
+
+describe("body health (every skill)", () => {
+  it(`body stays under ${MAX_BODY_LINES} lines`, () => {
+    for (const s of skills) {
+      const n = countLines(s.body);
+      assert.ok(n <= MAX_BODY_LINES, `${s.slug}: body has ${n} lines (cap ${MAX_BODY_LINES})`);
+    }
+  });
+
+  it("has at least one H1/H2 heading", () => {
+    for (const s of skills) {
+      assert.ok(s.sections.length > 0, `${s.slug}: no headings found`);
+    }
+  });
+});
+
+describe("unified-command refactor guard (every skill)", () => {
+  it("contains no legacy per-step slash commands", () => {
+    for (const s of skills) {
+      const hits = s.text.match(LEGACY_COMMANDS) || [];
+      assert.equal(hits.length, 0, `${s.slug}: legacy command(s) ${[...new Set(hits)].join(", ")}`);
+    }
+  });
+
+  it("uses no stale 'Use skill:' invocation directives", () => {
+    for (const s of skills) {
+      assert.equal(countMatches(s.text, /Use skill:/i), 0, `${s.slug}: stale "Use skill:" directive`);
+    }
+  });
+});
+
+describe("cross-reference links resolve (every skill)", () => {
+  it("every relative markdown link points to an existing file", () => {
+    for (const s of skills) {
+      const dir = path.dirname(s.file);
+      for (const { target } of extractRelativeLinks(s.text)) {
+        const resolved = path.resolve(dir, target);
+        assert.ok(existsSync(resolved), `${s.slug}: broken link -> ${target}`);
+      }
+    }
+  });
+});
+
+describe("methodology content (per skill)", () => {
+  for (const [slug, tokens] of Object.entries(REQUIRED_TOKENS)) {
+    it(`${slug} contains its required methodology tokens`, () => {
+      const s = bySlug.get(slug);
+      assert.ok(s, `skill ${slug} not loaded`);
+      for (const [id, pattern] of tokens) {
+        assert.ok(pattern.test(s.text), `${slug}: missing "${id}" (${pattern})`);
+      }
+    });
+  }
+});
+
+describe("problem-based-srs orchestrator", () => {
+  it("advertises every unified action", () => {
+    const s = bySlug.get("problem-based-srs");
+    for (const action of ORCHESTRATOR_ACTIONS) {
+      const re = new RegExp("/problem-based-srs " + action.replace(/[-]/g, "\\-"));
+      assert.ok(re.test(s.text), `orchestrator missing action: /problem-based-srs ${action}`);
+    }
+  });
+
+  it("documents the full-run default (bare command)", () => {
+    const s = bySlug.get("problem-based-srs");
+    assert.ok(/`\/problem-based-srs`/.test(s.text), "orchestrator missing bare /problem-based-srs");
+  });
+});
+
+describe("handoff continuity", () => {
+  const chain = [
+    ["business-context", /\/problem-based-srs problems/],
+    ["customer-problems", /\/problem-based-srs software-glance/],
+    ["customer-needs", /\/problem-based-srs software-vision/],
+    ["software-vision", /\/problem-based-srs functional-requirements/],
+  ];
+  it("each step points to the next via the unified command", () => {
+    for (const [slug, next] of chain) {
+      const s = bySlug.get(slug);
+      assert.ok(hasSection(s.body, /handoff|next step/i), `${slug}: missing Handoff/Next Step section`);
+      assert.ok(next.test(s.text), `${slug}: does not hand off via ${next}`);
+    }
+  });
+});

--- a/run-tests.ps1
+++ b/run-tests.ps1
@@ -1,0 +1,105 @@
+# Run every test suite in the repository.
+#
+#   pwsh run-tests.ps1                 # run all suites
+#   pwsh run-tests.ps1 -SkipCanvas     # skip the canvas extension suite
+#   pwsh run-tests.ps1 -SkipEvals      # skip the skill-eval deterministic suite
+#   pwsh run-tests.ps1 -SkipValidate   # skip the plugin manifest/skill validation
+#
+# Suites:
+#   1. Plugin validation  — scripts/build-plugin.py validate (manifest + skills)
+#   2. Canvas extension   — .github/extensions/srs-navigator (node --test)
+#   3. Skill evals        — evals/ deterministic tests (node --test, offline)
+#
+# Live LLM evals are NOT run here (they call the model and are opt-in);
+# use evals/scripts/run-evals.ps1 for those.
+
+[CmdletBinding()]
+param(
+    [switch]$SkipValidate,
+    [switch]$SkipCanvas,
+    [switch]$SkipEvals
+)
+
+$ErrorActionPreference = 'Stop'
+$RepoRoot = $PSScriptRoot
+
+$results = [System.Collections.Generic.List[object]]::new()
+
+function Invoke-Suite {
+    param(
+        [string]$Name,
+        [scriptblock]$Action
+    )
+    Write-Host ''
+    Write-Host "==================== $Name ====================" -ForegroundColor Cyan
+    $sw = [System.Diagnostics.Stopwatch]::StartNew()
+    try {
+        & $Action
+        $code = $LASTEXITCODE
+        if ($null -eq $code) { $code = 0 }
+    }
+    catch {
+        Write-Host $_.Exception.Message -ForegroundColor Red
+        $code = 1
+    }
+    $sw.Stop()
+    $script:results.Add([pscustomobject]@{
+        Suite    = $Name
+        ExitCode = $code
+        Passed   = ($code -eq 0)
+        Seconds  = [math]::Round($sw.Elapsed.TotalSeconds, 1)
+    })
+}
+
+Push-Location $RepoRoot
+try {
+    # 1. Plugin validation (manifest + every SKILL.md).
+    if (-not $SkipValidate) {
+        Invoke-Suite 'Plugin validation' {
+            $py = Get-Command python -ErrorAction SilentlyContinue
+            if (-not $py) { $py = Get-Command py -ErrorAction SilentlyContinue }
+            if (-not $py) { throw 'Python was not found on PATH; skip with -SkipValidate.' }
+            & $py.Source scripts/build-plugin.py validate
+        }
+    }
+
+    # 2. Canvas extension test suite.
+    if (-not $SkipCanvas) {
+        Invoke-Suite 'Canvas extension (srs-navigator)' {
+            if (-not (Get-Command node -ErrorAction SilentlyContinue)) {
+                throw 'Node.js was not found on PATH.'
+            }
+            Push-Location (Join-Path $RepoRoot '.github/extensions/srs-navigator')
+            try { npm test } finally { Pop-Location }
+        }
+    }
+
+    # 3. Skill eval deterministic tests (offline).
+    if (-not $SkipEvals) {
+        Invoke-Suite 'Skill evals (deterministic)' {
+            & (Join-Path $RepoRoot 'evals/scripts/run-tests.ps1')
+        }
+    }
+}
+finally {
+    Pop-Location
+}
+
+# Summary.
+Write-Host ''
+Write-Host '==================== Summary ====================' -ForegroundColor Cyan
+foreach ($r in $results) {
+    $label = if ($r.Passed) { 'PASS' } else { 'FAIL' }
+    $color = if ($r.Passed) { 'Green' } else { 'Red' }
+    Write-Host ("  [{0}] {1,-34} {2,5}s" -f $label, $r.Suite, $r.Seconds) -ForegroundColor $color
+}
+
+$failed = @($results | Where-Object { -not $_.Passed })
+Write-Host ''
+if ($failed.Count -eq 0) {
+    Write-Host ("==> All {0} suite(s) passed." -f $results.Count) -ForegroundColor Green
+    exit 0
+} else {
+    Write-Host ("==> {0} of {1} suite(s) failed." -f $failed.Count, $results.Count) -ForegroundColor Red
+    exit 1
+}

--- a/skills/business-context/SKILL.md
+++ b/skills/business-context/SKILL.md
@@ -484,7 +484,7 @@ Summary:
 The Business Context provides structured foundation for problem discovery.
 
 → Next Step: 1 - Customer Problems
-→ Use skill: customer-problems
+→ Action: /problem-based-srs problems
 → Input: The Business Context above (especially Current Situation and Pain Points)
 ```
 

--- a/skills/complexity-analysis/SKILL.md
+++ b/skills/complexity-analysis/SKILL.md
@@ -273,4 +273,4 @@ CP.5     [ ]   [ ]   [ ]   [ ]   [ ]   [C]
 
 **Version:** 1.2  
 **Type:** Optional Advanced Validation Tool  
-**Command:** `/complexity-analysis`
+**Command:** `/problem-based-srs complexity`

--- a/skills/customer-needs/SKILL.md
+++ b/skills/customer-needs/SKILL.md
@@ -230,9 +230,9 @@ Summary:
 - [N] Construction needs
 - [N] Entertainment needs
 
-→ MANDATORY: Run zigzag-validator skill to validate CP → CN traceability
+→ MANDATORY: Run /problem-based-srs validate to validate CP → CN traceability
 → Next Step: 4 - Software Vision
-→ Use skill: software-vision
+→ Action: /problem-based-srs software-vision
 ```
 
 ---

--- a/skills/customer-problems/SKILL.md
+++ b/skills/customer-problems/SKILL.md
@@ -367,7 +367,7 @@ Artifacts:
 [List CP-IDs with brief titles]
 
 → Next Step: 2 - Software Glance
-→ Use skill: software-glance
+→ Action: /problem-based-srs software-glance
 → Input: The CPs documented above
 ```
 

--- a/skills/functional-requirements/SKILL.md
+++ b/skills/functional-requirements/SKILL.md
@@ -476,7 +476,7 @@ After completing this step:
 
 📁 Updated: traceability-matrix.md
 
-→ MANDATORY: Run zigzag-validator skill for full chain verification
+→ MANDATORY: Run /problem-based-srs validate for full chain verification
 → Engineers can now pick individual FR files to implement
 ```
 
@@ -488,4 +488,4 @@ Based on Problem-Based SRS methodology (Gorski & Stadzisz, 2016)
 
 **Version:** 1.2  
 **Step:** 5 of 5  
-**Validation:** zigzag-validator skill
+**Validation:** `/problem-based-srs validate`

--- a/skills/live/SKILL.md
+++ b/skills/live/SKILL.md
@@ -80,4 +80,4 @@ consistent with the methodology naming convention (`CP → CN → FR`).
   the current scope. It lives at `.github/extensions/srs-navigator/`; reload extensions
   so the `srs-navigator` canvas and its tools are registered, then retry `open_canvas`.
 - This skill only handles **visualization**. To create or refine the underlying
-  artifacts, use the methodology skills (`problem-based-srs`, `customer-problems`, etc.).
+  artifacts, use the `/problem-based-srs` command (e.g. `/problem-based-srs problems`).

--- a/skills/problem-based-srs/SKILL.md
+++ b/skills/problem-based-srs/SKILL.md
@@ -22,32 +22,32 @@ Orchestrate requirements engineering using the Problem-Based SRS methodology (Go
 Stakeholder Input
        ↓
 ┌──────────────────┐
-│ Step 0: BC       │ → Use skill: business-context
+│ Step 0: BC       │ → /problem-based-srs business-context
 │ Business Context │
 └────────┬─────────┘
          ↓
 ┌──────────────────┐
-│ Step 1: CP       │ → Use skill: customer-problems
+│ Step 1: CP       │ → /problem-based-srs problems
 │ Customer Problems│
 └────────┬─────────┘
          ↓
 ┌──────────────────┐
-│ Step 2: SG       │ → Use skill: software-glance
+│ Step 2: SG       │ → /problem-based-srs software-glance
 │ Software Glance  │
 └────────┬─────────┘
          ↓
 ┌──────────────────┐
-│ Step 3: CN       │ → Use skill: customer-needs
+│ Step 3: CN       │ → /problem-based-srs needs
 │ Customer Needs   │
 └────────┬─────────┘
          ↓
 ┌──────────────────┐
-│ Step 4: SV       │ → Use skill: software-vision
+│ Step 4: SV       │ → /problem-based-srs software-vision
 │ Software Vision  │
 └────────┬─────────┘
          ↓
 ┌──────────────────┐
-│ Step 5: FR/NFR   │ → Use skill: functional-requirements
+│ Step 5: FR/NFR   │ → /problem-based-srs functional-requirements
 │ Requirements     │
 └──────────────────┘
 ```
@@ -61,20 +61,23 @@ Stakeholder Input
 | **WHAT** | Customer Needs (CN) | What outcomes must the software provide? |
 | **HOW** | Functional Requirements (FR) | How will the system behave? |
 
-## Available Skills
+## Available Actions
 
-This orchestrator coordinates the following skills:
+The Problem-Based SRS methodology is driven by a **single command** — `/problem-based-srs` —
+that dispatches to a step via an **action** argument. Run `/problem-based-srs` with no
+action (or `full`) to orchestrate the complete methodology end-to-end.
 
-| Skill | Command | Purpose |
-|-------|---------|---------|
-| `business-context` | `/business-context` | Step 0: Establish structured business context and principles |
-| `customer-problems` | `/customer-problems` | Step 1: Identify and classify customer problems |
-| `software-glance` | `/software-glance` | Step 2: Create high-level solution view |
-| `customer-needs` | `/customer-needs` | Step 3: Specify customer needs (outcomes) |
-| `software-vision` | `/software-vision` | Step 4: Define software vision and architecture |
-| `functional-requirements` | `/functional-requirements` | Step 5: Generate functional requirements |
-| `zigzag-validator` | `/zigzag-validator` | Validate traceability across domains |
-| `complexity-analysis` | `/complexity-analysis` | Optional: Axiomatic Design quality analysis |
+| Action | Command | Purpose |
+|--------|---------|---------|
+| `business-context` | `/problem-based-srs business-context` | Step 0: Establish structured business context and principles |
+| `problems` | `/problem-based-srs problems` | Step 1: Identify and classify customer problems |
+| `software-glance` | `/problem-based-srs software-glance` | Step 2: Create high-level solution view |
+| `needs` | `/problem-based-srs needs` | Step 3: Specify customer needs (outcomes) |
+| `software-vision` | `/problem-based-srs software-vision` | Step 4: Define software vision and architecture |
+| `functional-requirements` | `/problem-based-srs functional-requirements` | Step 5: Generate functional requirements |
+| `validate` | `/problem-based-srs validate` | Validate traceability across domains (ZigZag) |
+| `complexity` | `/problem-based-srs complexity` | Optional: Axiomatic Design quality analysis |
+| `full` | `/problem-based-srs` | Run the complete methodology (Step 0 → Step 5) |
 
 ## 📁 Saving Progress (CRITICAL)
 
@@ -252,10 +255,10 @@ The business context captures: project identity, business principles (Mandatory/
 ### Starting Fresh
 When user provides business context or problem description:
 1. **Ask where to save artifacts** (if not already specified)
-2. **Start with Step 0** — Use `business-context` skill to establish structured context
+2. **Start with Step 0** — Use the `business-context` action to establish structured context
 3. **Save `00-business-context.md`** with the structured business context
 4. Detect current step (see Detection Heuristics below)
-5. Invoke the appropriate skill
+5. Invoke the appropriate action
 6. Follow instructions from that skill
 7. **Save output to the corresponding file(s)**
 8. Guide user through the process
@@ -266,24 +269,24 @@ If user has existing artifacts (CPs, CNs, etc.):
 2. **Read existing files** to understand current state
 3. Identify what they have
 4. Jump to appropriate step
-5. Invoke that step's skill
+5. Invoke that step's action
 6. Continue from there, **updating files as needed**
 
 ### Validation
-At any point, use zigzag-validator skill to check consistency.
+At any point, use `/problem-based-srs validate` to check consistency.
 
 ## Detection Heuristics
 
 Determine current step by checking what artifacts exist:
 
-| If user has... | Current Step | Use Skill | Save To |
-|----------------|--------------|-----------|---------|
-| Nothing / business idea only | 0 | business-context | 00-business-context.md |
-| Business Context (BC) | 1 | customer-problems | 01-customer-problems.md |
-| Customer Problems (CPs) | 2 | software-glance | 02-software-glance.md |
-| CPs + Software Glance | 3 | customer-needs | 03-customer-needs.md |
-| CPs + CNs + Software Glance | 4 | software-vision | 04-software-vision.md |
-| CPs + CNs + Software Vision | 5 | functional-requirements | functional-requirements/*.md |
+| If user has... | Current Step | Action | Save To |
+|----------------|--------------|--------|---------|
+| Nothing / business idea only | 0 | `business-context` | 00-business-context.md |
+| Business Context (BC) | 1 | `problems` | 01-customer-problems.md |
+| Customer Problems (CPs) | 2 | `software-glance` | 02-software-glance.md |
+| CPs + Software Glance | 3 | `needs` | 03-customer-needs.md |
+| CPs + CNs + Software Glance | 4 | `software-vision` | 04-software-vision.md |
+| CPs + CNs + Software Vision | 5 | `functional-requirements` | functional-requirements/*.md |
 
 ## The Steps (Quick Reference)
 
@@ -292,7 +295,7 @@ Determine current step by checking what artifacts exist:
 **Input:** Stakeholder conversations, project briefs, existing documentation
 **Output:** Business context document with identity, principles, stakeholders, boundaries, constraints, success criteria
 **Save to:** `00-business-context.md`
-**Skill:** business-context
+**Action:** `/problem-based-srs business-context`
 
 ### Step 1: Customer Problems (CP)
 **Purpose:** Identify and document business problems
@@ -300,14 +303,14 @@ Determine current step by checking what artifacts exist:
 **Output:** List of CPs classified as Obligation/Expectation/Hope
 **Syntax:** `[Subject] [must/expects/hopes] [Object] [Penalty]`
 **Save to:** `01-customer-problems.md`
-**Skill:** customer-problems
+**Action:** `/problem-based-srs problems`
 
 ### Step 2: Software Glance (SG)
 **Purpose:** Create initial abstract solution view  
 **Input:** Customer Problems  
 **Output:** High-level system description with boundaries and components  
 **Save to:** `02-software-glance.md`  
-**Skill:** software-glance
+**Action:** `/problem-based-srs software-glance`
 
 ### Step 3: Customer Needs (CN)
 **Purpose:** Specify outcomes software must provide  
@@ -315,14 +318,14 @@ Determine current step by checking what artifacts exist:
 **Output:** CNs with outcome classes (Information/Control/Construction/Entertainment)  
 **Syntax:** `[Subject] needs [system] to [Verb] [Object] [Condition]`  
 **Save to:** `03-customer-needs.md`  
-**Skill:** customer-needs
+**Action:** `/problem-based-srs needs`
 
 ### Step 4: Software Vision (SV)
 **Purpose:** Define high-level scope and positioning  
 **Input:** CNs + Software Glance  
 **Output:** Vision document with stakeholders, features, architecture  
 **Save to:** `04-software-vision.md`  
-**Skill:** software-vision
+**Action:** `/problem-based-srs software-vision`
 
 ### Step 5: Functional Requirements (FR) & Non-Functional Requirements (NFR)
 **Purpose:** Generate detailed requirements  
@@ -330,11 +333,11 @@ Determine current step by checking what artifacts exist:
 **Output:** Individual FR and NFR files with traceability  
 **Syntax FR:** `The [System] shall [Verb] [Object] [Constraint] [Condition]`  
 **Save to:** `functional-requirements/FR-XXX.md` and `non-functional-requirements/NFR-XXX.md`  
-**Skill:** functional-requirements
+**Action:** `/problem-based-srs functional-requirements`
 
 ## Quality Gates
 
-**IMPORTANT:** Zigzag validation using zigzag-validator skill is **MANDATORY** after Steps 3 and 5 to verify traceability and identify gaps.
+**IMPORTANT:** Zigzag validation using the `/problem-based-srs validate` action is **MANDATORY** after Steps 3 and 5 to verify traceability and identify gaps.
 
 ### After Step 0 (BC)
 - [ ] Project identity complete (name, domain, purpose)
@@ -397,13 +400,13 @@ If user attempts to skip to solutions, redirect:
 I notice you're describing a solution. Let's first understand the problem.
 
 Before we design [mentioned solution], help me understand:
-1. What is the business context? (→ business-context skill)
+1. What is the business context? (→ `business-context` action)
 2. What business obligation, expectation, or hope drives this need?
 3. What negative consequences occur without this?
 4. Who is impacted?
 
-→ Loading: business-context skill (if no BC exists)
-→ Loading: customer-problems skill (if BC exists)
+→ Loading: `business-context` action (if no BC exists)
+→ Loading: `problems` action (if BC exists)
 ```
 
 ## Quick Syntax Reference
@@ -463,7 +466,7 @@ Complete initial pass, then iterate on specific steps as understanding improves.
 **Remember:** Update existing files rather than creating new ones.
 
 ### Pattern 4: Validation Only
-Use zigzag-validator skill to check existing artifacts without generating new ones.
+Use the `/problem-based-srs validate` action to check existing artifacts without generating new ones.
 
 ### Pattern 5: Independent Development
 After Step 5, engineers can pick up individual FR files and develop independently.
@@ -474,7 +477,7 @@ Use Problem-Based SRS iteratively within agile workflows:
 - **Sprint 0:** Steps 0-2 (BC + CPs + Software Glance) for product vision
 - **Sprint 1+:** Steps 3-5 for specific feature sets
 - **Per Feature:** Complete CP→CN→FR chain for one feature at a time
-- **Validation:** Run zigzag-validator after each sprint to ensure traceability
+- **Validation:** Run `/problem-based-srs validate` after each sprint to ensure traceability
 
 ### Pattern 7: Minimal Viable SRS
 For quick prototypes or MVPs:
@@ -484,20 +487,20 @@ For quick prototypes or MVPs:
 4. Generate only critical FRs
 5. Skip detailed validation until expansion
 
-## When to Use Each Skill
+## When to Use Each Action
 
-- **business-context:** User is starting a new project and needs to establish structured context
-- **customer-problems:** User has business context but no structured problems
-- **software-glance:** User has CPs and needs high-level solution view
-- **customer-needs:** User has CPs + SG and needs to specify outcomes
-- **software-vision:** User has CNs and needs detailed vision document
-- **functional-requirements:** User has CNs + SV and needs functional requirements
-- **zigzag-validator:** User needs to check traceability or consistency
-- **complexity-analysis:** User explicitly requests Axiomatic Design analysis
+- **`business-context`:** User is starting a new project and needs to establish structured context
+- **`problems`:** User has business context but no structured problems
+- **`software-glance`:** User has CPs and needs high-level solution view
+- **`needs`:** User has CPs + SG and needs to specify outcomes
+- **`software-vision`:** User has CNs and needs detailed vision document
+- **`functional-requirements`:** User has CNs + SV and needs functional requirements
+- **`validate`:** User needs to check traceability or consistency
+- **`complexity`:** User explicitly requests Axiomatic Design analysis
 
 ## Optional: Complexity Analysis
 
-For deeper quality analysis, users can explicitly invoke the `complexity-analysis` skill for Axiomatic Design-based specification quality analysis. Use for critical systems, large specifications, or formal reviews. This is **NOT** part of the standard flow.
+For deeper quality analysis, users can explicitly invoke the `/problem-based-srs complexity` action for Axiomatic Design-based specification quality analysis. Use for critical systems, large specifications, or formal reviews. This is **NOT** part of the standard flow.
 
 ## Examples
 
@@ -505,4 +508,4 @@ For complete walkthroughs, see:
 - [CRM Example](references/crm-example.md) — Business domain (Customer Relationship Management)
 - [MicroER Example](references/microer-example.md) — Technical domain (Renewable Energy System)
 
-**Use skills individually** based on current step to minimize context usage.
+**Run actions individually** based on current step to minimize context usage.

--- a/skills/software-glance/SKILL.md
+++ b/skills/software-glance/SKILL.md
@@ -174,7 +174,7 @@ After generating the Software Glance, instruct the user:
 
 > ✅ **Software Glance complete.** To continue the Problem-Based SRS process:
 > 
-> **Next Step:** Use `customer-needs` skill to specify Customer Needs based on this Software Glance and the Customer Problems.
+> **Next Step:** Run `/problem-based-srs needs` to specify Customer Needs based on this Software Glance and the Customer Problems.
 > 
 > The Software Glance provides boundaries and direction for identifying what outcomes the software must provide.
 
@@ -299,7 +299,7 @@ Before accepting the Software Glance output:
 | 4 | [software-vision](../software-vision/SKILL.md) | 🔗 Drills down from this glance |
 | 5 | functional-requirements | |
 
-**Next:** Use the Software Glance output with `customer-needs` skill to specify what outcomes the software must provide.
+**Next:** Use the Software Glance output with `/problem-based-srs needs` to specify what outcomes the software must provide.
 
 ---
 

--- a/skills/software-vision/SKILL.md
+++ b/skills/software-vision/SKILL.md
@@ -258,7 +258,7 @@ Summary:
 - Architecture overview complete
 
 → Next Step: 5 - Functional Requirements
-→ Use skill: functional-requirements
+→ Action: /problem-based-srs functional-requirements
 → Input: Customer Needs + Software Vision
 ```
 

--- a/skills/zigzag-validator/SKILL.md
+++ b/skills/zigzag-validator/SKILL.md
@@ -252,7 +252,7 @@ Use **C** (Complete) and **P** (Partial) markers to indicate how well each eleme
 ### Uncovered Customer Problems
 | CP | Statement | Suggested Action |
 |----|-----------|------------------|
-| CP.3 | [statement] | Generate CN using customer-needs skill |
+| CP.3 | [statement] | Generate CN using /problem-based-srs needs |
 
 ### Orphan Items
 | Item | Type | Issue | Suggested Action |


### PR DESCRIPTION
Release v2.4. Unifies the nine per-step slash commands into a single /problem-based-srs <action> command across the CLI skills/agent, the SRS Navigator canvas extension, and the webpage. Adds a new evals/ harness (deterministic offline tests + opt-in live LLM evals via the Copilot CLI SDK), verbose eval output, PowerShell runners, and a repo-root run-tests.ps1. Validated: build-plugin.py build --version 2.4 (10 skills) and pwsh run-tests.ps1 (all 3 suites pass).