### PR TITLE
docs: Animate How It Works to show one command, many actions

### DIFF
--- a/docs/assets/site.css
+++ b/docs/assets/site.css
@@ -367,11 +367,11 @@
         .cli-line { display: flex; align-items: baseline; flex-wrap: wrap; gap: 0.2rem 0.75rem; }
         .cli-you { color: oklch(0.9 0.012 264); margin-bottom: 0.4rem; }
         .cli-caret { color: var(--step-what); font-weight: 700; }
-        .cli-cmd {
-            color: color-mix(in oklab, var(--c) 62%, white);
-            font-weight: 600; min-width: 15.5em;
-        }
+        .cli-cmd { min-width: 15.5em; font-weight: 400; }
         .cli-cmd::before { content: '↳ '; color: oklch(0.55 0.015 264); font-weight: 400; }
+        /* One command, many actions: the command recedes, the action carries the color. */
+        .cli-base { color: oklch(0.62 0.015 264); }
+        .cli-action { color: color-mix(in oklab, var(--c) 66%, white); font-weight: 600; }
         .cli-out { color: oklch(0.68 0.015 264); }
         .cli-done { margin-top: 0.5rem; color: var(--step-vision); font-weight: 600; }
         .cli-check { color: var(--step-vision); font-weight: 700; }

--- a/docs/index.html
+++ b/docs/index.html
@@ -211,12 +211,12 @@
                             </div>
                             <div class="cli-body" aria-hidden="true">
                                 <div class="cli-line cli-you" style="--i:0"><span class="cli-caret">&rsaquo;</span> Turn the outage postmortem into a spec</div>
-                                <div class="cli-line" style="--i:1"><span class="cli-cmd" style="--c: var(--step-context)">/problem-based-srs business-context</span><span class="cli-out">project identity, constraints, success criteria</span></div>
-                                <div class="cli-line" style="--i:2"><span class="cli-cmd" style="--c: var(--step-why)">/problem-based-srs problems</span><span class="cli-out">CP&#8209;1&#8230;CP&#8209;5, classified by severity</span></div>
-                                <div class="cli-line" style="--i:3"><span class="cli-cmd" style="--c: var(--step-glance)">/problem-based-srs software-glance</span><span class="cli-out">high-level solution sketch</span></div>
-                                <div class="cli-line" style="--i:4"><span class="cli-cmd" style="--c: var(--step-what)">/problem-based-srs needs</span><span class="cli-out">each CN traces to a CP</span></div>
-                                <div class="cli-line" style="--i:5"><span class="cli-cmd" style="--c: var(--step-vision)">/problem-based-srs software-vision</span><span class="cli-out">architecture and approach</span></div>
-                                <div class="cli-line" style="--i:6"><span class="cli-cmd" style="--c: var(--step-how)">/problem-based-srs functional-requirements</span><span class="cli-out">each FR traces to a CN and a CP</span></div>
+                                <div class="cli-line" style="--i:1"><span class="cli-cmd"><span class="cli-base">/problem-based-srs</span> <span class="cli-action" style="--c: var(--step-context)">business-context</span></span><span class="cli-out">project identity, constraints, success criteria</span></div>
+                                <div class="cli-line" style="--i:2"><span class="cli-cmd"><span class="cli-base">/problem-based-srs</span> <span class="cli-action" style="--c: var(--step-why)">problems</span></span><span class="cli-out">CP&#8209;1&#8230;CP&#8209;5, classified by severity</span></div>
+                                <div class="cli-line" style="--i:3"><span class="cli-cmd"><span class="cli-base">/problem-based-srs</span> <span class="cli-action" style="--c: var(--step-glance)">software-glance</span></span><span class="cli-out">high-level solution sketch</span></div>
+                                <div class="cli-line" style="--i:4"><span class="cli-cmd"><span class="cli-base">/problem-based-srs</span> <span class="cli-action" style="--c: var(--step-what)">needs</span></span><span class="cli-out">each CN traces to a CP</span></div>
+                                <div class="cli-line" style="--i:5"><span class="cli-cmd"><span class="cli-base">/problem-based-srs</span> <span class="cli-action" style="--c: var(--step-vision)">software-vision</span></span><span class="cli-out">architecture and approach</span></div>
+                                <div class="cli-line" style="--i:6"><span class="cli-cmd"><span class="cli-base">/problem-based-srs</span> <span class="cli-action" style="--c: var(--step-how)">functional-requirements</span></span><span class="cli-out">each FR traces to a CN and a CP</span></div>
                                 <div class="cli-line cli-done" style="--i:7"><span class="cli-check">&#10003;</span> 100% traceability &middot; FR &larr; CN &larr; CP<span class="cli-cursor"></span></div>
                             </div>
                         </div>


### PR DESCRIPTION
## What

Aligns the animated "How it works" CLI simulation with the v2.4 unified-command refactor.

Previously the animation repeated the full `/problem-based-srs` string six times, so it read as six separate commands. Now:

- The constant `/problem-based-srs` recedes into a dim terminal gray (`.cli-base`).
- The **action** token (`business-context`, `problems`, `needs`, `software-vision`, `functional-requirements`, …) is the bright, color-coded payload that changes each line (`.cli-action`).

As the staggered lines stream in, the animation now visually communicates *one command, many actions*, matching the refactor.

## Scope

- `docs/index.html` — split each animated command line into a dim base + colored action span.
- `docs/assets/site.css` — add `.cli-base` / `.cli-action` styles; move the color emphasis from the whole command onto the action token.

The two graph SVGs (`srs-chain.svg`, `srs-problems.svg`) contain no command references and depict the unchanged CP → CN → FR traceability model, so they were left as-is.

## Preserved

Same fonts, step colors, ease-out-quart stagger, and the `prefers-reduced-motion` fallback (lines remain visible). Layout/alignment mechanics unchanged.