### PR TITLE
feat: Hero CTA copy-paste install + 5-minute promise (#52)

### DIFF
--- a/docs/assets/site.css
+++ b/docs/assets/site.css
@@ -568,6 +568,66 @@
     background: var(--hf, var(--primary)); align-self: center;
 }
 
+/* ── Hero install CTA (primary action) ── */
+.hero-install { margin-bottom: var(--space-lg); max-width: 34rem; }
+.hero-install-label {
+    display: flex; align-items: center; gap: 0.5em;
+    font-family: var(--font-mono); font-size: var(--text-xs);
+    letter-spacing: 0.01em; color: var(--muted);
+    margin-bottom: var(--space-sm);
+}
+.copy-cmd {
+    display: flex; align-items: center; gap: var(--space-sm);
+    background: var(--bg-elevated);
+    border: 1px solid var(--surface-border);
+    border-radius: 10px;
+    padding: 0.5rem 0.5rem 0.5rem 0.85rem;
+}
+.copy-cmd:focus-within { border-color: var(--muted-light); }
+.copy-cmd-text {
+    flex: 1 1 auto; min-width: 0;
+    background: none; border: none; padding: 0; border-radius: 0;
+    font-family: var(--font-mono); font-size: var(--text-sm);
+    line-height: 1.5; color: var(--ink-heading);
+    white-space: normal; overflow-wrap: anywhere;
+}
+.copy-cmd-btn {
+    flex: 0 0 auto; align-self: stretch;
+    display: inline-flex; align-items: center; justify-content: center; gap: 0.4em;
+    background: var(--primary); color: var(--on-primary);
+    border: none; border-radius: 6px;
+    padding: 0.5em 0.9em;
+    font-family: var(--font-body); font-size: var(--text-sm); font-weight: 600;
+    white-space: nowrap; cursor: pointer;
+    transition: background 0.2s ease;
+}
+.copy-cmd-btn:hover { background: var(--primary-hover); }
+.copy-cmd-btn:focus-visible { outline: 2px solid var(--primary); outline-offset: 2px; }
+.copy-cmd-btn.is-copied { background: var(--step-vision); }
+.copy-cmd-icon { width: 15px; height: 15px; flex: 0 0 auto; }
+.copy-cmd-icon--done { display: none; }
+.copy-cmd-btn.is-copied .copy-cmd-icon--copy { display: none; }
+.copy-cmd-btn.is-copied .copy-cmd-icon--done { display: inline; }
+.hero-install-promise {
+    display: flex; align-items: center; gap: 0.5em;
+    margin-top: var(--space-sm);
+    font-size: var(--text-sm); color: var(--muted);
+}
+.hero-install-promise strong { color: var(--ink-heading); font-weight: 600; }
+.hero-install-promise svg { width: 16px; height: 16px; flex: 0 0 auto; color: var(--cp-bold); }
+.visually-hidden {
+    position: absolute; width: 1px; height: 1px;
+    margin: -1px; padding: 0; border: 0;
+    clip: rect(0 0 0 0); clip-path: inset(50%); overflow: hidden; white-space: nowrap;
+}
+@media (max-width: 640px) {
+    .copy-cmd { flex-direction: column; align-items: stretch; gap: 0.6rem; padding: 0.75rem; }
+    .copy-cmd-btn { align-self: stretch; }
+}
+@media (prefers-reduced-motion: reduce) {
+    .copy-cmd-btn { transition: none; }
+}
+
 /* ── Two parts: Skills + App ── */
 .parts-grid { display: grid; gap: var(--space-lg); margin-top: var(--space-xl); }
 @media (min-width: 860px) { .parts-grid { grid-template-columns: 1fr 1fr; } }

--- a/docs/assets/site.js
+++ b/docs/assets/site.js
@@ -30,4 +30,59 @@
             }
         });
     });
