### PR TITLE
docs: Bump webpage version badge to v2.4

### DIFF
--- a/docs/app.html
+++ b/docs/app.html
@@ -18,7 +18,7 @@
         <div class="wrap">
             <div class="site-nav-id">
                 <a href="index.html" class="site-nav-brand" aria-label="Problem-Based SRS home">Problem-Based <span>SRS</span></a>
-                <a href="https://github.com/RafaelGorski/Problem-Based-SRS/releases" class="version-badge" target="_blank" rel="noopener" aria-label="Version 2.3, view releases">v2.3</a>
+                <a href="https://github.com/RafaelGorski/Problem-Based-SRS/releases" class="version-badge" target="_blank" rel="noopener" aria-label="Version 2.4, view releases">v2.4</a>
             </div>
             <ul class="site-nav-links">
                 <li><a href="index.html">Home</a></li>
@@ -260,7 +260,7 @@
 
     <footer class="site-footer">
         <div class="wrap">
-            <p>Problem-Based SRS &middot; <a href="https://github.com/RafaelGorski/Problem-Based-SRS/releases" class="footer-version">v2.3</a> &middot; Methodology by Gorski &amp; Stadzisz</p>
+            <p>Problem-Based SRS &middot; <a href="https://github.com/RafaelGorski/Problem-Based-SRS/releases" class="footer-version">v2.4</a> &middot; Methodology by Gorski &amp; Stadzisz</p>
             <p class="footer-links">
                 <a href="index.html">Home</a>
                 <a href="https://github.com/RafaelGorski/Problem-Based-SRS">GitHub</a>

--- a/docs/index.html
+++ b/docs/index.html
@@ -18,7 +18,7 @@
         <div class="wrap">
             <div class="site-nav-id">
                 <a href="/" class="site-nav-brand" aria-label="Problem-Based SRS home">Problem-Based <span>SRS</span></a>
-                <a href="https://github.com/RafaelGorski/Problem-Based-SRS/releases" class="version-badge" target="_blank" rel="noopener" aria-label="Version 2.3, view releases">v2.3</a>
+                <a href="https://github.com/RafaelGorski/Problem-Based-SRS/releases" class="version-badge" target="_blank" rel="noopener" aria-label="Version 2.4, view releases">v2.4</a>
             </div>
             <ul class="site-nav-links">
                 <li><a href="#problem">The problem</a></li>
@@ -398,7 +398,7 @@ Our warehouse tracks everything in spreadsheets and loses $50k/month due to erro
 
     <footer class="site-footer">
         <div class="wrap">
-            <p>Problem-Based SRS · <a href="https://github.com/RafaelGorski/Problem-Based-SRS/releases" class="footer-version">v2.3</a> · Methodology by Gorski &amp; Stadzisz</p>
+            <p>Problem-Based SRS · <a href="https://github.com/RafaelGorski/Problem-Based-SRS/releases" class="footer-version">v2.4</a> · Methodology by Gorski &amp; Stadzisz</p>
             <p class="footer-links">
                 <a href="https://github.com/RafaelGorski/Problem-Based-SRS">GitHub</a>
                 <a href="https://github.com/RafaelGorski/Problem-Based-SRS/blob/main/CHANGELOG.md">Changelog</a>


### PR DESCRIPTION
Follow-up to #45 / the v2.4 release: the webpage version badge and footer still showed v2.3. Updates both docs/index.html and docs/app.html to v2.4.