### PR TITLE
Fix stale-CSS breakage on GitHub Pages (cache-bust assets)

### DIFF
--- a/docs/docs.html
+++ b/docs/docs.html
@@ -9,7 +9,8 @@
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Bricolage+Grotesque:wght@700;800&family=Figtree:wght@400;500;600&family=JetBrains+Mono:wght@400&display=swap" rel="stylesheet">
-    <link rel="stylesheet" href="assets/site.css">
+    <!-- Bump the ?v= query on any assets/site.css or assets/site.js change to bust the 10-min Pages cache. -->
+    <link rel="stylesheet" href="assets/site.css?v=2.4.0">
 </head>
 <body>
     <a href="#main" class="skip-link">Skip to content</a>
@@ -535,7 +536,7 @@ git tag vX.Y &amp;&amp; git push origin vX.Y</code></pre>
         </div>
     </footer>
 
-    <script src="assets/site.js" defer></script>
+    <script src="assets/site.js?v=2.4.0" defer></script>
     <script>
         (function () {
             // Sidebar toggle (mobile)

--- a/docs/index.html
+++ b/docs/index.html
@@ -9,7 +9,8 @@
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Bricolage+Grotesque:wght@700;800&family=Figtree:wght@400;500;600&family=JetBrains+Mono:wght@400&display=swap" rel="stylesheet">
-    <link rel="stylesheet" href="assets/site.css">
+    <!-- Bump the ?v= query on any assets/site.css or assets/site.js change to bust the 10-min Pages cache. -->
+    <link rel="stylesheet" href="assets/site.css?v=2.4.0">
 </head>
 <body>
     <a href="#main" class="skip-link">Skip to content</a>
@@ -441,6 +442,6 @@ Our warehouse tracks everything in spreadsheets and loses $50k/month due to erro
         </div>
     </footer>
 
-    <script src="assets/site.js" defer></script>
+    <script src="assets/site.js?v=2.4.0" defer></script>
 </body>
 </html>


### PR DESCRIPTION
Versions the site.css/site.js URLs (?v=2.4.0) so a stylesheet change no longer leaves returning visitors on a 10-minute-cached old site.css, which rendered docs.html unstyled (styled header, raw sidebar + toggle). Bump the query on future asset edits.

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>