+    // ── Copy-to-clipboard commands ────────────────────────────────
+    function copyText(text) {
+        if (navigator.clipboard && window.isSecureContext) {
+            return navigator.clipboard.writeText(text);
+        }
+        return new Promise(function (resolve, reject) {
+            var ta = document.createElement('textarea');
+            ta.value = text;
+            ta.setAttribute('readonly', '');
+            ta.style.position = 'fixed';
+            ta.style.top = '-9999px';
+            document.body.appendChild(ta);
+            ta.select();
+            try {
+                var ok = document.execCommand('copy');
+                document.body.removeChild(ta);
+                ok ? resolve() : reject(new Error('execCommand failed'));
+            } catch (err) {
+                document.body.removeChild(ta);
+                reject(err);
+            }
+        });
+    }
+
+    document.querySelectorAll('[data-copy]').forEach(function (btn) {
+        var labelEl = btn.querySelector('.copy-cmd-btn-label');
+        var defaultLabel = labelEl ? labelEl.textContent : 'Copy';
+        var statusEl = document.querySelector(btn.getAttribute('data-copy-status') || '');
+        var resetTimer;
+
+        function reset() {
+            btn.classList.remove('is-copied');
+            if (labelEl) { labelEl.textContent = defaultLabel; }
+        }
+
+        btn.addEventListener('click', function () {
+            var source = document.querySelector(btn.getAttribute('data-copy'));
+            if (!source) { return; }
+            var text = (source.textContent || '').trim();
+            copyText(text).then(function () {
+                btn.classList.add('is-copied');
+                if (labelEl) { labelEl.textContent = 'Copied'; }
+                if (statusEl) { statusEl.textContent = 'Install command copied to clipboard'; }
+            }).catch(function () {
+                if (labelEl) { labelEl.textContent = 'Press Ctrl+C'; }
+                if (statusEl) { statusEl.textContent = 'Copy failed. Select the command and press Ctrl+C.'; }
+            }).then(function () {
+                clearTimeout(resetTimer);
+                resetTimer = setTimeout(function () {
+                    reset();
+                    if (statusEl) { statusEl.textContent = ''; }
+                }, 2200);
+            });
+        });
+    });
 })();

--- a/docs/docs.html
+++ b/docs/docs.html
@@ -10,7 +10,7 @@
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Bricolage+Grotesque:wght@700;800&family=Figtree:wght@400;500;600&family=JetBrains+Mono:wght@400&display=swap" rel="stylesheet">
     <!-- Bump the ?v= query on any assets/site.css or assets/site.js change to bust the 10-min Pages cache. -->
-    <link rel="stylesheet" href="assets/site.css?v=2.4.1">
+    <link rel="stylesheet" href="assets/site.css?v=2.4.2">
 </head>
 <body>
     <a href="#main" class="skip-link">Skip to content</a>
@@ -536,7 +536,7 @@ git tag vX.Y &amp;&amp; git push origin vX.Y</code></pre>
         </div>
     </footer>
 
-    <script src="assets/site.js?v=2.4.1" defer></script>
+    <script src="assets/site.js?v=2.4.2" defer></script>
     <script>
         (function () {
             // Sidebar toggle (mobile)

--- a/docs/index.html
+++ b/docs/index.html
@@ -10,7 +10,7 @@
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Bricolage+Grotesque:wght@700;800&family=Figtree:wght@400;500;600&family=JetBrains+Mono:wght@400&display=swap" rel="stylesheet">
     <!-- Bump the ?v= query on any assets/site.css or assets/site.js change to bust the 10-min Pages cache. -->
-    <link rel="stylesheet" href="assets/site.css?v=2.4.1">
+    <link rel="stylesheet" href="assets/site.css?v=2.4.2">
 </head>
 <body>
     <a href="#main" class="skip-link">Skip to content</a>
@@ -48,8 +48,24 @@
                 <span class="hero-feature"><span class="hf-dot" style="--hf: var(--step-why)" aria-hidden="true"></span><b>Skills</b> <span class="hf-kind">the methodology</span></span>
                 <span class="hero-feature"><span class="hf-dot" style="--hf: var(--step-how)" aria-hidden="true"></span><b>SRS Navigator</b> <span class="hf-kind">the app</span></span>
             </div>
+            <div class="hero-install">
+                <p class="hero-install-label">Paste into GitHub Copilot or Claude Code</p>
+                <div class="copy-cmd">
+                    <code class="copy-cmd-text" id="hero-install-cmd">Install the Problem-Based SRS skills from RafaelGorski/Problem-Based-SRS into .github/skills/</code>
+                    <button type="button" class="copy-cmd-btn" data-copy="#hero-install-cmd" data-copy-status="#copy-status">
+                        <svg class="copy-cmd-icon copy-cmd-icon--copy" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><rect x="9" y="9" width="13" height="13" rx="2"/><path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"/></svg>
+                        <svg class="copy-cmd-icon copy-cmd-icon--done" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><polyline points="20 6 9 17 4 12"/></svg>
+                        <span class="copy-cmd-btn-label">Copy</span>
+                    </button>
+                </div>
+                <p class="hero-install-promise">
+                    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="9"/><polyline points="12 7 12 12 15 14"/></svg>
+                    <span>Then describe your project and get your first traced spec in <strong>5 minutes</strong>.</span>
+                </p>
+                <span id="copy-status" class="visually-hidden" role="status" aria-live="polite"></span>
+            </div>
             <div class="hero-actions">
-                <a href="https://github.com/RafaelGorski/Problem-Based-SRS" class="btn-primary">View on GitHub</a>
+                <a href="https://github.com/RafaelGorski/Problem-Based-SRS" class="btn-ghost">View on GitHub</a>
                 <a href="docs.html#navigator" class="btn-ghost">Explore the app</a>
             </div>
             <div class="hero-meta">
@@ -442,6 +458,6 @@ Our warehouse tracks everything in spreadsheets and loses $50k/month due to erro
         </div>
     </footer>
 
-    <script src="assets/site.js?v=2.4.1" defer></script>
+    <script src="assets/site.js?v=2.4.2" defer></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
Reworks the landing-page hero's primary call-to-action from **"View on GitHub"** (which sent a skeptical engineer *to a repo to read*) into a **copy-to-clipboard install command** plus an explicit **"first traced spec in 5 minutes"** promise, shortening time-to-first-value. Implements issue #52.

## Changes (`docs/` — the GitHub Page)
- **`docs/index.html`** — new `.hero-install` block: a mono "Paste into GitHub Copilot or Claude Code" label → the real README install line in an elevated/hairline command card with an indigo **Copy** button → an amber-clock **"first traced spec in 5 minutes"** promise. Adds a visually-hidden `role="status"` live region. **"View on GitHub"** is demoted to a secondary ghost button beside "Explore the app".
- **`docs/assets/site.css`** — `.copy-cmd` / `.copy-cmd-btn` styles using only DESIGN.md tokens (Graph Indigo, `lg`/`sm` radii), a green "Copied ✓" success state, mobile stacking, `.visually-hidden`, and reduced-motion handling.
- **`docs/assets/site.js`** — generic `[data-copy]` handler: Clipboard API with an `execCommand` fallback, Copy→Copied label swap + check icon, ARIA live-region announcement, 2.2s auto-reset.
- Cache-buster bumped to `?v=2.4.2` on `index.html` and `docs.html`.

## Verification (Playwright / Chromium)
Automated checks pass: clicking **Copy** writes the exact install line to the clipboard; the button enters the Copied/check state, announces to screen readers, then resets; the 5-minute promise is visible; "View on GitHub" is a ghost button; and the command block stacks full-width on mobile (390px). Desktop + mobile screenshots reviewed. Preserves the site's committed brand identity.

## Acceptance criteria
- [x] Hero's primary action is a copy-to-clipboard install snippet
- [x] "5-minute first spec" promise is visible in the hero
- [x] "View on GitHub" remains available as a secondary button
- [x] Copy button works on the install snippet

Closes #52