### PR TITLE
Fix ID notation drift, run every suite in CI, and publish a health dashboard

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -62,10 +62,10 @@ All Problem-Based SRS artifacts are saved to the `.spec/` folder at the project 
 ├── 04-software-vision.md
 ├── functional-requirements/
 │   ├── _index.md
-│   └── FR-001-[short-name].md
+│   └── FR.01.1.1-[short-name].md
 └── non-functional-requirements/
     ├── _index.md
-    └── NFR-001-[short-name].md
+    └── NFR.01-[short-name].md
 ```
 
 When adding or changing features/requirements in the solution, reference the `.spec/` folder for existing artifacts and save new artifacts there. If a legacy folder is detected (`docs/srs/`, `requirements/`), continue using it for consistency.
@@ -75,7 +75,15 @@ When adding or changing features/requirements in the solution, reference the `.s
 - **Customer Problems**: `CP.{n}` or `CP.{n}.{m}` (e.g., CP.01, CP.01.1)
 - **Customer Needs**: `CN.{cp}.{n}` (e.g., CN.01.1 traces to CP.01)
 - **Functional Requirements**: `FR.{cp}.{cn}.{n}` (e.g., FR.01.1.1 traces to CN.01.1)
-- **Non-Functional Requirements**: `NFR.{version}.md` (e.g., NFR.1.0.md)
+- **Non-Functional Requirements**: `NFR.{n}` (e.g., NFR.01)
+
+IDs are **dotted** so the ID itself carries the traceability chain. Requirement filenames
+embed the ID plus a short name: `FR.01.1.1-client-registration.md`, `NFR.01-response-time.md`.
+Hyphen IDs (`CP-001`, `FR-002-name.md`) are accepted-legacy — the parsers still read them,
+but new artifacts must not use them. The canonical definition lives in the "Identifier
+Notation" section of `skills/problem-based-srs/SKILL.md`, is enforced by
+`evals/tests/skills-static.test.mjs`, and is implemented in
+`.github/extensions/srs-navigator/lib/notation.mjs`.
 
 ---
 

--- a/.github/extensions/srs-navigator/README.md
+++ b/.github/extensions/srs-navigator/README.md
@@ -250,16 +250,16 @@ The extension accepts specifications in the Problem-Based SRS JSON format:
   "description": "System description",
   "version": "1.0",
   "problems": [
-    { "id": "CP-1", "title": "...", "description": "..." }
+    { "id": "CP.01", "title": "...", "description": "..." }
   ],
   "needs": [
-    { "id": "CN-1", "title": "...", "description": "...", "problemIds": ["CP-1"] }
+    { "id": "CN.01.1", "title": "...", "description": "...", "problemIds": ["CP.01"] }
   ],
   "functionalRequirements": [
-    { "id": "FR-1", "title": "...", "description": "...", "needIds": ["CN-1"] }
+    { "id": "FR.01.1.1", "title": "...", "description": "...", "needIds": ["CN.01.1"] }
   ],
   "nonFunctionalRequirements": [
-    { "id": "NFR-1", "title": "...", "description": "...", "needIds": ["CN-1"] }
+    { "id": "NFR.01", "title": "...", "description": "...", "needIds": ["CN.01.1"] }
   ]
 }
 ```

--- a/.github/extensions/srs-navigator/docs/DESIGN.md
+++ b/.github/extensions/srs-navigator/docs/DESIGN.md
@@ -140,7 +140,7 @@ Warm problem hues cooling toward technical implementation (ember → teal → in
 **Body Font:** Figtree (with system-ui, -apple-system, sans-serif fallback)
 **Mono Font:** JetBrains Mono (with ui-monospace, monospace fallback)
 
-**Character:** Shared visual language with the project site. Bricolage Grotesque gives headings (page title, node titles) a confident display voice with expressive contrast; Figtree carries dense UI and body text with a high x-height that stays clear at small sizes; JetBrains Mono handles identifiers (CP-1, FR-3, NFR-2) where character distinction matters.
+**Character:** Shared visual language with the project site. Bricolage Grotesque gives headings (page title, node titles) a confident display voice with expressive contrast; Figtree carries dense UI and body text with a high x-height that stays clear at small sizes; JetBrains Mono handles identifiers (CP.01, FR.03.1.1, NFR.02) where character distinction matters.
 
 ### Hierarchy
 - **Display** (700, 22px, 1.2): Page title only. One instance per view.

--- a/.github/extensions/srs-navigator/extension.mjs
+++ b/.github/extensions/srs-navigator/extension.mjs
@@ -642,7 +642,7 @@ const session = await joinSession({
                     inputSchema: {
                         type: "object",
                         properties: {
-                            nodeId: { type: "string", description: "The node ID to inspect (e.g., CP-1, CN-2, FR-3, NFR-1)" }
+                            nodeId: { type: "string", description: "The node ID to inspect (e.g., CP.01, CN.02.1, FR.03.1.1, NFR.01)" }
                         },
                         required: ["nodeId"]
                     },
@@ -829,7 +829,7 @@ const session = await joinSession({
                     inputSchema: {
                         type: "object",
                         properties: {
-                            nodeId: { type: "string", description: "The node ID to decompose (e.g., FR-1, CN-2)" }
+                            nodeId: { type: "string", description: "The node ID to decompose (e.g., FR.01.1.1, CN.02.1)" }
                         },
                         required: ["nodeId"]
                     },

--- a/.github/extensions/srs-navigator/lib/decompose.mjs
+++ b/.github/extensions/srs-navigator/lib/decompose.mjs
@@ -11,7 +11,10 @@ const TYPE_META = {
   nfr: { key: "nonFunctionalRequirements", prefix: "NFR", linkField: "needIds" },
 };
 
-/** Compute the next sequential id (e.g. "FR-4") given existing ids of a prefix. */
+/**
+ * Compute the next sequential id (e.g. "FR-4") given existing ids of a prefix.
+ * Only used for legacy hyphen specs; dotted specs use {@link childId}.
+ */
 export function nextId(ids, prefix) {
   let max = 0;
   for (const id of ids) {
@@ -19,6 +22,24 @@ export function nextId(ids, prefix) {
     if (m) max = Math.max(max, Number(m[1]));
   }
   return `${prefix}-${max + 1}`;
+}
+
+/**
+ * Compute a child id for canonical dotted notation by appending a level to the
+ * parent, e.g. CP.01 -> CP.01.1, FR.01.1.1 -> FR.01.1.1.1. This keeps the
+ * traceability chain readable in the id itself, which is the whole point of the
+ * dotted scheme, and matches the documented sub-problem convention.
+ */
+export function childId(parentId, existingIds) {
+  const taken = new Set(existingIds.map(String));
+  let k = 1;
+  while (taken.has(`${parentId}.${k}`)) k += 1;
+  return `${parentId}.${k}`;
+}
+
+/** True when an id uses canonical dotted notation (CP.01) rather than legacy hyphen (CP-1). */
+export function isDottedId(id) {
+  return /^[A-Za-z]+\.\d/.test(String(id));
 }
 
 function detectType(spec, nodeId) {
@@ -52,8 +73,9 @@ export function decomposeNode(spec, nodeId) {
   if (sentences.length < 2) return { spec: next, added: [] };
 
   const existingIds = list.map((i) => i.id);
+  const dotted = isDottedId(nodeId);
   const added = sentences.map((sentence) => {
-    const id = nextId(existingIds, meta.prefix);
+    const id = dotted ? childId(nodeId, existingIds) : nextId(existingIds, meta.prefix);
     existingIds.push(id);
     const item = { id, title: sentence.slice(0, 80), description: sentence };
     if (meta.linkField) item[meta.linkField] = [...(parent[meta.linkField] || [])];

--- a/.github/extensions/srs-navigator/lib/demo-spec.mjs
+++ b/.github/extensions/srs-navigator/lib/demo-spec.mjs
@@ -4,40 +4,40 @@ export const DEMO_SPEC = {
   description: "Customer Relationship Management System Specification",
   version: "1.0",
   problems: [
-    { id: "CP-1", title: "Scattered Customer Information", description: "Sales teams waste valuable time searching for customer information across multiple disconnected systems." },
-    { id: "CP-2", title: "Missed Follow-ups and Lost Opportunities", description: "Without a systematic way to track interactions, sales reps miss important touchpoints." },
-    { id: "CP-3", title: "Lack of Sales Pipeline Visibility", description: "Sales managers have no clear, real-time view of pipeline status or performance metrics." },
-    { id: "CP-4", title: "Inefficient Lead Management", description: "New leads from various sources are manually entered with no standardized process." },
-    { id: "CP-5", title: "No Customer Communication History", description: "No shared record of previous conversations or commitments across team members." }
+    { id: "CP.01", title: "Scattered Customer Information", description: "Sales teams waste valuable time searching for customer information across multiple disconnected systems." },
+    { id: "CP.02", title: "Missed Follow-ups and Lost Opportunities", description: "Without a systematic way to track interactions, sales reps miss important touchpoints." },
+    { id: "CP.03", title: "Lack of Sales Pipeline Visibility", description: "Sales managers have no clear, real-time view of pipeline status or performance metrics." },
+    { id: "CP.04", title: "Inefficient Lead Management", description: "New leads from various sources are manually entered with no standardized process." },
+    { id: "CP.05", title: "No Customer Communication History", description: "No shared record of previous conversations or commitments across team members." }
   ],
   needs: [
-    { id: "CN-1", title: "Centralized Customer Database", description: "A single searchable repository for all customer information.", problemIds: ["CP-1", "CP-5"] },
-    { id: "CN-2", title: "Automated Task and Follow-up Management", description: "Automatic follow-up tasks and reminders based on interactions.", problemIds: ["CP-2"] },
-    { id: "CN-3", title: "Visual Sales Pipeline Management", description: "Visual deal progression through stages with metrics.", problemIds: ["CP-3"] },
-    { id: "CN-4", title: "Automated Lead Capture and Routing", description: "Automatic lead capture, qualification, and intelligent routing.", problemIds: ["CP-4"] },
-    { id: "CN-5", title: "Comprehensive Activity Tracking", description: "Automatic logging of all customer touchpoints.", problemIds: ["CP-5"] },
-    { id: "CN-6", title: "Real-time Reporting and Analytics", description: "Customizable dashboards with real-time sales metrics.", problemIds: ["CP-3"] },
-    { id: "CN-7", title: "Mobile Access to Customer Data", description: "Full mobile access with offline capability.", problemIds: ["CP-1", "CP-2"] }
+    { id: "CN.01.1", title: "Centralized Customer Database", description: "A single searchable repository for all customer information.", problemIds: ["CP.01", "CP.05"] },
+    { id: "CN.02.1", title: "Automated Task and Follow-up Management", description: "Automatic follow-up tasks and reminders based on interactions.", problemIds: ["CP.02"] },
+    { id: "CN.03.1", title: "Visual Sales Pipeline Management", description: "Visual deal progression through stages with metrics.", problemIds: ["CP.03"] },
+    { id: "CN.04.1", title: "Automated Lead Capture and Routing", description: "Automatic lead capture, qualification, and intelligent routing.", problemIds: ["CP.04"] },
+    { id: "CN.05.1", title: "Comprehensive Activity Tracking", description: "Automatic logging of all customer touchpoints.", problemIds: ["CP.05"] },
+    { id: "CN.03.2", title: "Real-time Reporting and Analytics", description: "Customizable dashboards with real-time sales metrics.", problemIds: ["CP.03"] },
+    { id: "CN.01.2", title: "Mobile Access to Customer Data", description: "Full mobile access with offline capability.", problemIds: ["CP.01", "CP.02"] }
   ],
   functionalRequirements: [
-    { id: "FR-1", title: "Contact and Company Management", description: "Database with hierarchical relationships, custom fields, and search.", needIds: ["CN-1"] },
-    { id: "FR-2", title: "Activity Logging Interface", description: "Logging calls, emails, meetings with timeline view.", needIds: ["CN-5"] },
-    { id: "FR-3", title: "Task Management System", description: "Tasks with due dates, priorities, and automated creation.", needIds: ["CN-2"] },
-    { id: "FR-4", title: "Pipeline Visualization", description: "Kanban-style board with drag-and-drop deal management.", needIds: ["CN-3"] },
-    { id: "FR-5", title: "Lead Capture Forms and API", description: "Embeddable forms and REST API for lead submission.", needIds: ["CN-4"] },
-    { id: "FR-6", title: "Lead Qualification and Scoring", description: "Scoring system based on attributes and behaviors.", needIds: ["CN-4"] },
-    { id: "FR-7", title: "Automated Lead Assignment", description: "Rule engine for lead routing based on criteria.", needIds: ["CN-4"] },
-    { id: "FR-8", title: "Dashboard and Reporting Engine", description: "Pre-built widgets and custom report builder.", needIds: ["CN-6"] },
-    { id: "FR-9", title: "Mobile Application", description: "Native mobile apps with offline caching.", needIds: ["CN-7"] },
-    { id: "FR-10", title: "Email Integration", description: "Two-way email sync with tracking.", needIds: ["CN-5", "CN-7"] },
-    { id: "FR-11", title: "Calendar Integration", description: "Sync with external calendars.", needIds: ["CN-2", "CN-5"] },
-    { id: "FR-12", title: "User and Permission Management", description: "Role-based access control with team hierarchies.", needIds: ["CN-1", "CN-6"] }
+    { id: "FR.01.1.1", title: "Contact and Company Management", description: "Database with hierarchical relationships, custom fields, and search.", needIds: ["CN.01.1"] },
+    { id: "FR.05.1.1", title: "Activity Logging Interface", description: "Logging calls, emails, meetings with timeline view.", needIds: ["CN.05.1"] },
+    { id: "FR.02.1.1", title: "Task Management System", description: "Tasks with due dates, priorities, and automated creation.", needIds: ["CN.02.1"] },
+    { id: "FR.03.1.1", title: "Pipeline Visualization", description: "Kanban-style board with drag-and-drop deal management.", needIds: ["CN.03.1"] },
+    { id: "FR.04.1.1", title: "Lead Capture Forms and API", description: "Embeddable forms and REST API for lead submission.", needIds: ["CN.04.1"] },
+    { id: "FR.04.1.2", title: "Lead Qualification and Scoring", description: "Scoring system based on attributes and behaviors.", needIds: ["CN.04.1"] },
+    { id: "FR.04.1.3", title: "Automated Lead Assignment", description: "Rule engine for lead routing based on criteria.", needIds: ["CN.04.1"] },
+    { id: "FR.03.2.1", title: "Dashboard and Reporting Engine", description: "Pre-built widgets and custom report builder.", needIds: ["CN.03.2"] },
+    { id: "FR.01.2.1", title: "Mobile Application", description: "Native mobile apps with offline caching.", needIds: ["CN.01.2"] },
+    { id: "FR.05.1.2", title: "Email Integration", description: "Two-way email sync with tracking.", needIds: ["CN.05.1", "CN.01.2"] },
+    { id: "FR.02.1.2", title: "Calendar Integration", description: "Sync with external calendars.", needIds: ["CN.02.1", "CN.05.1"] },
+    { id: "FR.01.1.2", title: "User and Permission Management", description: "Role-based access control with team hierarchies.", needIds: ["CN.01.1", "CN.03.2"] }
   ],
   nonFunctionalRequirements: [
-    { id: "NFR-1", title: "Performance", description: "Page load < 2s, search results < 500ms.", needIds: ["CN-1", "CN-6"] },
-    { id: "NFR-2", title: "Security", description: "SOC2 compliance, encryption at rest and in transit.", needIds: ["CN-1"] },
-    { id: "NFR-3", title: "Scalability", description: "Support 10,000+ concurrent users.", needIds: ["CN-1", "CN-4"] },
-    { id: "NFR-4", title: "Availability", description: "99.9% uptime SLA.", needIds: ["CN-7"] },
-    { id: "NFR-5", title: "Usability", description: "Intuitive UI requiring < 2hr onboarding.", needIds: ["CN-3", "CN-7"] }
+    { id: "NFR.01", title: "Performance", description: "Page load < 2s, search results < 500ms.", needIds: ["CN.01.1", "CN.03.2"] },
+    { id: "NFR.02", title: "Security", description: "SOC2 compliance, encryption at rest and in transit.", needIds: ["CN.01.1"] },
+    { id: "NFR.03", title: "Scalability", description: "Support 10,000+ concurrent users.", needIds: ["CN.01.1", "CN.04.1"] },
+    { id: "NFR.04", title: "Availability", description: "99.9% uptime SLA.", needIds: ["CN.01.2"] },
+    { id: "NFR.05", title: "Usability", description: "Intuitive UI requiring < 2hr onboarding.", needIds: ["CN.03.1", "CN.01.2"] }
   ]
 };

--- a/.github/extensions/srs-navigator/lib/notation.mjs
+++ b/.github/extensions/srs-navigator/lib/notation.mjs
@@ -31,6 +31,18 @@ export function idSource(prefixes) {
 }
 
 /**
+ * Build an anchored regex that validates a complete identifier, used to gate
+ * specification JSON. Accepts canonical dotted IDs (CP.01, FR.01.1.1) and
+ * legacy hyphen IDs (CP-1, FR-001). Rejecting dotted IDs here used to make the
+ * canvas refuse every spec written in the methodology's own canonical notation.
+ * @param {string[]} prefixes e.g. ["CP", "P"]
+ * @returns {RegExp}
+ */
+export function idPattern(prefixes) {
+  return new RegExp(String.raw`^${idSource(prefixes)}$`, "i");
+}
+
+/**
  * Build a global, case-insensitive regex that finds references to any of the
  * given prefixes in free text (e.g. "Addresses CP.01 and CP-2").
  * @param {string[]} prefixes

--- a/.github/extensions/srs-navigator/lib/notation.mjs
+++ b/.github/extensions/srs-navigator/lib/notation.mjs
@@ -1,0 +1,98 @@
+// Single source of truth for Problem-Based SRS identifier notation.
+//
+// The methodology's canonical notation is DOTTED, encoding traceability in the
+// ID itself:
+//
+//   CP.01            a Customer Problem
+//   CN.01.1          a Customer Need addressing CP.01
+//   FR.01.1.1        a Functional Requirement implementing CN.01.1
+//
+// HYPHEN notation (CP-1, CP-001, FR-001) is accepted as legacy so specs written
+// before the canonical notation was settled — and the bundled demo spec — keep
+// rendering. Both parsers (lib/parser.mjs and lib/spec-compiler.mjs) build their
+// regexes from here so the two can never drift apart again.
+
+/** Prefixes used for graph node IDs, including the parser's bare fallbacks. */
+export const ID_PREFIXES = ["CP", "CN", "FR", "NFR", "P", "N"];
+
+// First separator may be "-" (legacy) or "." (canonical); any further levels
+// are dot-separated only. Keeping subsequent levels dot-only means a filename
+// like "FR-001-client-registration.md" still yields the ID "FR-001" rather than
+// swallowing the short-name suffix.
+const LEVELS = String.raw`\d+(?:\.\d+)*`;
+
+/**
+ * Regex source matching one identifier for the given prefix alternatives.
+ * @param {string[]} prefixes e.g. ["CP", "P"]
+ * @returns {string} regex source, with the ID as the whole match
+ */
+export function idSource(prefixes) {
+  return `(?:${prefixes.join("|")})[-.]${LEVELS}`;
+}
+
+/**
+ * Build a global, case-insensitive regex that finds references to any of the
+ * given prefixes in free text (e.g. "Addresses CP.01 and CP-2").
+ * @param {string[]} prefixes
+ * @returns {RegExp}
+ */
+export function refPattern(prefixes) {
+  return new RegExp(String.raw`\b(${idSource(prefixes)})\b`, "gi");
+}
+
+/**
+ * Build a regex matching a markdown heading that carries an ID, tolerating the
+ * bracketed and bare forms the methodology templates emit:
+ *
+ *   ### [CP-1] Title      ### CP-001: Title      ### CP.01 Title
+ *
+ * @param {string} prefix e.g. "CP"
+ * @param {string} hashes heading level, e.g. "###"
+ * @param {string} flags  extra regex flags (default "gmi")
+ * @returns {RegExp} capture 1 = ID, capture 2 = title
+ */
+export function headingPattern(prefix, hashes = "###", flags = "gmi") {
+  return new RegExp(
+    String.raw`^${hashes}\s+\[?(${idSource([prefix])})\]?[:\s-]*\s*(.+)`,
+    flags
+  );
+}
+
+/**
+ * Match an ID anywhere inside a heading string, bracketed or bare.
+ * @param {string} heading
+ * @returns {string|undefined} the upper-cased ID, if present
+ */
+export function extractHeadingId(heading) {
+  const m = String(heading ?? "").match(
+    new RegExp(String.raw`\[(${idSource(ID_PREFIXES)})\]|^\s*(${idSource(ID_PREFIXES)})\b`, "i")
+  );
+  return (m?.[1] ?? m?.[2])?.toUpperCase();
+}
+
+/**
+ * Strip a leading ID (bracketed or bare, with optional ":" / "-" separator)
+ * from a heading, leaving the human title.
+ * @param {string} heading
+ * @returns {string}
+ */
+export function stripHeadingId(heading) {
+  return String(heading ?? "")
+    .replace(new RegExp(String.raw`^\s*\[(?:${idSource(ID_PREFIXES)})\]\s*[:\-]?\s*`, "i"), "")
+    .replace(new RegExp(String.raw`^\s*(?:${idSource(ID_PREFIXES)})\s*[:\-]\s*`, "i"), "")
+    .replace(new RegExp(String.raw`^\s*(?:${idSource(ID_PREFIXES)})\s+`, "i"), "")
+    .trim();
+}
+
+/**
+ * Build a regex matching per-requirement filenames, tolerating dotted IDs and
+ * the documented "-[short-name]" suffix:
+ *
+ *   FR-001.md   FR-001-client-registration.md   FR.01.1.1-client-registration.md
+ *
+ * @param {string} prefix "FR" or "NFR"
+ * @returns {RegExp}
+ */
+export function requirementFilePattern(prefix) {
+  return new RegExp(String.raw`^${prefix}[-.]${LEVELS}(?:-[^.]*)?\.md$`, "i");
+}

--- a/.github/extensions/srs-navigator/lib/parser.mjs
+++ b/.github/extensions/srs-navigator/lib/parser.mjs
@@ -2,8 +2,14 @@
 // Parses markdown and JSON specifications into graph data structures
 
 import { extractRefs } from "./text-refs.mjs";
+import { refPattern, extractHeadingId, stripHeadingId } from "./notation.mjs";
 
 const MAX_INPUT_SIZE = 2 * 1024 * 1024; // 2 MB
+
+// Reference patterns are rebuilt per use because they carry the /g flag
+// (a shared global regex would carry lastIndex between calls).
+const CP_REFS = () => refPattern(["CP", "P"]);
+const CN_REFS = () => refPattern(["CN", "N"]);
 
 /**
  * Parse sub-items from a markdown section using a line-by-line approach
@@ -17,8 +23,8 @@ function parseSubItems(section) {
   for (const line of lines) {
     if (line.startsWith('### ')) {
       if (currentHeader !== undefined) {
-        const id = currentHeader.match(/\[(\w+-\d+)\]/)?.[1]?.toUpperCase();
-        const title = currentHeader.replace(/\[[\w-]+\]\s*/, '').trim();
+        const id = extractHeadingId(currentHeader);
+        const title = stripHeadingId(currentHeader);
         items.push({ id, title, content: currentContent.join('\n').trim() });
       }
       currentHeader = line.slice(4).trim();
@@ -29,8 +35,8 @@ function parseSubItems(section) {
   }
 
   if (currentHeader !== undefined) {
-    const id = currentHeader.match(/\[(\w+-\d+)\]/)?.[1]?.toUpperCase();
-    const title = currentHeader.replace(/\[[\w-]+\]\s*/, '').trim();
+    const id = extractHeadingId(currentHeader);
+    const title = stripHeadingId(currentHeader);
     items.push({ id, title, content: currentContent.join('\n').trim() });
   }
 
@@ -70,7 +76,7 @@ export function parseSpecificationData(rawData) {
           id: id || `N-${needs.length + 1}`,
           title,
           description: content,
-          problemIds: extractRefs(content, /\b(CP-\d+|P-\d+)\b/gi)
+          problemIds: extractRefs(content, CP_REFS())
         });
       }
     } else if (trimmedSection.match(/^#\s+Functional\s*Requirements?/i)) {
@@ -79,7 +85,7 @@ export function parseSpecificationData(rawData) {
           id: id || `FR-${functionalRequirements.length + 1}`,
           title,
           description: content,
-          needIds: extractRefs(content, /\b(CN-\d+|N-\d+)\b/gi)
+          needIds: extractRefs(content, CN_REFS())
         });
       }
     } else if (trimmedSection.match(/^#\s+Non-?Functional\s*Requirements?/i)) {
@@ -88,7 +94,7 @@ export function parseSpecificationData(rawData) {
           id: id || `NFR-${nonFunctionalRequirements.length + 1}`,
           title,
           description: content,
-          needIds: extractRefs(content, /\b(CN-\d+|N-\d+)\b/gi)
+          needIds: extractRefs(content, CN_REFS())
         });
       }
     }

--- a/.github/extensions/srs-navigator/lib/spec-compiler.mjs
+++ b/.github/extensions/srs-navigator/lib/spec-compiler.mjs
@@ -4,6 +4,11 @@
 import { readFile, readdir, writeFile, stat } from "node:fs/promises";
 import { join, basename } from "node:path";
 import { extractRefs } from "./text-refs.mjs";
+import { refPattern, headingPattern, requirementFilePattern } from "./notation.mjs";
+
+// Rebuilt per use: these carry /g, and a shared instance would retain lastIndex.
+const CP_REFS = () => refPattern(["CP"]);
+const CN_REFS = () => refPattern(["CN"]);
 
 /**
  * Scan .spec/ folder for markdown artifacts and compile into a JSON specification.
@@ -43,7 +48,7 @@ export async function compileSpecFromFolder(specDir) {
                 id: item.id,
                 title: item.title,
                 description: item.description,
-                problemIds: extractRefs(item.description, /\bCP-\d+\b/gi)
+                problemIds: extractRefs(item.description, CP_REFS())
             });
         }
     } catch { /* file may not exist yet */ }
@@ -53,7 +58,7 @@ export async function compileSpecFromFolder(specDir) {
         const frDir = join(specDir, "functional-requirements");
         const frStat = await stat(frDir);
         if (frStat.isDirectory()) {
-            const files = (await readdir(frDir)).filter(f => f.match(/^FR-\d+\.md$/i)).sort();
+            const files = (await readdir(frDir)).filter(f => requirementFilePattern("FR").test(f)).sort();
             for (const file of files) {
                 const content = await readFile(join(frDir, file), "utf-8");
                 const fr = parseSingleRequirement(content, "FR", basename(file, ".md"));
@@ -72,7 +77,7 @@ export async function compileSpecFromFolder(specDir) {
                     id: item.id,
                     title: item.title,
                     description: item.description,
-                    needIds: extractRefs(item.description, /\bCN-\d+\b/gi)
+                    needIds: extractRefs(item.description, CN_REFS())
                 });
             }
         } catch { /* optional */ }
@@ -83,7 +88,7 @@ export async function compileSpecFromFolder(specDir) {
         const nfrDir = join(specDir, "non-functional-requirements");
         const nfrStat = await stat(nfrDir);
         if (nfrStat.isDirectory()) {
-            const files = (await readdir(nfrDir)).filter(f => f.match(/^NFR-\d+\.md$/i)).sort();
+            const files = (await readdir(nfrDir)).filter(f => requirementFilePattern("NFR").test(f)).sort();
             for (const file of files) {
                 const content = await readFile(join(nfrDir, file), "utf-8");
                 const nfr = parseSingleRequirement(content, "NFR", basename(file, ".md"));
@@ -101,7 +106,7 @@ export async function compileSpecFromFolder(specDir) {
                     id: item.id,
                     title: item.title,
                     description: item.description,
-                    needIds: extractRefs(item.description, /\bCN-\d+\b/gi)
+                    needIds: extractRefs(item.description, CN_REFS())
                 });
             }
         } catch { /* optional */ }
@@ -151,14 +156,13 @@ export async function compileAndSave(specDir) {
  *   ### [CP-1] Title
  *   ### CP-1: Title
  *   ### CP-001 Title
+ *   ### CP.01: Title          (canonical dotted notation)
+ *   ### [CN.01.1] Title       (canonical, multi-level)
  */
 function parseItemsFromMarkdown(content, prefix) {
     const items = [];
-    // Match section headers with IDs
-    const headerPattern = new RegExp(
-        `^###\\s+(?:\\[?(${prefix}-\\d+)\\]?[:\\s-]*)\\s*(.+)`,
-        "gmi"
-    );
+    // Match section headers with IDs (dotted canonical or hyphen legacy).
+    const headerPattern = headingPattern(prefix, "###");
 
     let match;
     const matches = [];
@@ -187,8 +191,8 @@ function parseItemsFromMarkdown(content, prefix) {
  * Parse a single FR/NFR file into a requirement object.
  */
 function parseSingleRequirement(content, prefix, fallbackId) {
-    // Extract ID from header: # FR-001: Title or # FR-001 Title
-    const headerMatch = content.match(new RegExp(`^#\\s+(?:\\[?(${prefix}-\\d+)\\]?)[:\\s-]*\\s*(.+)`, "mi"));
+    // Extract ID from header: # FR-001: Title, # FR.01.1.1 Title, # [FR-1] Title
+    const headerMatch = content.match(headingPattern(prefix, "#", "mi"));
     const id = headerMatch ? headerMatch[1].toUpperCase() : fallbackId.toUpperCase();
     const title = headerMatch ? headerMatch[2].trim() : fallbackId;
 
@@ -197,7 +201,7 @@ function parseSingleRequirement(content, prefix, fallbackId) {
     const description = stmtMatch ? stmtMatch[1].trim() : "";
 
     // Extract need references from traceability section or full content
-    const needIds = extractRefs(content, /\bCN-\d+\b/gi);
+    const needIds = extractRefs(content, CN_REFS());
 
     return { id, title, description, needIds };
 }

--- a/.github/extensions/srs-navigator/lib/validation.mjs
+++ b/.github/extensions/srs-navigator/lib/validation.mjs
@@ -1,11 +1,15 @@
 // Validation logic ported from the Problem-Based SRS Navigator
 // Validates specification JSON against expected schema and reference integrity
 
+import { idPattern } from "./notation.mjs";
+
+// Canonical dotted IDs and legacy hyphen IDs are both accepted; the shapes come
+// from lib/notation.mjs so this gate can never drift from the two parsers.
 const ID_PATTERNS = {
-  problem: /^(CP|P)-\d+$/,
-  need: /^(CN|N)-\d+$/,
-  fr: /^FR-\d+$/,
-  nfr: /^NFR-\d+$/
+  problem: idPattern(["CP", "P"]),
+  need: idPattern(["CN", "N"]),
+  fr: idPattern(["FR"]),
+  nfr: idPattern(["NFR"])
 };
 
 /**
@@ -69,10 +73,10 @@ export function validateSpecificationJSON(data) {
     return validated;
   };
 
-  const problems = validateArray(data.problems || [], 'problems', ID_PATTERNS.problem, 'Problem (CP-X or P-X)');
-  const needs = validateArray(data.needs || [], 'needs', ID_PATTERNS.need, 'Need (CN-X or N-X)');
-  const functionalRequirements = validateArray(data.functionalRequirements || [], 'functionalRequirements', ID_PATTERNS.fr, 'FR (FR-X)');
-  const nonFunctionalRequirements = validateArray(data.nonFunctionalRequirements || [], 'nonFunctionalRequirements', ID_PATTERNS.nfr, 'NFR (NFR-X)');
+  const problems = validateArray(data.problems || [], 'problems', ID_PATTERNS.problem, 'Problem (CP.01 or CP-1)');
+  const needs = validateArray(data.needs || [], 'needs', ID_PATTERNS.need, 'Need (CN.01.1 or CN-1)');
+  const functionalRequirements = validateArray(data.functionalRequirements || [], 'functionalRequirements', ID_PATTERNS.fr, 'FR (FR.01.1.1 or FR-1)');
+  const nonFunctionalRequirements = validateArray(data.nonFunctionalRequirements || [], 'nonFunctionalRequirements', ID_PATTERNS.nfr, 'NFR (NFR.01 or NFR-1)');
 
   if (errors.length > 0) {
     return { success: false, errors };

--- a/.github/extensions/srs-navigator/package.json
+++ b/.github/extensions/srs-navigator/package.json
@@ -9,7 +9,7 @@
     "test": "tests"
   },
   "scripts": {
-    "test": "node --test tests/parser.test.mjs tests/validation.test.mjs tests/renderer.test.mjs tests/action-bar.test.mjs tests/integration.test.mjs tests/decompose.test.mjs tests/skill-sync.test.mjs tests/interview-guard.test.mjs tests/http-guard.test.mjs tests/text-refs.test.mjs tests/notation.test.mjs tests/test-wiring.test.mjs",
+    "test": "node --test tests/parser.test.mjs tests/validation.test.mjs tests/renderer.test.mjs tests/action-bar.test.mjs tests/integration.test.mjs tests/decompose.test.mjs tests/skill-sync.test.mjs tests/interview-guard.test.mjs tests/http-guard.test.mjs tests/text-refs.test.mjs tests/notation.test.mjs tests/serve-canvas.test.mjs tests/test-wiring.test.mjs",
     "test:skill-behavior": "node --test tests/skill-behavior/*.test.mjs",
     "test:e2e": "playwright test",
     "sync-skills": "node scripts/sync-skills.mjs"

--- a/.github/extensions/srs-navigator/package.json
+++ b/.github/extensions/srs-navigator/package.json
@@ -9,7 +9,7 @@
     "test": "tests"
   },
   "scripts": {
-    "test": "node --test tests/parser.test.mjs tests/validation.test.mjs tests/renderer.test.mjs tests/action-bar.test.mjs tests/integration.test.mjs tests/decompose.test.mjs tests/skill-sync.test.mjs tests/interview-guard.test.mjs",
+    "test": "node --test tests/parser.test.mjs tests/validation.test.mjs tests/renderer.test.mjs tests/action-bar.test.mjs tests/integration.test.mjs tests/decompose.test.mjs tests/skill-sync.test.mjs tests/interview-guard.test.mjs tests/http-guard.test.mjs tests/text-refs.test.mjs tests/notation.test.mjs tests/test-wiring.test.mjs",
     "test:skill-behavior": "node --test tests/skill-behavior/*.test.mjs",
     "test:e2e": "playwright test",
     "sync-skills": "node scripts/sync-skills.mjs"

--- a/.github/extensions/srs-navigator/playwright.config.mjs
+++ b/.github/extensions/srs-navigator/playwright.config.mjs
@@ -1,5 +1,8 @@
 import { defineConfig } from '@playwright/test';
 
+const PORT = Number(process.env.CANVAS_PORT) || 56107;
+const BASE_URL = process.env.CANVAS_URL || `http://127.0.0.1:${PORT}/`;
+
 export default defineConfig({
   testDir: './tests',
   testMatch: 'visual.test.mjs',
@@ -7,5 +10,17 @@ export default defineConfig({
   use: {
     headless: true,
     viewport: { width: 1280, height: 800 },
+    baseURL: BASE_URL,
   },
+  // Start the canvas ourselves so `npm run test:e2e` is self-contained. Without
+  // this the suite pointed at a port nothing was listening on and never ran.
+  // Set CANVAS_URL to test against an already-running canvas instead.
+  webServer: process.env.CANVAS_URL
+    ? undefined
+    : {
+        command: `node scripts/serve-canvas.mjs --port ${PORT}`,
+        url: `http://127.0.0.1:${PORT}/health`,
+        reuseExistingServer: !process.env.CI,
+        timeout: 30000,
+      },
 });

--- a/.github/extensions/srs-navigator/scripts/serve-canvas.mjs
+++ b/.github/extensions/srs-navigator/scripts/serve-canvas.mjs
@@ -1,0 +1,91 @@
+#!/usr/bin/env node
+// Serve the SRS Navigator canvas for end-to-end tests and local preview.
+//
+// The Playwright visual suite used to point at a hardcoded http://127.0.0.1:56107
+// that nothing started, so `npm run test:e2e` only worked if someone had already
+// launched the extension by hand — which meant the suite effectively never ran.
+// This renders the bundled demo spec through the same pipeline the extension uses
+// (validate -> convert -> graph -> HTML) and serves it, so the e2e suite is
+// self-contained.
+//
+// Usage:
+//   node scripts/serve-canvas.mjs              # serve on 127.0.0.1:56107
+//   node scripts/serve-canvas.mjs --port 8080
+//   node scripts/serve-canvas.mjs --spec ../../../.spec/crm-system.json
+
+import { createServer } from "node:http";
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { buildGraphData, convertJSONToSpecificationData } from "../lib/parser.mjs";
+import { validateSpecificationJSON } from "../lib/validation.mjs";
+import { renderGraphHtml } from "../lib/renderer.mjs";
+import { DEMO_SPEC } from "../lib/demo-spec.mjs";
+
+const HERE = path.dirname(fileURLToPath(import.meta.url));
+
+export const DEFAULT_PORT = 56107;
+export const DEFAULT_HOST = "127.0.0.1";
+
+function parseArgs(argv) {
+  const opts = { port: Number(process.env.CANVAS_PORT) || DEFAULT_PORT, host: DEFAULT_HOST, spec: null };
+  for (let i = 0; i < argv.length; i++) {
+    if (argv[i] === "--port") opts.port = Number(argv[++i]);
+    else if (argv[i] === "--host") opts.host = argv[++i];
+    else if (argv[i] === "--spec") opts.spec = argv[++i];
+  }
+  return opts;
+}
+
+/** Render a specification object to the canvas HTML the extension would show. */
+export function renderSpecHtml(spec) {
+  const validation = validateSpecificationJSON(spec);
+  if (!validation.success) {
+    throw new Error(`Specification is invalid:\n  - ${validation.errors.join("\n  - ")}`);
+  }
+  const graphData = buildGraphData(convertJSONToSpecificationData(validation.data));
+  return renderGraphHtml(graphData, { title: spec.name || "SRS Navigator" });
+}
+
+async function loadSpec(specPath) {
+  if (!specPath) return DEMO_SPEC;
+  const resolved = path.isAbsolute(specPath) ? specPath : path.resolve(HERE, specPath);
+  return JSON.parse(await readFile(resolved, "utf8"));
+}
+
+/**
+ * Start the canvas server. Returns { server, url, close } so tests and scripts
+ * can await a listening server rather than racing a fixed sleep.
+ */
+export async function startCanvasServer({ port = DEFAULT_PORT, host = DEFAULT_HOST, spec = DEMO_SPEC } = {}) {
+  const html = renderSpecHtml(spec);
+  const server = createServer((req, res) => {
+    if (req.url === "/health") {
+      res.writeHead(200, { "Content-Type": "application/json" });
+      res.end(JSON.stringify({ ok: true }));
+      return;
+    }
+    res.writeHead(200, { "Content-Type": "text/html; charset=utf-8" });
+    res.end(html);
+  });
+
+  await new Promise((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(port, host, resolve);
+  });
+
+  const actual = server.address().port;
+  return {
+    server,
+    url: `http://${host}:${actual}/`,
+    close: () => new Promise((resolve) => server.close(resolve)),
+  };
+}
+
+const isMain = process.argv[1] && path.resolve(process.argv[1]) === fileURLToPath(import.meta.url);
+if (isMain) {
+  const opts = parseArgs(process.argv.slice(2));
+  const spec = await loadSpec(opts.spec);
+  const { url } = await startCanvasServer({ port: opts.port, host: opts.host, spec });
+  console.log(`SRS Navigator canvas serving ${spec.name} at ${url}`);
+}

--- a/.github/extensions/srs-navigator/skills/functional-requirements.md
+++ b/.github/extensions/srs-navigator/skills/functional-requirements.md
@@ -64,7 +64,7 @@ This is a required interaction. STOP and ask the user to clarify what you cannot
 #### What to Ask (adapt to context)
 
 **Round 1 — Scope and Detail:**
-- Should we specify requirements for ALL Customer Needs, or focus on a specific subset? (e.g., "Start with CN-001 through CN-003 for the MVP")
+- Should we specify requirements for ALL Customer Needs, or focus on a specific subset? (e.g., "Start with CN.01.1 through CN.01.3 for the MVP")
 - What level of detail is needed? (Full acceptance criteria per FR, or high-level "shall" statements first?)
 - Are there known technical constraints that should shape the requirements? (e.g., "must work offline", "must support REST APIs")
 
@@ -92,7 +92,7 @@ When skipping, state in one line what you're using as the basis and proceed.
 **Every FR in the response MUST include:**
 
 1. **The "shall" statement** — written out explicitly using the grammar: `The [System] shall [verb] [object]`
-2. **CN traceability** — each FR MUST show which CN it traces to (e.g., `→ CN-001`)
+2. **CN traceability** — each FR MUST show which CN it traces to (e.g., `→ CN.01.1`)
 3. **Acceptance criteria** — at least 2 testable criteria per FR
 
 **Example of CORRECT response format:**
@@ -100,8 +100,8 @@ When skipping, state in one line what you're using as the basis and proceed.
 ```markdown
 ## Functional Requirements
 
-### FR-001: Client Registration
-**Traces to:** CN-001 — Client data management
+### FR.01.1.1: Client Registration
+**Traces to:** CN.01.1 — Client data management
 
 The CRM system shall allow the Account Manager to register a new client in the database.
 
@@ -109,8 +109,8 @@ The CRM system shall allow the Account Manager to register a new client in the d
 - [ ] System accepts client name, contact info, and company details
 - [ ] System assigns unique client ID upon successful registration
 
-### FR-002: Client Data Update
-**Traces to:** CN-001 — Client data management
+### FR.01.1.2: Client Data Update
+**Traces to:** CN.01.1 — Client data management
 
 The CRM system shall allow the Account Manager to update existing client records.
 
@@ -123,7 +123,7 @@ The CRM system shall allow the Account Manager to update existing client records
 ```
 | CN | Functional Requirements |
 |----|------------------------|
-| CN.1 | FR-001 Registration, FR-002 Update |
+| CN.1 | FR.01.1.1 Registration, FR.01.1.2 Update |
 ```
 
 The wrong format above lacks "shall" statements, acceptance criteria, and proper traceability.
@@ -142,27 +142,30 @@ The wrong format above lacks "shall" statements, acceptance criteria, and proper
 .spec/
 ├── functional-requirements/
 │   ├── _index.md                    # Summary and traceability matrix
-│   ├── FR-001-[short-name].md       # Individual FR file
-│   ├── FR-002-[short-name].md
+│   ├── FR.01.1.1-[short-name].md    # Individual FR file
+│   ├── FR.01.1.2-[short-name].md
 │   └── ...
 └── non-functional-requirements/
     ├── _index.md                    # Summary
-    ├── NFR-001-[short-name].md      # Individual NFR file
+    ├── NFR.01-[short-name].md       # Individual NFR file
     └── ...
 ```
 
 ### File Naming Convention
 
 ```
-FR-[NNN]-[short-descriptive-name].md
-NFR-[NNN]-[short-descriptive-name].md
+FR.[CP].[CN].[N]-[short-descriptive-name].md
+NFR.[N]-[short-descriptive-name].md
 ```
 
+Where `[CP]`/`[CN]` are the parent Customer Problem and Customer Need numbers, so the
+filename itself carries the traceability chain (see "Identifier Notation" in `SKILL.md`).
+
 Examples:
-- `FR-001-client-registration.md`
-- `FR-002-client-data-modification.md`
-- `NFR-001-response-time.md`
-- `NFR-002-data-encryption.md`
+- `FR.01.1.1-client-registration.md`
+- `FR.01.1.2-client-data-modification.md`
+- `NFR.01-response-time.md`
+- `NFR.02-data-encryption.md`
 
 ---
 
@@ -202,11 +205,11 @@ Where:
 Each FR file MUST follow this template:
 
 ```markdown
-## FR-[NNN]: [Brief Title]
+## FR.[CP].[CN].[N]: [Brief Title]
 
 ## Requirement
 
-**ID:** FR-[NNN]  
+**ID:** FR.[CP].[CN].[N]  
 **Title:** [Descriptive title]  
 **Priority:** [Must Have | Should Have | Could Have | Won't Have]  
 **Status:** [Draft | Review | Approved | In Progress | Implemented | Tested]
@@ -219,8 +222,8 @@ The [System] shall [verb] [object] [constraint] [condition].
 
 | Traces To | ID | Description |
 |-----------|-----|-------------|
-| Customer Need | CN-[X] | [CN description] |
-| Customer Problem | CP-[Y] | [CP description] |
+| Customer Need | CN.[CP].[X] | [CN description] |
+| Customer Problem | CP.[Y] | [CP description] |
 
 ## Acceptance Criteria
 
@@ -249,11 +252,11 @@ The [System] shall [verb] [object] [constraint] [condition].
 Each NFR file MUST follow this template:
 
 ```markdown
-## NFR-[NNN]: [Brief Title]
+## NFR.[N]: [Brief Title]
 
 ## Requirement
 
-**ID:** NFR-[NNN]  
+**ID:** NFR.[N]  
 **Title:** [Descriptive title]  
 **Category:** [Performance | Security | Usability | Reliability | Scalability | Maintainability]  
 **Priority:** [Must Have | Should Have | Could Have | Won't Have]  
@@ -267,8 +270,8 @@ The [System] shall [quality attribute] [measurable target] [condition].
 
 | Traces To | ID | Description |
 |-----------|-----|-------------|
-| Customer Need | CN-[X] | [CN description] |
-| Applies To FRs | FR-[A], FR-[B] | [Related FRs] |
+| Customer Need | CN.[CP].[X] | [CN description] |
+| Applies To FRs | FR.[A], FR.[B] | [Related FRs] |
 
 ## Measurement Criteria
 
@@ -339,14 +342,14 @@ Construction and implementation details belong in separate design documents:
 
 ## Examples
 
-### Example FR File: FR-001-client-registration.md
+### Example FR File: FR.01.1.1-client-registration.md
 
 ```markdown
-## FR-001: Client Registration
+## FR.01.1.1: Client Registration
 
 ## Requirement
 
-**ID:** FR-001  
+**ID:** FR.01.1.1  
 **Title:** Client Registration  
 **Priority:** Must Have  
 **Status:** Draft
@@ -359,8 +362,8 @@ The CRM system shall allow the Account Manager to register a new client in the d
 
 | Traces To | ID | Description |
 |-----------|-----|-------------|
-| Customer Need | CN-001 | Account Manager needs system to maintain client records |
-| Customer Problem | CP-001 | Company must maintain accurate client data for compliance |
+| Customer Need | CN.01.1 | Account Manager needs system to maintain client records |
+| Customer Problem | CP.01 | Company must maintain accurate client data for compliance |
 
 ## Acceptance Criteria
 
@@ -375,14 +378,14 @@ The CRM system shall allow the Account Manager to register a new client in the d
 *Author: Requirements Team*
 ```
 
-### Example NFR File: NFR-001-response-time.md
+### Example NFR File: NFR.01-response-time.md
 
 ```markdown
-## NFR-001: Response Time
+## NFR.01: Response Time
 
 ## Requirement
 
-**ID:** NFR-001  
+**ID:** NFR.01  
 **Title:** Search Response Time  
 **Category:** Performance  
 **Priority:** Must Have  
@@ -396,8 +399,8 @@ The CRM system shall return client search results within 2 seconds under normal 
 
 | Traces To | ID | Description |
 |-----------|-----|-------------|
-| Customer Need | CN-002 | Users need quick access to client information |
-| Applies To FRs | FR-004, FR-007 | Client search and filtering functions |
+| Customer Need | CN.01.2 | Users need quick access to client information |
+| Applies To FRs | FR.01.2.1, FR.01.2.2 | Client search and filtering functions |
 
 ## Measurement Criteria
 
@@ -422,7 +425,7 @@ The CRM system shall return client search results within 2 seconds under normal 
 Before finalizing, verify:
 
 - [ ] Every FR uses syntax: The [Subject] shall [Verb] [Object] [Constraint] [Condition]
-- [ ] Every FR saved as individual file (FR-NNN-name.md)
+- [ ] Every FR saved as individual file (`FR.[CP].[CN].[N]-name.md`)
 - [ ] Every FR traces to at least one CN
 - [ ] Every CN from input is addressed by at least one FR
 - [ ] All FRs are testable with clear acceptance criteria
@@ -457,13 +460,13 @@ After completing this step:
 
 📁 Created: functional-requirements/
    ├── _index.md (N FRs total)
-   ├── FR-001-*.md → CN-001
-   ├── FR-002-*.md → CN-001
+   ├── FR.01.1.1-*.md → CN.01.1
+   ├── FR.01.1.2-*.md → CN.01.1
    └── ...
 
 📁 Created: non-functional-requirements/
    ├── _index.md (N NFRs total)
-   └── NFR-001-*.md
+   └── NFR.01-*.md
 
 📁 Updated: traceability-matrix.md
 

--- a/.github/extensions/srs-navigator/skills/functional-requirements.md
+++ b/.github/extensions/srs-navigator/skills/functional-requirements.md
@@ -235,6 +235,9 @@ The [System] shall [verb] [object] [constraint] [condition].
 
 <!-- Engineers add notes here during implementation -->
 
+<!-- ⚠️ NO CODE SNIPPETS: do not include code examples, SQL, or implementation
+     details in the requirement itself. Construction details belong in design/. -->
+
 ## Test Cases
 
 <!-- QA adds test case references here -->
@@ -287,6 +290,9 @@ The [System] shall [quality attribute] [measurable target] [condition].
 ## Implementation Notes
 
 <!-- Engineers add notes here during implementation -->
+
+<!-- ⚠️ NO CODE SNIPPETS: do not include code examples or technical
+     specifications in the requirement itself; those belong in design/. -->
 
 ---
 *Created: [Date]*  

--- a/.github/extensions/srs-navigator/skills/problem-based-srs.md
+++ b/.github/extensions/srs-navigator/skills/problem-based-srs.md
@@ -101,6 +101,30 @@ artifact, and follow it exactly:
 For a **full** run (bare `/problem-based-srs`), work through the steps in order,
 reading each `reference/<action>.md` as you reach that step.
 
+## 🔖 Identifier Notation (CANONICAL)
+
+Every artifact ID uses **dotted notation**, which encodes the traceability chain in
+the ID itself — reading an ID tells you what it descends from:
+
+| Artifact | Format | Example | Reads as |
+|----------|--------|---------|----------|
+| Customer Problem | `CP.{n}` | `CP.01` | the first customer problem |
+| Sub-problem | `CP.{n}.{m}` | `CP.01.1` | first facet of `CP.01` |
+| Customer Need | `CN.{cp}.{n}` | `CN.01.1` | first need addressing `CP.01` |
+| Functional Requirement | `FR.{cp}.{cn}.{n}` | `FR.01.1.1` | first FR implementing `CN.01.1` |
+| Non-Functional Requirement | `NFR.{n}` | `NFR.01` | the first quality requirement |
+
+**Rules:**
+
+1. **Always emit dotted IDs.** `CP.01`, `CN.01.1`, `FR.01.1.1` — never `CP.1.1` for a
+   need or other ad-hoc shapes.
+2. **An ID must state its parent.** `FR.01.1.1` implements `CN.01.1`, which addresses
+   `CP.01`. If you cannot name the parent, the artifact is not ready to be written.
+3. **Hyphen IDs (`CP-001`, `FR-002`) are legacy.** Existing specs that use them stay
+   valid and the tooling still reads them, but do NOT produce new ones.
+4. **Reference IDs verbatim in prose** (e.g. "Addresses CP.01") so traceability can be
+   extracted automatically.
+
 ## 📁 Saving Progress (CRITICAL)
 
 **IMPORTANT:** At each step, you MUST save the produced artifacts to files. Progress is NOT automatically saved between sessions.
@@ -126,12 +150,12 @@ Create the following folder structure as you progress through each step:
 ├── 04-software-vision.md             # Step 4: Architecture and scope
 ├── functional-requirements/          # Step 5: Individual FR files
 │   ├── _index.md                     # FR summary and traceability matrix
-│   ├── FR-001.md                     # Individual FR file
-│   ├── FR-002.md                     # Individual FR file
+│   ├── FR.01.1.1-[short-name].md     # Individual FR file
+│   ├── FR.01.1.2-[short-name].md     # Individual FR file
 │   └── ...                           # One file per FR
 ├── non-functional-requirements/      # NFR files (quality attributes)
 │   ├── _index.md                     # NFR summary
-│   ├── NFR-001.md                    # Individual NFR file
+│   ├── NFR.01-[short-name].md        # Individual NFR file
 │   └── ...                           # One file per NFR
 └── traceability-matrix.md            # CP → CN → FR complete mapping
 ```
@@ -238,14 +262,14 @@ Example handoff for Step 5:
 
 📁 Saved to: .spec/functional-requirements/
    ├── _index.md (summary with 8 FRs)
-   ├── FR-001.md → CN-001 (User Registration)
-   ├── FR-002.md → CN-001 (User Authentication)
-   ├── FR-003.md → CN-002 (Data Validation)
-   ├── FR-004.md → CN-002 (Error Handling)
-   ├── FR-005.md → CN-003 (Report Generation)
-   ├── FR-006.md → CN-003 (Export Functionality)
-   ├── FR-007.md → CN-004 (Search Capability)
-   └── FR-008.md → CN-004 (Filter Options)
+   ├── FR.01.1.1-user-registration.md   → CN.01.1 (User Registration)
+   ├── FR.01.1.2-user-authentication.md → CN.01.1 (User Authentication)
+   ├── FR.01.2.1-data-validation.md     → CN.01.2 (Data Validation)
+   ├── FR.01.2.2-error-handling.md      → CN.01.2 (Error Handling)
+   ├── FR.02.1.1-report-generation.md   → CN.02.1 (Report Generation)
+   ├── FR.02.1.2-export-functionality.md→ CN.02.1 (Export Functionality)
+   ├── FR.02.2.1-search-capability.md   → CN.02.2 (Search Capability)
+   └── FR.02.2.2-filter-options.md      → CN.02.2 (Filter Options)
 
 📁 Updated: .spec/traceability-matrix.md
 
@@ -459,9 +483,9 @@ Example:
 📁 Saved to: .spec/03-customer-needs.md
 
 Outputs:
-- CN-001: [Information] User needs system to display...
-- CN-002: [Control] Admin needs system to manage...
-- CN-003: [Information] Manager needs system to report...
+- CN.01.1: [Information] User needs system to display...
+- CN.01.2: [Control] Admin needs system to manage...
+- CN.02.1: [Information] Manager needs system to report...
 
 Gate Check:
 - [x] All CNs use structured notation

--- a/.github/extensions/srs-navigator/skills/problem-based-srs.md
+++ b/.github/extensions/srs-navigator/skills/problem-based-srs.md
@@ -170,82 +170,12 @@ Each Functional Requirement and Non-Functional Requirement is saved as a **separ
 4. **Traceability** is maintained at the file level
 5. **Status tracking** is easier (draft, approved, implemented, tested)
 
-### FR File Template (FR-XXX.md)
+### FR and NFR File Templates
 
-Each FR file follows this template:
-
-```markdown
-# FR-XXX: [Brief Title]
-
-## Requirement
-
-**Statement:** The [System] shall [verb] [object] [constraint] [condition].
-
-**Priority:** [Must Have | Should Have | Could Have | Won't Have]
-**Status:** [Draft | Review | Approved | Implemented | Tested]
-
-## Traceability
-
-| Traces To | ID | Description |
-|-----------|-----|-------------|
-| Customer Need | CN-XXX | [Brief CN description] |
-| Customer Problem | CP-XXX | [Brief CP description] |
-
-## Acceptance Criteria
-
-- [ ] Criterion 1 (testable)
-- [ ] Criterion 2 (testable)
-- [ ] Criterion 3 (testable)
-
-## Notes
-
-[Any additional context, assumptions, or dependencies]
-
-<!-- ⚠️ NO CODE SNIPPETS: Do not include code examples, SQL, or implementation details here.
-     Construction details belong in design/ folder (see design/implementation-notes/) -->
-
----
-*Created: [Date]*
-*Last Updated: [Date]*
-*Author: [Name]*
-```
-
-### NFR File Template (NFR-XXX.md)
-
-```markdown
-# NFR-XXX: [Brief Title]
-
-## Requirement
-
-**Category:** [Performance | Security | Usability | Reliability | Scalability | Maintainability]
-**Statement:** The [System] shall [quality attribute with measurable criteria].
-
-**Priority:** [Must Have | Should Have | Could Have | Won't Have]
-**Status:** [Draft | Review | Approved | Implemented | Tested]
-
-## Traceability
-
-| Traces To | ID | Description |
-|-----------|-----|-------------|
-| Customer Need | CN-XXX | [Brief CN description] |
-| Applies To FRs | FR-XXX, FR-YYY | [Related functional requirements] |
-
-## Acceptance Criteria
-
-- [ ] Criterion 1 (measurable)
-- [ ] Criterion 2 (measurable)
-
-## Measurement Method
-
-[How this NFR will be verified/tested]
-
-<!-- ⚠️ NO CODE SNIPPETS: Do not include code examples or implementation details here.
-     Technical specifications belong in design/ folder -->
-
----
-*Created: [Date]*
-*Last Updated: [Date]*
-```
+Both templates live in the Step 5 action file — see **Individual FR File Template**
+and **Individual NFR File Template** in `reference/functional-requirements.md`.
+Load that file before writing any requirement file so every FR/NFR has the same
+shape, the same traceability table, and the same acceptance-criteria format.
 
 ### Save After Each Step
 
@@ -380,7 +310,7 @@ Determine current step by checking what artifacts exist:
 **Input:** CNs + Software Vision  
 **Output:** Individual FR and NFR files with traceability  
 **Syntax FR:** `The [System] shall [Verb] [Object] [Constraint] [Condition]`  
-**Save to:** `functional-requirements/FR-XXX.md` and `non-functional-requirements/NFR-XXX.md`  
+**Save to:** `functional-requirements/FR.[CP].[CN].[N]-[short-name].md` and `non-functional-requirements/NFR.[N]-[short-name].md`  
 **Action:** `/problem-based-srs functional-requirements`
 
 ## Quality Gates

--- a/.github/extensions/srs-navigator/skills/problems.md
+++ b/.github/extensions/srs-navigator/skills/problems.md
@@ -152,14 +152,16 @@ Classify each CP by severity:
 
 ## Output Format
 
-**⚠ ID Format:** Always use `CP-` with a dash (e.g., `CP-001`, `CP-002`). Do NOT use dots (e.g., `CP.01`).
+**⚠ ID Format:** Always use canonical dotted notation — `CP.01`, `CP.02`, and `CP.01.1` for
+sub-problems. Hyphen IDs (`CP-001`) are legacy: still readable, but do not produce new ones.
+See "Identifier Notation" in `SKILL.md`.
 
 ### For Mode 1 (Generation)
 
 For each identified problem, produce:
 
 ```markdown
-### CP-001: [Brief Title]
+### CP.01: [Brief Title]
 
 **Statement:** [Subject] [Verb] [Object] [Penalty]
 
@@ -196,7 +198,7 @@ For each identified problem, produce:
 
 ### Example 1: Obligation
 ```markdown
-### CP-001: Regulatory Compliance
+### CP.01: Regulatory Compliance
 
 **Statement:** The company must submit emission compliance reports within 30 days of each quarter end otherwise faces fines up to 5% of revenue.
 
@@ -217,7 +219,7 @@ For each identified problem, produce:
 
 ### Example 2: Expectation
 ```markdown
-### CP-002: Customer Response Time
+### CP.02: Customer Response Time
 
 **Statement:** Customers expect responses to support inquiries within 24 hours otherwise they become dissatisfied and may switch to competitors.
 
@@ -238,7 +240,7 @@ For each identified problem, produce:
 
 ### Example 3: Hope
 ```markdown
-### CP-003: Sales Forecasting
+### CP.03: Sales Forecasting
 
 **Statement:** Management hopes to predict quarterly sales with 85% accuracy otherwise strategic planning remains reactive rather than proactive.
 
@@ -280,37 +282,37 @@ Decompose a CP into sub-CPs when:
 
 | Trigger | Example |
 |---------|---------|
-| Multiple distinct facets | CP-001 has communication AND frequency aspects |
-| Different subjects affected | CP-001 affects both company AND customers |
+| Multiple distinct facets | CP.01 has communication AND frequency aspects |
+| Different subjects affected | CP.01 affects both company AND customers |
 | Independent penalties | Failure of one aspect doesn't cause all penalties |
 | Separate solutions likely | Each facet could be solved by different FRs |
 
 ### Numbering Convention
 
 ```
-CP-001        → Main problem
-CP-001.1      → First sub-problem of CP-001
-CP-001.2      → Second sub-problem of CP-001
-CP-001.2.1    → Sub-sub-problem (rarely needed)
+CP.01          → Main problem
+CP.01.1        → First sub-problem of CP.01
+CP.01.2        → Second sub-problem of CP.01
+CP.01.2.1      → Sub-sub-problem (rarely needed)
 ```
 
 ### Decomposition Example
 
 **Before decomposition:**
 ```
-CP-001: The company must ensure effective communication with customers, 
+CP.01: The company must ensure effective communication with customers, 
       otherwise it loses customers affecting marketing and sales.
 ```
 
 **After decomposition:**
 ```
-CP-001: The company must ensure effective communication with customers, 
+CP.01: The company must ensure effective communication with customers, 
       otherwise it loses customers affecting marketing and sales.
 
-CP-001.1: The company must ensure it can contact all customers 
+CP.01.1: The company must ensure it can contact all customers 
         (having valid contact information).
 
-CP-001.2: The company must ensure each customer is contacted regularly 
+CP.01.2: The company must ensure each customer is contacted regularly 
         (frequency of communication).
 ```
 

--- a/.github/extensions/srs-navigator/tests/integration.test.mjs
+++ b/.github/extensions/srs-navigator/tests/integration.test.mjs
@@ -43,7 +43,7 @@ describe("Integration: Full specification pipeline", () => {
     // Render
     const html = renderGraphHtml(graphData, { title: DEMO_SPEC.name });
     assert.ok(html.includes("CRM System"));
-    assert.ok(html.includes("CP-1"));
+    assert.ok(html.includes("CP.01"));
     assert.ok(html.length > 1000);
   });
 
@@ -201,7 +201,7 @@ Fix the bug. Related to CP-1.
     const specData = convertJSONToSpecificationData(DEMO_SPEC);
     const graphData = buildGraphData(specData);
 
-    const nodeId = "CP-1";
+    const nodeId = "CP.01";
     const node = graphData.nodes.find(n => n.id === nodeId);
     assert.ok(node);
     assert.equal(node.type, "problem");

--- a/.github/extensions/srs-navigator/tests/notation.test.mjs
+++ b/.github/extensions/srs-navigator/tests/notation.test.mjs
@@ -1,0 +1,195 @@
+// Regression tests for ID notation handling across both parsers.
+//
+// Why this exists: the methodology's canonical notation is DOTTED
+// (CP.01 → CN.01.1 → FR.01.1.1) and `reference/validate.md` — the file that
+// defines traceability — uses it throughout. But both parsers accepted only
+// HYPHEN IDs, because `\w` in `/\[(\w+-\d+)\]/` excludes ".". A spec authored
+// per the methodology therefore lost every ID (falling back to auto-generated
+// P-1/N-1) and every CP→CN→FR link, so the /live canvas rendered an unlinked
+// graph. These tests pin both notations, in both parsers.
+import { describe, it, before, after } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtemp, writeFile, mkdir, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { parseSpecificationData } from "../lib/parser.mjs";
+import { compileSpecFromFolder } from "../lib/spec-compiler.mjs";
+import {
+  refPattern,
+  extractHeadingId,
+  stripHeadingId,
+  requirementFilePattern,
+  headingPattern,
+} from "../lib/notation.mjs";
+
+describe("notation: canonical dotted IDs in markdown", () => {
+  it("keeps dotted problem IDs instead of falling back to P-n", () => {
+    const md = `# Customer Problems
+
+### [CP.01] Scattered Customer Information
+Sales teams waste time searching across systems.
+
+### CP.02: Missed Follow-ups
+Reps miss important touchpoints.
+`;
+    const result = parseSpecificationData(md);
+    assert.equal(result.problems.length, 2);
+    assert.equal(result.problems[0].id, "CP.01");
+    assert.equal(result.problems[0].title, "Scattered Customer Information");
+    assert.equal(result.problems[1].id, "CP.02");
+    assert.equal(result.problems[1].title, "Missed Follow-ups");
+  });
+
+  it("links multi-level needs to dotted problems", () => {
+    const md = `# Customer Needs
+
+### [CN.01.1] Centralized Customer Database
+Addresses CP.01 and CP.05.
+
+### CN.02.1: Automated Follow-ups
+Addresses CP.02.
+`;
+    const result = parseSpecificationData(md);
+    assert.equal(result.needs[0].id, "CN.01.1");
+    assert.deepEqual(result.needs[0].problemIds, ["CP.01", "CP.05"]);
+    assert.equal(result.needs[1].id, "CN.02.1");
+    assert.deepEqual(result.needs[1].problemIds, ["CP.02"]);
+  });
+
+  it("links three-level FRs to multi-level needs", () => {
+    const md = `# Functional Requirements
+
+### [FR.01.1.1] Contact Management
+Implements CN.01.1.
+`;
+    const result = parseSpecificationData(md);
+    assert.equal(result.functionalRequirements[0].id, "FR.01.1.1");
+    assert.deepEqual(result.functionalRequirements[0].needIds, ["CN.01.1"]);
+  });
+
+  it("parses the bare (unbracketed) heading form the skill templates emit", () => {
+    // skills/problem-based-srs/reference/problems.md emits "### CP-001: Title"
+    const md = `# Customer Problems
+
+### CP-001: Regulatory Compliance
+Must satisfy the audit requirement.
+`;
+    const result = parseSpecificationData(md);
+    assert.equal(result.problems[0].id, "CP-001");
+    assert.equal(result.problems[0].title, "Regulatory Compliance");
+  });
+
+  it("still supports legacy hyphen notation end to end", () => {
+    const md = `# Customer Problems
+
+### [CP-1] Legacy Problem
+Body.
+
+# Customer Needs
+
+### [CN-1] Legacy Need
+Addresses CP-1.
+`;
+    const result = parseSpecificationData(md);
+    assert.equal(result.problems[0].id, "CP-1");
+    assert.deepEqual(result.needs[0].problemIds, ["CP-1"]);
+  });
+
+  it("does not swallow a trailing sentence period into the ID", () => {
+    const md = `# Customer Needs
+
+### [CN.01.1] A Need
+This addresses CP.01. Nothing else.
+`;
+    const result = parseSpecificationData(md);
+    assert.deepEqual(result.needs[0].problemIds, ["CP.01"]);
+  });
+});
+
+describe("notation helpers", () => {
+  it("extracts IDs from bracketed and bare headings", () => {
+    assert.equal(extractHeadingId("[CP.01] Title"), "CP.01");
+    assert.equal(extractHeadingId("CP-001: Title"), "CP-001");
+    assert.equal(extractHeadingId("[FR.01.1.1] Title"), "FR.01.1.1");
+    assert.equal(extractHeadingId("No identifier here"), undefined);
+  });
+
+  it("strips the ID and separator from headings", () => {
+    assert.equal(stripHeadingId("[CP.01] Scattered Info"), "Scattered Info");
+    assert.equal(stripHeadingId("CP-001: Regulatory Compliance"), "Regulatory Compliance");
+    assert.equal(stripHeadingId("CN.01.1 Centralized Database"), "Centralized Database");
+  });
+
+  it("finds both notations as references in free text", () => {
+    const refs = [..."Addresses CP.01, CP-2 and CN.03.1.".matchAll(refPattern(["CP", "CN"]))].map(
+      (m) => m[1]
+    );
+    assert.deepEqual(refs, ["CP.01", "CP-2", "CN.03.1"]);
+  });
+
+  it("matches requirement filenames with dotted IDs and short-name suffixes", () => {
+    const fr = requirementFilePattern("FR");
+    // The documented convention: FR-001-[short-name].md — previously rejected.
+    assert.ok(fr.test("FR-001-client-registration.md"));
+    assert.ok(fr.test("FR-001.md"));
+    assert.ok(fr.test("FR.01.1.1.md"));
+    assert.ok(fr.test("FR.01.1.1-client-registration.md"));
+    assert.ok(!fr.test("_index.md"));
+    assert.ok(!fr.test("NFR-001.md"));
+    assert.ok(!fr.test("notes.md"));
+  });
+
+  it("builds heading patterns that capture ID and title", () => {
+    const m = "### [CN.01.1] Centralized Database".match(headingPattern("CN", "###", "mi"));
+    assert.equal(m[1], "CN.01.1");
+    assert.equal(m[2].trim(), "Centralized Database");
+  });
+});
+
+describe("notation: spec-compiler reads a .spec/ folder", () => {
+  // Covers Finding C: the documented filename `FR-001-[short-name].md` was
+  // rejected by `/^FR-\d+\.md$/i`, so every FR written per the convention was
+  // silently skipped and the compiler fell back to _index.md.
+  let dir;
+
+  before(async () => {
+    dir = await mkdtemp(path.join(tmpdir(), "srs-spec-"));
+    await writeFile(
+      path.join(dir, "01-customer-problems.md"),
+      "# Customer Problems\n\n### CP.01: Scattered Customer Information\nSales teams waste time.\n"
+    );
+    await writeFile(
+      path.join(dir, "03-customer-needs.md"),
+      "# Customer Needs\n\n### CN.01.1: Centralized Database\nAddresses CP.01.\n"
+    );
+    await mkdir(path.join(dir, "functional-requirements"));
+    await writeFile(
+      path.join(dir, "functional-requirements", "FR-001-client-registration.md"),
+      "# FR-001: Client Registration\n\n**Statement:** The system shall register clients.\n\nTraceability: CN.01.1\n"
+    );
+    await writeFile(
+      path.join(dir, "functional-requirements", "FR.01.1.2-contact-search.md"),
+      "# FR.01.1.2: Contact Search\n\n**Statement:** The system shall search contacts.\n\nTraceability: CN.01.1\n"
+    );
+  });
+
+  after(async () => {
+    await rm(dir, { recursive: true, force: true });
+  });
+
+  it("compiles dotted problems and needs with links intact", async () => {
+    const spec = await compileSpecFromFolder(dir);
+    assert.equal(spec.problems[0].id, "CP.01");
+    assert.equal(spec.needs[0].id, "CN.01.1");
+    assert.deepEqual(spec.needs[0].problemIds, ["CP.01"]);
+  });
+
+  it("reads FR files named per the documented -[short-name] convention", async () => {
+    const spec = await compileSpecFromFolder(dir);
+    const ids = spec.functionalRequirements.map((f) => f.id).sort();
+    assert.deepEqual(ids, ["FR-001", "FR.01.1.2"]);
+    for (const fr of spec.functionalRequirements) {
+      assert.deepEqual(fr.needIds, ["CN.01.1"], `${fr.id} should trace to CN.01.1`);
+    }
+  });
+});

--- a/.github/extensions/srs-navigator/tests/notation.test.mjs
+++ b/.github/extensions/srs-navigator/tests/notation.test.mjs
@@ -14,6 +14,9 @@ import { tmpdir } from "node:os";
 import path from "node:path";
 import { parseSpecificationData } from "../lib/parser.mjs";
 import { compileSpecFromFolder } from "../lib/spec-compiler.mjs";
+import { validateSpecificationJSON, validateReferenceIntegrity } from "../lib/validation.mjs";
+import { decomposeNode } from "../lib/decompose.mjs";
+import { DEMO_SPEC } from "../lib/demo-spec.mjs";
 import {
   refPattern,
   extractHeadingId,
@@ -191,5 +194,79 @@ describe("notation: spec-compiler reads a .spec/ folder", () => {
     for (const fr of spec.functionalRequirements) {
       assert.deepEqual(fr.needIds, ["CN.01.1"], `${fr.id} should trace to CN.01.1`);
     }
+  });
+});
+
+describe("specification JSON validation accepts both notations", () => {
+  // The validation gate is the harshest form of the notation bug: a spec written
+  // in the methodology's own canonical notation was not merely mis-linked, it was
+  // rejected outright ("Problem ID must match format").
+  const spec = (ids) => ({
+    name: "T",
+    description: "d",
+    version: "1.0",
+    problems: [{ id: ids.cp, title: "P", description: "d" }],
+    needs: [{ id: ids.cn, title: "N", description: "d", problemIds: [ids.cp] }],
+    functionalRequirements: [{ id: ids.fr, title: "F", description: "d", needIds: [ids.cn] }],
+    nonFunctionalRequirements: [{ id: ids.nfr, title: "Q", description: "d", needIds: [ids.cn] }],
+  });
+
+  it("accepts canonical dotted IDs", () => {
+    const res = validateSpecificationJSON(spec({ cp: "CP.01", cn: "CN.01.1", fr: "FR.01.1.1", nfr: "NFR.01" }));
+    assert.equal(res.success, true, `errors: ${(res.errors || []).join("; ")}`);
+  });
+
+  it("still accepts legacy hyphen IDs", () => {
+    const res = validateSpecificationJSON(spec({ cp: "CP-1", cn: "CN-1", fr: "FR-1", nfr: "NFR-1" }));
+    assert.equal(res.success, true, `errors: ${(res.errors || []).join("; ")}`);
+  });
+
+  it("still rejects malformed IDs", () => {
+    const res = validateSpecificationJSON(spec({ cp: "PROBLEM_ONE", cn: "CN-1", fr: "FR-1", nfr: "NFR-1" }));
+    assert.equal(res.success, false);
+  });
+
+  it("keeps the bundled demo spec on canonical dotted IDs", () => {
+    const res = validateSpecificationJSON(DEMO_SPEC);
+    assert.equal(res.success, true, `errors: ${(res.errors || []).join("; ")}`);
+    const all = [
+      ...DEMO_SPEC.problems,
+      ...DEMO_SPEC.needs,
+      ...DEMO_SPEC.functionalRequirements,
+      ...DEMO_SPEC.nonFunctionalRequirements,
+    ];
+    for (const item of all) {
+      assert.match(item.id, /^(?:CP|CN|FR|NFR)\.\d/, `demo spec id ${item.id} is not canonical dotted`);
+    }
+    assert.equal(validateReferenceIntegrity(res.data).valid, true);
+  });
+});
+
+describe("decomposition follows the notation of the spec", () => {
+  const dotted = {
+    problems: [{ id: "CP.01", title: "Slow", description: "Search is slow. Reports lag." }],
+    needs: [], functionalRequirements: [], nonFunctionalRequirements: [],
+  };
+
+  it("extends the parent ID for dotted specs", () => {
+    const { added } = decomposeNode(dotted, "CP.01");
+    assert.deepEqual(added.map((a) => a.id), ["CP.01.1", "CP.01.2"]);
+  });
+
+  it("does not collide when the same node is decomposed twice", () => {
+    const once = decomposeNode(dotted, "CP.01");
+    const twice = decomposeNode(once.spec, "CP.01");
+    assert.deepEqual(twice.added.map((a) => a.id), ["CP.01.3", "CP.01.4"]);
+    const ids = twice.spec.problems.map((p) => p.id);
+    assert.equal(new Set(ids).size, ids.length, "decomposition produced duplicate IDs");
+  });
+
+  it("keeps sequential IDs for legacy hyphen specs", () => {
+    const legacy = {
+      problems: [{ id: "CP-1", title: "Slow", description: "Search is slow. Reports lag." }],
+      needs: [], functionalRequirements: [], nonFunctionalRequirements: [],
+    };
+    const { added } = decomposeNode(legacy, "CP-1");
+    assert.deepEqual(added.map((a) => a.id), ["CP-2", "CP-3"]);
   });
 });

--- a/.github/extensions/srs-navigator/tests/serve-canvas.test.mjs
+++ b/.github/extensions/srs-navigator/tests/serve-canvas.test.mjs
@@ -1,0 +1,73 @@
+// Guards the e2e canvas server.
+//
+// The Playwright visual suite pointed at a hardcoded 127.0.0.1:56107 that nothing
+// started, so 18 visual assertions silently never ran. scripts/serve-canvas.mjs
+// now backs playwright.config.mjs's webServer block. These offline checks (no
+// browser, no Playwright) make sure the server keeps working and that the config
+// stays wired to it.
+
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { startCanvasServer, renderSpecHtml, DEFAULT_PORT } from "../scripts/serve-canvas.mjs";
+import { DEMO_SPEC } from "../lib/demo-spec.mjs";
+
+const HERE = path.dirname(fileURLToPath(import.meta.url));
+const EXT_ROOT = path.resolve(HERE, "..");
+
+describe("e2e canvas server", () => {
+  it("serves the rendered demo canvas", async () => {
+    const s = await startCanvasServer({ port: 0 });
+    try {
+      const res = await fetch(s.url);
+      assert.equal(res.status, 200);
+      assert.match(res.headers.get("content-type") || "", /text\/html/);
+      const html = await res.text();
+      assert.ok(html.length > 1000, "canvas HTML looks empty");
+      // The visual suite waits on `.node`; if the markup stops containing nodes
+      // every e2e assertion would time out instead of failing usefully.
+      assert.match(html, /class="node/, "rendered canvas has no .node elements");
+      assert.match(html, /CP\.01/, "rendered canvas does not contain demo IDs");
+    } finally {
+      await s.close();
+    }
+  });
+
+  it("exposes a /health endpoint for the webServer readiness probe", async () => {
+    const s = await startCanvasServer({ port: 0 });
+    try {
+      const res = await fetch(new URL("/health", s.url));
+      assert.equal(res.status, 200);
+      assert.deepEqual(await res.json(), { ok: true });
+    } finally {
+      await s.close();
+    }
+  });
+
+  it("refuses to serve an invalid specification", () => {
+    const broken = { ...DEMO_SPEC, problems: [{ id: "NOPE", title: "x", description: "y" }] };
+    assert.throws(() => renderSpecHtml(broken), /Specification is invalid/);
+  });
+
+  it("playwright config starts the server and probes the same port", async () => {
+    const config = await readFile(path.join(EXT_ROOT, "playwright.config.mjs"), "utf8");
+    assert.match(config, /webServer/, "playwright config has no webServer block");
+    assert.match(config, /scripts\/serve-canvas\.mjs/, "webServer does not launch serve-canvas.mjs");
+    assert.match(config, /\/health/, "webServer readiness probe should use /health");
+    assert.ok(
+      config.includes(String(DEFAULT_PORT)) || /CANVAS_PORT/.test(config),
+      "playwright config and serve-canvas.mjs disagree about the port",
+    );
+  });
+
+  it("the visual suite uses the config baseURL rather than a hardcoded host", async () => {
+    const visual = await readFile(path.join(EXT_ROOT, "tests", "visual.test.mjs"), "utf8");
+    assert.doesNotMatch(
+      visual,
+      /['"`]http:\/\/127\.0\.0\.1:\d+/,
+      "visual.test.mjs hardcodes a host again; use the Playwright baseURL",
+    );
+  });
+});

--- a/.github/extensions/srs-navigator/tests/test-wiring.test.mjs
+++ b/.github/extensions/srs-navigator/tests/test-wiring.test.mjs
@@ -1,0 +1,64 @@
+// Drift guard: every deterministic test file must actually run in `npm test`.
+//
+// Why this exists: `tests/http-guard.test.mjs` (the loopback/CSRF guard for the
+// canvas's local server) and `tests/text-refs.test.mjs` sat on disk for multiple
+// releases while being absent from the `test` script, so they ran in CI never.
+// In an anti-drift product, an unwired test file is a silent coverage hole —
+// this test fails the moment a new `tests/*.test.mjs` is added without wiring.
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync, readdirSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const HERE = path.dirname(fileURLToPath(import.meta.url));
+const EXT_ROOT = path.resolve(HERE, "..");
+
+// Playwright-driven suites must NOT run under `node --test` (they import
+// `@playwright/test`, which is only meaningful under the playwright runner).
+const PLAYWRIGHT_ONLY = new Set(["visual.test.mjs"]);
+
+function readTestScript() {
+  const pkg = JSON.parse(readFileSync(path.join(EXT_ROOT, "package.json"), "utf8"));
+  return pkg.scripts?.test ?? "";
+}
+
+function listTestFiles() {
+  return readdirSync(path.join(EXT_ROOT, "tests"))
+    .filter((f) => f.endsWith(".test.mjs"))
+    .sort();
+}
+
+describe("test wiring", () => {
+  it("runs every tests/*.test.mjs in the npm test script", () => {
+    const script = readTestScript();
+    const missing = listTestFiles()
+      .filter((f) => !PLAYWRIGHT_ONLY.has(f))
+      .filter((f) => !script.includes(`tests/${f}`));
+
+    assert.deepEqual(
+      missing,
+      [],
+      `Unwired test file(s): ${missing.join(", ")}. Add them to the "test" script in package.json.`
+    );
+  });
+
+  it("does not run Playwright-only suites under node --test", () => {
+    const script = readTestScript();
+    for (const f of PLAYWRIGHT_ONLY) {
+      assert.ok(
+        !script.includes(`tests/${f}`),
+        `${f} imports @playwright/test and must stay out of the node --test script.`
+      );
+    }
+  });
+
+  it("only references test files that exist on disk", () => {
+    const script = readTestScript();
+    const referenced = [...script.matchAll(/tests\/([\w.-]+\.test\.mjs)/g)].map((m) => m[1]);
+    const onDisk = new Set(listTestFiles());
+    const phantom = referenced.filter((f) => !onDisk.has(f));
+
+    assert.deepEqual(phantom, [], `Test script references missing file(s): ${phantom.join(", ")}`);
+  });
+});

--- a/.github/extensions/srs-navigator/tests/visual.test.mjs
+++ b/.github/extensions/srs-navigator/tests/visual.test.mjs
@@ -5,7 +5,9 @@
  */
 import { test, expect } from '@playwright/test';
 
-const CANVAS_URL = process.env.CANVAS_URL || 'http://127.0.0.1:56107/';
+// Relative so Playwright's baseURL (and the webServer it starts) applies. Set
+// CANVAS_URL to point the suite at an already-running canvas instead.
+const CANVAS_URL = process.env.CANVAS_URL || '/';
 
 test.describe('SRS Navigator Canvas - Visual Rendering', () => {
   test.beforeEach(async ({ page }) => {

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,27 @@ permissions:
   contents: read
 
 jobs:
+  test:
+    name: Test (canvas + skill evals)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+
+      # No `npm ci` needed: the deterministic suites import only node:test /
+      # node:assert. Playwright-driven specs are excluded from `npm test`.
+      - name: Canvas extension tests
+        working-directory: .github/extensions/srs-navigator
+        run: npm test
+
+      - name: Deterministic skill evals
+        run: node --test evals/tests/*.test.mjs
+
   build:
     name: Build & validate plugin
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,42 @@ jobs:
       - name: Deterministic skill evals
         run: node --test evals/tests/*.test.mjs
 
+  e2e:
+    name: Canvas e2e (Playwright)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: npm
+          cache-dependency-path: .github/extensions/srs-navigator/package-lock.json
+
+      - name: Install dependencies
+        working-directory: .github/extensions/srs-navigator
+        run: npm ci
+
+      - name: Install Chromium
+        working-directory: .github/extensions/srs-navigator
+        run: npx playwright install --with-deps chromium
+
+      # playwright.config.mjs starts scripts/serve-canvas.mjs itself, so no
+      # separate server step is needed here.
+      - name: Run visual suite
+        working-directory: .github/extensions/srs-navigator
+        run: npm run test:e2e
+
+      - name: Upload Playwright report on failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-report
+          path: .github/extensions/srs-navigator/playwright-report
+          if-no-files-found: ignore
+
   build:
     name: Build & validate plugin
     runs-on: ubuntu-latest

--- a/.spec/crm-system.json
+++ b/.spec/crm-system.json
@@ -3,40 +3,40 @@
   "description": "Customer Relationship Management System Specification",
   "version": "1.0",
   "problems": [
-    { "id": "CP-1", "title": "Scattered Customer Information", "description": "Sales teams waste valuable time searching for customer information across multiple disconnected systems." },
-    { "id": "CP-2", "title": "Missed Follow-ups and Lost Opportunities", "description": "Without a systematic way to track interactions, sales reps miss important touchpoints." },
-    { "id": "CP-3", "title": "Lack of Sales Pipeline Visibility", "description": "Sales managers have no clear, real-time view of pipeline status or performance metrics." },
-    { "id": "CP-4", "title": "Inefficient Lead Management", "description": "New leads from various sources are manually entered with no standardized process." },
-    { "id": "CP-5", "title": "No Customer Communication History", "description": "No shared record of previous conversations or commitments across team members." }
+    { "id": "CP.01", "title": "Scattered Customer Information", "description": "Sales teams waste valuable time searching for customer information across multiple disconnected systems." },
+    { "id": "CP.02", "title": "Missed Follow-ups and Lost Opportunities", "description": "Without a systematic way to track interactions, sales reps miss important touchpoints." },
+    { "id": "CP.03", "title": "Lack of Sales Pipeline Visibility", "description": "Sales managers have no clear, real-time view of pipeline status or performance metrics." },
+    { "id": "CP.04", "title": "Inefficient Lead Management", "description": "New leads from various sources are manually entered with no standardized process." },
+    { "id": "CP.05", "title": "No Customer Communication History", "description": "No shared record of previous conversations or commitments across team members." }
   ],
   "needs": [
-    { "id": "CN-1", "title": "Centralized Customer Database", "description": "A single searchable repository for all customer information.", "problemIds": ["CP-1", "CP-5"] },
-    { "id": "CN-2", "title": "Automated Task and Follow-up Management", "description": "Automatic follow-up tasks and reminders based on interactions.", "problemIds": ["CP-2"] },
-    { "id": "CN-3", "title": "Visual Sales Pipeline Management", "description": "Visual deal progression through stages with metrics.", "problemIds": ["CP-3"] },
-    { "id": "CN-4", "title": "Automated Lead Capture and Routing", "description": "Automatic lead capture, qualification, and intelligent routing.", "problemIds": ["CP-4"] },
-    { "id": "CN-5", "title": "Comprehensive Activity Tracking", "description": "Automatic logging of all customer touchpoints.", "problemIds": ["CP-5"] },
-    { "id": "CN-6", "title": "Real-time Reporting and Analytics", "description": "Customizable dashboards with real-time sales metrics.", "problemIds": ["CP-3"] },
-    { "id": "CN-7", "title": "Mobile Access to Customer Data", "description": "Full mobile access with offline capability.", "problemIds": ["CP-1", "CP-2"] }
+    { "id": "CN.01.1", "title": "Centralized Customer Database", "description": "A single searchable repository for all customer information.", "problemIds": ["CP.01", "CP.05"] },
+    { "id": "CN.02.1", "title": "Automated Task and Follow-up Management", "description": "Automatic follow-up tasks and reminders based on interactions.", "problemIds": ["CP.02"] },
+    { "id": "CN.03.1", "title": "Visual Sales Pipeline Management", "description": "Visual deal progression through stages with metrics.", "problemIds": ["CP.03"] },
+    { "id": "CN.04.1", "title": "Automated Lead Capture and Routing", "description": "Automatic lead capture, qualification, and intelligent routing.", "problemIds": ["CP.04"] },
+    { "id": "CN.05.1", "title": "Comprehensive Activity Tracking", "description": "Automatic logging of all customer touchpoints.", "problemIds": ["CP.05"] },
+    { "id": "CN.03.2", "title": "Real-time Reporting and Analytics", "description": "Customizable dashboards with real-time sales metrics.", "problemIds": ["CP.03"] },
+    { "id": "CN.01.2", "title": "Mobile Access to Customer Data", "description": "Full mobile access with offline capability.", "problemIds": ["CP.01", "CP.02"] }
   ],
   "functionalRequirements": [
-    { "id": "FR-1", "title": "Contact and Company Management", "description": "Database with hierarchical relationships, custom fields, and search.", "needIds": ["CN-1"] },
-    { "id": "FR-2", "title": "Activity Logging Interface", "description": "Logging calls, emails, meetings with timeline view.", "needIds": ["CN-5"] },
-    { "id": "FR-3", "title": "Task Management System", "description": "Tasks with due dates, priorities, and automated creation.", "needIds": ["CN-2"] },
-    { "id": "FR-4", "title": "Pipeline Visualization", "description": "Kanban-style board with drag-and-drop deal management.", "needIds": ["CN-3"] },
-    { "id": "FR-5", "title": "Lead Capture Forms and API", "description": "Embeddable forms and REST API for lead submission.", "needIds": ["CN-4"] },
-    { "id": "FR-6", "title": "Lead Qualification and Scoring", "description": "Scoring system based on attributes and behaviors.", "needIds": ["CN-4"] },
-    { "id": "FR-7", "title": "Automated Lead Assignment", "description": "Rule engine for lead routing based on criteria.", "needIds": ["CN-4"] },
-    { "id": "FR-8", "title": "Dashboard and Reporting Engine", "description": "Pre-built widgets and custom report builder.", "needIds": ["CN-6"] },
-    { "id": "FR-9", "title": "Mobile Application", "description": "Native mobile apps with offline caching.", "needIds": ["CN-7"] },
-    { "id": "FR-10", "title": "Email Integration", "description": "Two-way email sync with tracking.", "needIds": ["CN-5", "CN-7"] },
-    { "id": "FR-11", "title": "Calendar Integration", "description": "Sync with external calendars.", "needIds": ["CN-2", "CN-5"] },
-    { "id": "FR-12", "title": "User and Permission Management", "description": "Role-based access control with team hierarchies.", "needIds": ["CN-1", "CN-6"] }
+    { "id": "FR.01.1.1", "title": "Contact and Company Management", "description": "Database with hierarchical relationships, custom fields, and search.", "needIds": ["CN.01.1"] },
+    { "id": "FR.05.1.1", "title": "Activity Logging Interface", "description": "Logging calls, emails, meetings with timeline view.", "needIds": ["CN.05.1"] },
+    { "id": "FR.02.1.1", "title": "Task Management System", "description": "Tasks with due dates, priorities, and automated creation.", "needIds": ["CN.02.1"] },
+    { "id": "FR.03.1.1", "title": "Pipeline Visualization", "description": "Kanban-style board with drag-and-drop deal management.", "needIds": ["CN.03.1"] },
+    { "id": "FR.04.1.1", "title": "Lead Capture Forms and API", "description": "Embeddable forms and REST API for lead submission.", "needIds": ["CN.04.1"] },
+    { "id": "FR.04.1.2", "title": "Lead Qualification and Scoring", "description": "Scoring system based on attributes and behaviors.", "needIds": ["CN.04.1"] },
+    { "id": "FR.04.1.3", "title": "Automated Lead Assignment", "description": "Rule engine for lead routing based on criteria.", "needIds": ["CN.04.1"] },
+    { "id": "FR.03.2.1", "title": "Dashboard and Reporting Engine", "description": "Pre-built widgets and custom report builder.", "needIds": ["CN.03.2"] },
+    { "id": "FR.01.2.1", "title": "Mobile Application", "description": "Native mobile apps with offline caching.", "needIds": ["CN.01.2"] },
+    { "id": "FR.05.1.2", "title": "Email Integration", "description": "Two-way email sync with tracking.", "needIds": ["CN.05.1", "CN.01.2"] },
+    { "id": "FR.02.1.2", "title": "Calendar Integration", "description": "Sync with external calendars.", "needIds": ["CN.02.1", "CN.05.1"] },
+    { "id": "FR.01.1.2", "title": "User and Permission Management", "description": "Role-based access control with team hierarchies.", "needIds": ["CN.01.1", "CN.03.2"] }
   ],
   "nonFunctionalRequirements": [
-    { "id": "NFR-1", "title": "Performance", "description": "Page load < 2s, search results < 500ms.", "needIds": ["CN-1", "CN-6"] },
-    { "id": "NFR-2", "title": "Security", "description": "SOC2 compliance, encryption at rest and in transit.", "needIds": ["CN-1"] },
-    { "id": "NFR-3", "title": "Scalability", "description": "Support 10,000+ concurrent users.", "needIds": ["CN-1", "CN-4"] },
-    { "id": "NFR-4", "title": "Availability", "description": "99.9% uptime SLA.", "needIds": ["CN-7"] },
-    { "id": "NFR-5", "title": "Usability", "description": "Intuitive UI requiring < 2hr onboarding.", "needIds": ["CN-3", "CN-7"] }
+    { "id": "NFR.01", "title": "Performance", "description": "Page load < 2s, search results < 500ms.", "needIds": ["CN.01.1", "CN.03.2"] },
+    { "id": "NFR.02", "title": "Security", "description": "SOC2 compliance, encryption at rest and in transit.", "needIds": ["CN.01.1"] },
+    { "id": "NFR.03", "title": "Scalability", "description": "Support 10,000+ concurrent users.", "needIds": ["CN.01.1", "CN.04.1"] },
+    { "id": "NFR.04", "title": "Availability", "description": "99.9% uptime SLA.", "needIds": ["CN.01.2"] },
+    { "id": "NFR.05", "title": "Usability", "description": "Intuitive UI requiring < 2hr onboarding.", "needIds": ["CN.03.1", "CN.01.2"] }
   ]
 }

--- a/docs/assets/site.css
+++ b/docs/assets/site.css
@@ -269,6 +269,18 @@
             padding: var(--space-sm) var(--space-md); border-radius: 8px;
             display: block; margin: var(--space-md) 0;
         }
+        .problem-after .cp b {
+            display: block; font-weight: 600; letter-spacing: 0.01em;
+            margin-bottom: var(--space-xs);
+        }
+        .problem-chain {
+            font-family: var(--font-mono); font-size: var(--text-sm);
+            line-height: 1.9; color: var(--muted);
+            border-left: 2px solid var(--surface-border);
+            padding-left: var(--space-md); margin: var(--space-md) 0;
+        }
+        .problem-chain b { color: var(--ink-heading); font-weight: 600; }
+        .problem-chain span { color: var(--accent); padding: 0 0.15rem; }
         .problem-grid {
             display: grid; grid-template-columns: minmax(0, 1fr) minmax(0, 1.05fr);
             gap: clamp(1.5rem, 1rem + 3vw, 3.5rem); align-items: center;

--- a/docs/docs.html
+++ b/docs/docs.html
@@ -191,9 +191,9 @@
 &#9500;&#9472; 03-customer-needs.md
 &#9500;&#9472; 04-software-vision.md
 &#9500;&#9472; functional-requirements/
-&#9474;  &#9492;&#9472; FR-001-[short-name].md
+&#9474;  &#9492;&#9472; FR.01.1.1-[short-name].md
 &#9492;&#9472; non-functional-requirements/
-   &#9492;&#9472; NFR-001-[short-name].md</code></pre>
+   &#9492;&#9472; NFR.01-[short-name].md</code></pre>
                         </div>
                     </div>
                     <div class="concept" id="concept-naming">
@@ -205,7 +205,7 @@
                                 <a href="#skill-problems"><span class="dc-need">Customer Problem</span><span class="dc-cmd">CP.01 &middot; CP.01.1</span></a>
                                 <a href="#skill-needs"><span class="dc-need">Customer Need (traces to a CP)</span><span class="dc-cmd">CN.01.1</span></a>
                                 <a href="#skill-fr"><span class="dc-need">Functional Requirement (traces to a CN)</span><span class="dc-cmd">FR.01.1.1</span></a>
-                                <a href="#skill-fr"><span class="dc-need">Non-Functional Requirement</span><span class="dc-cmd">NFR.1.0</span></a>
+                                <a href="#skill-fr"><span class="dc-need">Non-Functional Requirement</span><span class="dc-cmd">NFR.01</span></a>
                             </div>
                         </div>
                     </div>

--- a/docs/index.html
+++ b/docs/index.html
@@ -160,7 +160,7 @@
                                 <span class="app-frame-title">srs-navigator &middot; VagrantChefHubot</span>
                             </div>
                             <img src="assets/srs-problems.svg" width="720" height="640"
-                                 alt="The SRS Navigator graph of the VagrantChefHubot spec: the whole specification appears, then the Needs and Requirements dim while the five Customer Problems (CP-1 through CP-5) light up." />
+                                 alt="The SRS Navigator graph of the VagrantChefHubot spec: the whole specification appears, then the Needs and Requirements dim while the five Customer Problems (CP.01 through CP.05) light up." />
                         </div>
                         <figcaption>Real spec, 28 nodes. Everything you build traces back to these <strong>five problems</strong>. That is where the work begins.</figcaption>
                     </figure>

--- a/docs/index.html
+++ b/docs/index.html
@@ -144,13 +144,15 @@
                 <div class="problem-grid">
                     <div class="problem-copy">
                         <div class="problem-before reveal">
-                            <p class="quote">"We need a reporting dashboard with 20 charts."</p>
-                            <p>You build it. Three weeks. Ship it. They use 3 of the 20 charts. The actual problem was slow data access, not visualization. Two weeks of engineering time, gone.</p>
+                            <p class="quote">"We need a CRM &mdash; with a mobile app and a dashboard."</p>
+                            <p>Hand that to an AI agent and you get a feature list in seconds. Six months later nobody can say why the dashboard exists, which customer problem it closes, or what breaks if you delete it. The requirements were never written down &mdash; only the code was.</p>
                         </div>
                         <div class="problem-after reveal">
-                            <p>This methodology reverses the order. Instead of starting with the stakeholder's solution, you start with their problem:</p>
-                            <code class="cp">CP.01: "Managers must access sales data within 5 seconds to make decisions."</code>
-                            <p>From that problem, you derive the need (CN: real-time data access), then the requirement (FR: data API + 3 targeted charts). Built in one week. Solves what actually matters.</p>
+                            <p>Problem-Based SRS reverses the order. The first artifact is not a feature. It is the problem, stated with the cost of leaving it unsolved:</p>
+                            <code class="cp"><b>CP.01 &middot; Scattered Customer Information</b>Sales teams waste valuable time searching for customer information across multiple disconnected systems.</code>
+                            <p>The need follows from the problem, the requirement from the need. Each identifier names its parent, so the chain reads in both directions &mdash; forward to what you build, backward to why:</p>
+                            <p class="problem-chain"><b>CP.01</b> <span aria-hidden="true">&rarr;</span> <b>CN.01.1</b> Centralized Customer Database <span aria-hidden="true">&rarr;</span> <b>FR.01.1.1</b> Contact and Company Management</p>
+                            <p>That is not an illustration. It is <code>.spec/crm-system.json</code>, the specification shipped with the plugin: 5 problems, 7 needs, 12 requirements, 5 quality attributes, no orphans. Run <code>/live</code> and the SRS Navigator opens that graph.</p>
                         </div>
                     </div>
                     <figure class="problem-figure reveal">
@@ -160,7 +162,7 @@
                                 <span class="app-frame-title">srs-navigator &middot; VagrantChefHubot</span>
                             </div>
                             <img src="assets/srs-problems.svg" width="720" height="640"
-                                 alt="The SRS Navigator graph of the VagrantChefHubot spec: the whole specification appears, then the Needs and Requirements dim while the five Customer Problems (CP.01 through CP.05) light up." />
+                                 alt="The SRS Navigator graph of the VagrantChefHubot spec: the whole specification appears, then the Needs and Requirements dim while the five Customer Problems (labelled CP-1 through CP-5 in this earlier spec) light up." />
                         </div>
                         <figcaption>Real spec, 28 nodes. Everything you build traces back to these <strong>five problems</strong>. That is where the work begins.</figcaption>
                     </figure>

--- a/docs/skills-health.html
+++ b/docs/skills-health.html
@@ -1,0 +1,203 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Skills Health — Problem-Based SRS</title>
+<meta name="description" content="Test-suite and context-budget health for the Problem-Based SRS plugin and the SRS Navigator canvas app.">
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Bricolage+Grotesque:wght@700;800&family=Figtree:wght@400;500;600&family=JetBrains+Mono:wght@400&display=swap" rel="stylesheet">
+<link rel="stylesheet" href="assets/site.css">
+<style>
+  .health { max-width: 68rem; margin: 0 auto; padding: var(--space-xl) var(--space-md) var(--space-2xl); }
+  .health h1 { font-family: var(--font-display); font-size: var(--text-3xl); color: var(--ink-heading); margin: 0 0 var(--space-xs); }
+  .health .sub { color: var(--muted); font-size: var(--text-sm); margin: 0 0 var(--space-lg); }
+  .health h2 { font-family: var(--font-display); font-size: var(--text-xl); color: var(--ink-heading); margin: var(--space-xl) 0 var(--space-sm); }
+  .cards { display: grid; grid-template-columns: repeat(auto-fit, minmax(9rem, 1fr)); gap: var(--space-sm); }
+  .card { background: var(--bg-elevated); border: 1px solid var(--surface-border); border-radius: 0.75rem; padding: var(--space-md); }
+  .card .k { display: block; font-size: var(--text-xs); text-transform: uppercase; letter-spacing: 0.06em; color: var(--muted); }
+  .card .v { display: block; font-family: var(--font-display); font-size: var(--text-2xl); color: var(--ink-heading); line-height: 1.1; }
+  .card.verdict-passed { border-color: oklch(0.55 0.12 150 / 0.45); }
+  .card.verdict-failed { border-color: oklch(0.55 0.18 27 / 0.5); }
+  .card.verdict-passed .v { color: oklch(0.45 0.12 150); }
+  .card.verdict-failed .v { color: oklch(0.50 0.18 27); }
+  table.health-table { width: 100%; border-collapse: collapse; font-size: var(--text-sm); background: var(--bg-elevated); border: 1px solid var(--surface-border); border-radius: 0.75rem; overflow: hidden; }
+  .health-table th { text-align: left; font-size: var(--text-xs); text-transform: uppercase; letter-spacing: 0.06em; color: var(--muted); font-weight: 600; padding: 0.6rem 0.75rem; border-bottom: 1px solid var(--surface-border); }
+  .health-table td { padding: 0.6rem 0.75rem; border-bottom: 1px solid var(--surface); vertical-align: top; color: var(--ink); }
+  .health-table tr:last-child td { border-bottom: 0; }
+  .health-table .num { text-align: right; font-family: var(--font-mono); font-variant-numeric: tabular-nums; }
+  .health-table .num.bad { color: oklch(0.50 0.18 27); font-weight: 600; }
+  .health-table .name { font-weight: 600; }
+  .health-table .name code { display: block; font-family: var(--font-mono); font-size: var(--text-xs); font-weight: 400; color: var(--muted); margin-top: 0.15rem; }
+  .health-table .note { color: var(--muted); font-size: var(--text-xs); }
+  .pill { display: inline-block; padding: 0.1rem 0.5rem; border-radius: 999px; font-size: var(--text-xs); font-weight: 600; }
+  .pill-passed, .pill-ok { background: oklch(0.55 0.12 150 / 0.14); color: oklch(0.40 0.12 150); }
+  .pill-failed, .pill-over { background: oklch(0.55 0.18 27 / 0.14); color: oklch(0.46 0.18 27); }
+  .pill-skipped { background: var(--surface); color: var(--muted); }
+  .pill-watch { background: oklch(0.61 0.18 48 / 0.16); color: oklch(0.45 0.15 48); }
+  .bar-cell { width: 40%; }
+  .bar { display: block; height: 0.4rem; border-radius: 999px; background: var(--surface); overflow: hidden; }
+  .bar i { display: block; height: 100%; background: var(--accent); }
+  .state-watch .bar i { background: var(--step-why); }
+  .state-over .bar i { background: oklch(0.55 0.18 27); }
+  .legend { color: var(--muted); font-size: var(--text-xs); margin-top: var(--space-sm); }
+</style>
+</head>
+<body>
+<main class="health">
+  <h1>Skills Health</h1>
+  <p class="sub">Problem-Based SRS v1.1.0 · generated 2026-07-30 23:52 UTC · <a href="index.html">back to the site</a></p>
+
+  <div class="cards">
+    <div class="card verdict-passed"><span class="k">Verdict</span><span class="v">Passed</span></div>
+    <div class="card"><span class="k">Tests</span><span class="v">325</span></div>
+    <div class="card"><span class="k">Passing</span><span class="v">325</span></div>
+    <div class="card"><span class="k">Failing</span><span class="v">0</span></div>
+    <div class="card"><span class="k">Suites run</span><span class="v">4/6</span></div>
+    <div class="card"><span class="k">Duration</span><span class="v">56.3s</span></div>
+  </div>
+
+  <h2>Suites</h2>
+  <table class="health-table">
+    <thead><tr><th>Suite</th><th>Result</th><th class="num">Tests</th><th class="num">Pass</th><th class="num">Fail</th><th class="num">Time</th><th>Note</th></tr></thead>
+    <tbody>
+        <tr class="state-passed">
+          <td class="name">Plugin validation<code>python scripts/build-plugin.py validate</code></td>
+          <td><span class="pill pill-passed">Passed</span></td>
+          <td class="num">1</td>
+          <td class="num">1</td>
+          <td class="num ">0</td>
+          <td class="num">0.3s</td>
+          <td class="note"></td>
+        </tr>
+        <tr class="state-passed">
+          <td class="name">Canvas extension<code>npm test</code></td>
+          <td><span class="pill pill-passed">Passed</span></td>
+          <td class="num">215</td>
+          <td class="num">215</td>
+          <td class="num ">0</td>
+          <td class="num">1.4s</td>
+          <td class="note"></td>
+        </tr>
+        <tr class="state-passed">
+          <td class="name">Skill evals<code>pwsh evals/scripts/run-tests.ps1</code></td>
+          <td><span class="pill pill-passed">Passed</span></td>
+          <td class="num">91</td>
+          <td class="num">91</td>
+          <td class="num ">0</td>
+          <td class="num">0.5s</td>
+          <td class="note"></td>
+        </tr>
+        <tr class="state-passed">
+          <td class="name">Canvas e2e<code>npm run test:e2e</code></td>
+          <td><span class="pill pill-passed">Passed</span></td>
+          <td class="num">18</td>
+          <td class="num">18</td>
+          <td class="num ">0</td>
+          <td class="num">54.1s</td>
+          <td class="note"></td>
+        </tr>
+        <tr class="state-skipped">
+          <td class="name">Skill behavior (LLM)<code>npm run test:skill-behavior</code></td>
+          <td><span class="pill pill-skipped">Skipped</span></td>
+          <td class="num">—</td>
+          <td class="num">—</td>
+          <td class="num ">—</td>
+          <td class="num">—</td>
+          <td class="note">not requested (-IncludeSkillBehavior)</td>
+        </tr>
+        <tr class="state-skipped">
+          <td class="name">Live skill evals (LLM)<code>node evals/run-evals.mjs</code></td>
+          <td><span class="pill pill-skipped">Skipped</span></td>
+          <td class="num">—</td>
+          <td class="num">—</td>
+          <td class="num ">—</td>
+          <td class="num">—</td>
+          <td class="note">not requested (-IncludeSkillBehavior)</td>
+        </tr>
+    </tbody>
+  </table>
+
+  <h2>Max context — skill line budget</h2>
+  <table class="health-table">
+    <thead><tr><th>File</th><th class="num">Lines</th><th>Share of cap</th><th>State</th></tr></thead>
+    <tbody>
+        <tr class="state-watch">
+          <td class="name"><code>skills/problem-based-srs/SKILL.md</code></td>
+          <td class="num">549</td>
+          <td class="bar-cell"><span class="bar"><i style="width:91.5%"></i></span></td>
+          <td><span class="pill pill-watch">Watch</span></td>
+        </tr>
+        <tr class="state-ok">
+          <td class="name"><code>skills/problem-based-srs/reference/business-context.md</code></td>
+          <td class="num">491</td>
+          <td class="bar-cell"><span class="bar"><i style="width:81.8%"></i></span></td>
+          <td><span class="pill pill-ok">OK</span></td>
+        </tr>
+        <tr class="state-ok">
+          <td class="name"><code>skills/problem-based-srs/reference/complexity.md</code></td>
+          <td class="num">267</td>
+          <td class="bar-cell"><span class="bar"><i style="width:44.5%"></i></span></td>
+          <td><span class="pill pill-ok">OK</span></td>
+        </tr>
+        <tr class="state-ok">
+          <td class="name"><code>skills/problem-based-srs/reference/crm-example.md</code></td>
+          <td class="num">179</td>
+          <td class="bar-cell"><span class="bar"><i style="width:29.8%"></i></span></td>
+          <td><span class="pill pill-ok">OK</span></td>
+        </tr>
+        <tr class="state-ok">
+          <td class="name"><code>skills/problem-based-srs/reference/functional-requirements.md</code></td>
+          <td class="num">486</td>
+          <td class="bar-cell"><span class="bar"><i style="width:81%"></i></span></td>
+          <td><span class="pill pill-ok">OK</span></td>
+        </tr>
+        <tr class="state-ok">
+          <td class="name"><code>skills/problem-based-srs/reference/live.md</code></td>
+          <td class="num">74</td>
+          <td class="bar-cell"><span class="bar"><i style="width:12.3%"></i></span></td>
+          <td><span class="pill pill-ok">OK</span></td>
+        </tr>
+        <tr class="state-ok">
+          <td class="name"><code>skills/problem-based-srs/reference/microer-example.md</code></td>
+          <td class="num">215</td>
+          <td class="bar-cell"><span class="bar"><i style="width:35.8%"></i></span></td>
+          <td><span class="pill pill-ok">OK</span></td>
+        </tr>
+        <tr class="state-ok">
+          <td class="name"><code>skills/problem-based-srs/reference/needs.md</code></td>
+          <td class="num">248</td>
+          <td class="bar-cell"><span class="bar"><i style="width:41.3%"></i></span></td>
+          <td><span class="pill pill-ok">OK</span></td>
+        </tr>
+        <tr class="state-ok">
+          <td class="name"><code>skills/problem-based-srs/reference/problems.md</code></td>
+          <td class="num">375</td>
+          <td class="bar-cell"><span class="bar"><i style="width:62.5%"></i></span></td>
+          <td><span class="pill pill-ok">OK</span></td>
+        </tr>
+        <tr class="state-ok">
+          <td class="name"><code>skills/problem-based-srs/reference/software-glance.md</code></td>
+          <td class="num">304</td>
+          <td class="bar-cell"><span class="bar"><i style="width:50.7%"></i></span></td>
+          <td><span class="pill pill-ok">OK</span></td>
+        </tr>
+        <tr class="state-ok">
+          <td class="name"><code>skills/problem-based-srs/reference/software-vision.md</code></td>
+          <td class="num">288</td>
+          <td class="bar-cell"><span class="bar"><i style="width:48%"></i></span></td>
+          <td><span class="pill pill-ok">OK</span></td>
+        </tr>
+        <tr class="state-ok">
+          <td class="name"><code>skills/problem-based-srs/reference/validate.md</code></td>
+          <td class="num">296</td>
+          <td class="bar-cell"><span class="bar"><i style="width:49.3%"></i></span></td>
+          <td><span class="pill pill-ok">OK</span></td>
+        </tr>
+    </tbody>
+  </table>
+  <p class="legend">Hard cap 600 lines · soft watch 500 lines. Front matter is excluded; the metric matches <code>evals/lib/skills.mjs</code>.</p>
+</main>
+</body>
+</html>

--- a/docs/skills-health.html
+++ b/docs/skills-health.html
@@ -47,12 +47,12 @@
 <body>
 <main class="health">
   <h1>Skills Health</h1>
-  <p class="sub">Problem-Based SRS v1.1.0 · generated 2026-07-30 23:52 UTC · <a href="index.html">back to the site</a></p>
+  <p class="sub">Problem-Based SRS v1.1.0 · generated 2026-07-31 00:00 UTC · <a href="index.html">back to the site</a></p>
 
   <div class="cards">
     <div class="card verdict-passed"><span class="k">Verdict</span><span class="v">Passed</span></div>
-    <div class="card"><span class="k">Tests</span><span class="v">325</span></div>
-    <div class="card"><span class="k">Passing</span><span class="v">325</span></div>
+    <div class="card"><span class="k">Tests</span><span class="v">330</span></div>
+    <div class="card"><span class="k">Passing</span><span class="v">330</span></div>
     <div class="card"><span class="k">Failing</span><span class="v">0</span></div>
     <div class="card"><span class="k">Suites run</span><span class="v">4/6</span></div>
     <div class="card"><span class="k">Duration</span><span class="v">56.3s</span></div>
@@ -77,14 +77,14 @@
           <td class="num">215</td>
           <td class="num">215</td>
           <td class="num ">0</td>
-          <td class="num">1.4s</td>
+          <td class="num">1.5s</td>
           <td class="note"></td>
         </tr>
         <tr class="state-passed">
           <td class="name">Skill evals<code>pwsh evals/scripts/run-tests.ps1</code></td>
           <td><span class="pill pill-passed">Passed</span></td>
-          <td class="num">91</td>
-          <td class="num">91</td>
+          <td class="num">96</td>
+          <td class="num">96</td>
           <td class="num ">0</td>
           <td class="num">0.5s</td>
           <td class="note"></td>
@@ -95,7 +95,7 @@
           <td class="num">18</td>
           <td class="num">18</td>
           <td class="num ">0</td>
-          <td class="num">54.1s</td>
+          <td class="num">53.8s</td>
           <td class="note"></td>
         </tr>
         <tr class="state-skipped">

--- a/docs/skills-health.html
+++ b/docs/skills-health.html
@@ -47,15 +47,15 @@
 <body>
 <main class="health">
   <h1>Skills Health</h1>
-  <p class="sub">Problem-Based SRS v1.1.0 · generated 2026-07-31 00:00 UTC · <a href="index.html">back to the site</a></p>
+  <p class="sub">Problem-Based SRS v1.1.0 · generated 2026-07-31 00:04 UTC · <a href="index.html">back to the site</a></p>
 
   <div class="cards">
     <div class="card verdict-passed"><span class="k">Verdict</span><span class="v">Passed</span></div>
-    <div class="card"><span class="k">Tests</span><span class="v">330</span></div>
-    <div class="card"><span class="k">Passing</span><span class="v">330</span></div>
+    <div class="card"><span class="k">Tests</span><span class="v">334</span></div>
+    <div class="card"><span class="k">Passing</span><span class="v">334</span></div>
     <div class="card"><span class="k">Failing</span><span class="v">0</span></div>
     <div class="card"><span class="k">Suites run</span><span class="v">4/6</span></div>
-    <div class="card"><span class="k">Duration</span><span class="v">56.3s</span></div>
+    <div class="card"><span class="k">Duration</span><span class="v">55.6s</span></div>
   </div>
 
   <h2>Suites</h2>
@@ -68,7 +68,7 @@
           <td class="num">1</td>
           <td class="num">1</td>
           <td class="num ">0</td>
-          <td class="num">0.3s</td>
+          <td class="num">0.4s</td>
           <td class="note"></td>
         </tr>
         <tr class="state-passed">
@@ -83,8 +83,8 @@
         <tr class="state-passed">
           <td class="name">Skill evals<code>pwsh evals/scripts/run-tests.ps1</code></td>
           <td><span class="pill pill-passed">Passed</span></td>
-          <td class="num">96</td>
-          <td class="num">96</td>
+          <td class="num">100</td>
+          <td class="num">100</td>
           <td class="num ">0</td>
           <td class="num">0.5s</td>
           <td class="note"></td>
@@ -95,7 +95,7 @@
           <td class="num">18</td>
           <td class="num">18</td>
           <td class="num ">0</td>
-          <td class="num">53.8s</td>
+          <td class="num">53.1s</td>
           <td class="note"></td>
         </tr>
         <tr class="state-skipped">
@@ -123,11 +123,11 @@
   <table class="health-table">
     <thead><tr><th>File</th><th class="num">Lines</th><th>Share of cap</th><th>State</th></tr></thead>
     <tbody>
-        <tr class="state-watch">
+        <tr class="state-ok">
           <td class="name"><code>skills/problem-based-srs/SKILL.md</code></td>
-          <td class="num">549</td>
-          <td class="bar-cell"><span class="bar"><i style="width:91.5%"></i></span></td>
-          <td><span class="pill pill-watch">Watch</span></td>
+          <td class="num">479</td>
+          <td class="bar-cell"><span class="bar"><i style="width:79.8%"></i></span></td>
+          <td><span class="pill pill-ok">OK</span></td>
         </tr>
         <tr class="state-ok">
           <td class="name"><code>skills/problem-based-srs/reference/business-context.md</code></td>
@@ -149,8 +149,8 @@
         </tr>
         <tr class="state-ok">
           <td class="name"><code>skills/problem-based-srs/reference/functional-requirements.md</code></td>
-          <td class="num">486</td>
-          <td class="bar-cell"><span class="bar"><i style="width:81%"></i></span></td>
+          <td class="num">492</td>
+          <td class="bar-cell"><span class="bar"><i style="width:82%"></i></span></td>
           <td><span class="pill pill-ok">OK</span></td>
         </tr>
         <tr class="state-ok">

--- a/docs/skills-health.json
+++ b/docs/skills-health.json
@@ -1,0 +1,165 @@
+{
+  "schema": "skills-health/1",
+  "generatedAt": "2026-07-30T23:52:36.9408292Z",
+  "repo": "RafaelGorski/Problem-Based-SRS",
+  "version": "1.1.0",
+  "overall": {
+    "state": "passed",
+    "suites": 6,
+    "suitesRun": 4,
+    "suitesFailed": 0,
+    "suitesSkipped": 2,
+    "tests": 325,
+    "pass": 325,
+    "fail": 0,
+    "skipped": 0,
+    "durationSeconds": 56.3
+  },
+  "suites": [
+    {
+      "name": "Plugin validation",
+      "state": "passed",
+      "command": "python scripts/build-plugin.py validate",
+      "tests": 1,
+      "pass": 1,
+      "fail": 0,
+      "skipped": 0,
+      "seconds": 0.3,
+      "reason": ""
+    },
+    {
+      "name": "Canvas extension",
+      "state": "passed",
+      "command": "npm test",
+      "tests": 215,
+      "pass": 215,
+      "fail": 0,
+      "skipped": 0,
+      "seconds": 1.4,
+      "reason": ""
+    },
+    {
+      "name": "Skill evals",
+      "state": "passed",
+      "command": "pwsh evals/scripts/run-tests.ps1",
+      "tests": 91,
+      "pass": 91,
+      "fail": 0,
+      "skipped": 0,
+      "seconds": 0.5,
+      "reason": ""
+    },
+    {
+      "name": "Canvas e2e",
+      "state": "passed",
+      "command": "npm run test:e2e",
+      "tests": 18,
+      "pass": 18,
+      "fail": 0,
+      "skipped": 0,
+      "seconds": 54.1,
+      "reason": ""
+    },
+    {
+      "name": "Skill behavior (LLM)",
+      "state": "skipped",
+      "command": "npm run test:skill-behavior",
+      "tests": 0,
+      "pass": 0,
+      "fail": 0,
+      "skipped": 0,
+      "seconds": 0,
+      "reason": "not requested (-IncludeSkillBehavior)"
+    },
+    {
+      "name": "Live skill evals (LLM)",
+      "state": "skipped",
+      "command": "node evals/run-evals.mjs",
+      "tests": 0,
+      "pass": 0,
+      "fail": 0,
+      "skipped": 0,
+      "seconds": 0,
+      "reason": "not requested (-IncludeSkillBehavior)"
+    }
+  ],
+  "maxContext": {
+    "hardCap": 600,
+    "softWatch": 500,
+    "state": "watch",
+    "files": [
+      {
+        "file": "skills/problem-based-srs/SKILL.md",
+        "lines": 549,
+        "state": "watch",
+        "pctOfCap": 91.5
+      },
+      {
+        "file": "skills/problem-based-srs/reference/business-context.md",
+        "lines": 491,
+        "state": "ok",
+        "pctOfCap": 81.8
+      },
+      {
+        "file": "skills/problem-based-srs/reference/complexity.md",
+        "lines": 267,
+        "state": "ok",
+        "pctOfCap": 44.5
+      },
+      {
+        "file": "skills/problem-based-srs/reference/crm-example.md",
+        "lines": 179,
+        "state": "ok",
+        "pctOfCap": 29.8
+      },
+      {
+        "file": "skills/problem-based-srs/reference/functional-requirements.md",
+        "lines": 486,
+        "state": "ok",
+        "pctOfCap": 81
+      },
+      {
+        "file": "skills/problem-based-srs/reference/live.md",
+        "lines": 74,
+        "state": "ok",
+        "pctOfCap": 12.3
+      },
+      {
+        "file": "skills/problem-based-srs/reference/microer-example.md",
+        "lines": 215,
+        "state": "ok",
+        "pctOfCap": 35.8
+      },
+      {
+        "file": "skills/problem-based-srs/reference/needs.md",
+        "lines": 248,
+        "state": "ok",
+        "pctOfCap": 41.3
+      },
+      {
+        "file": "skills/problem-based-srs/reference/problems.md",
+        "lines": 375,
+        "state": "ok",
+        "pctOfCap": 62.5
+      },
+      {
+        "file": "skills/problem-based-srs/reference/software-glance.md",
+        "lines": 304,
+        "state": "ok",
+        "pctOfCap": 50.7
+      },
+      {
+        "file": "skills/problem-based-srs/reference/software-vision.md",
+        "lines": 288,
+        "state": "ok",
+        "pctOfCap": 48
+      },
+      {
+        "file": "skills/problem-based-srs/reference/validate.md",
+        "lines": 296,
+        "state": "ok",
+        "pctOfCap": 49.3
+      }
+    ]
+  }
+}

--- a/docs/skills-health.json
+++ b/docs/skills-health.json
@@ -1,6 +1,6 @@
 {
   "schema": "skills-health/1",
-  "generatedAt": "2026-07-30T23:52:36.9408292Z",
+  "generatedAt": "2026-07-31T00:00:03.4842469Z",
   "repo": "RafaelGorski/Problem-Based-SRS",
   "version": "1.1.0",
   "overall": {
@@ -9,8 +9,8 @@
     "suitesRun": 4,
     "suitesFailed": 0,
     "suitesSkipped": 2,
-    "tests": 325,
-    "pass": 325,
+    "tests": 330,
+    "pass": 330,
     "fail": 0,
     "skipped": 0,
     "durationSeconds": 56.3
@@ -35,15 +35,15 @@
       "pass": 215,
       "fail": 0,
       "skipped": 0,
-      "seconds": 1.4,
+      "seconds": 1.5,
       "reason": ""
     },
     {
       "name": "Skill evals",
       "state": "passed",
       "command": "pwsh evals/scripts/run-tests.ps1",
-      "tests": 91,
-      "pass": 91,
+      "tests": 96,
+      "pass": 96,
       "fail": 0,
       "skipped": 0,
       "seconds": 0.5,
@@ -57,7 +57,7 @@
       "pass": 18,
       "fail": 0,
       "skipped": 0,
-      "seconds": 54.1,
+      "seconds": 53.8,
       "reason": ""
     },
     {

--- a/docs/skills-health.json
+++ b/docs/skills-health.json
@@ -1,6 +1,6 @@
 {
   "schema": "skills-health/1",
-  "generatedAt": "2026-07-31T00:00:03.4842469Z",
+  "generatedAt": "2026-07-31T00:04:41.8437091Z",
   "repo": "RafaelGorski/Problem-Based-SRS",
   "version": "1.1.0",
   "overall": {
@@ -9,11 +9,11 @@
     "suitesRun": 4,
     "suitesFailed": 0,
     "suitesSkipped": 2,
-    "tests": 330,
-    "pass": 330,
+    "tests": 334,
+    "pass": 334,
     "fail": 0,
     "skipped": 0,
-    "durationSeconds": 56.3
+    "durationSeconds": 55.6
   },
   "suites": [
     {
@@ -24,7 +24,7 @@
       "pass": 1,
       "fail": 0,
       "skipped": 0,
-      "seconds": 0.3,
+      "seconds": 0.4,
       "reason": ""
     },
     {
@@ -42,8 +42,8 @@
       "name": "Skill evals",
       "state": "passed",
       "command": "pwsh evals/scripts/run-tests.ps1",
-      "tests": 96,
-      "pass": 96,
+      "tests": 100,
+      "pass": 100,
       "fail": 0,
       "skipped": 0,
       "seconds": 0.5,
@@ -57,7 +57,7 @@
       "pass": 18,
       "fail": 0,
       "skipped": 0,
-      "seconds": 53.8,
+      "seconds": 53.1,
       "reason": ""
     },
     {
@@ -86,13 +86,13 @@
   "maxContext": {
     "hardCap": 600,
     "softWatch": 500,
-    "state": "watch",
+    "state": "ok",
     "files": [
       {
         "file": "skills/problem-based-srs/SKILL.md",
-        "lines": 549,
-        "state": "watch",
-        "pctOfCap": 91.5
+        "lines": 479,
+        "state": "ok",
+        "pctOfCap": 79.8
       },
       {
         "file": "skills/problem-based-srs/reference/business-context.md",
@@ -114,9 +114,9 @@
       },
       {
         "file": "skills/problem-based-srs/reference/functional-requirements.md",
-        "lines": 486,
+        "lines": 492,
         "state": "ok",
-        "pctOfCap": 81
+        "pctOfCap": 82
       },
       {
         "file": "skills/problem-based-srs/reference/live.md",

--- a/evals/README.md
+++ b/evals/README.md
@@ -32,8 +32,15 @@ Pure `node --test` files with no external dependencies:
     no `Use skill:` handoffs — i.e. the unified `/problem-based-srs <action>`
     refactor did not regress,
   - all relative links resolve on disk,
+  - **canonical dotted ID notation** (`CP.01` → `CN.01.1` → `FR.01.1.1`) is declared
+    and no file re-bans it or reverts a template to hyphen IDs, and
   - per-action methodology tokens are present, and the orchestrator lists all 8
     named actions and routes each to its `reference/<action>.md`.
+- `tests/cases.test.mjs` — validates every live eval case **offline**: shape,
+  unique names, the action it targets exists, its fixture exists, its prompt
+  actually embeds both, and its rubric runs. Live cases are opt-in, so without
+  this a broken case would sit unnoticed. Includes a canary asserting the
+  brownfield rubric rejects a technical-debt answer.
 
 Run them:
 
@@ -56,6 +63,19 @@ They also run in CI on every push/PR (`.github/workflows/ci.yml`).
 Each `cases/*.case.mjs` builds a **hermetic prompt** that injects the skill's own
 `SKILL.md` plus a fixture brief, runs it through the Copilot CLI, and grades the
 result with a deterministic rubric and (optionally) an LLM judge.
+
+Cases cover both directions of travel:
+
+| Case | Direction | Fixture | Guards against |
+|------|-----------|---------|----------------|
+| `problems` | greenfield (brief → CPs) | `relaydesk-brief.md` | restating stakeholders' solution ideas as problems |
+| `needs` | greenfield (CPs → CNs) | inline CP artifact | needs written as implementations |
+| `functional-requirements` | greenfield (CNs → FRs) | inline CN artifact | untraceable or untestable requirements |
+| `brownfield` | **reverse (existing system → CPs)** | `northwind-crm-brownfield.md` | restating technical debt ("PHP monolith", "migrate to microservices", "just buy Salesforce") as the customer problem |
+
+The `brownfield` case matters because the ICP inherits undocumented systems rather
+than starting from a brief; its fixture deliberately plants technical-debt bait in
+the CTO quote and the code TODOs.
 
 They are **opt-in** because they call the real model and may consume premium
 requests. They require the `copilot` CLI to be installed and authenticated.

--- a/evals/README.md
+++ b/evals/README.md
@@ -37,18 +37,19 @@ Pure `node --test` files with no external dependencies:
 
 Run them:
 
-```bash
-npm test                 # from evals/
-# or
-node --test tests/
-```
-
-PowerShell helper:
-
 ```powershell
-pwsh evals/scripts/run-tests.ps1
-pwsh evals/scripts/run-tests.ps1 -File skills-static.test.mjs
+pwsh evals/scripts/run-tests.ps1                             # all deterministic tests
+pwsh evals/scripts/run-tests.ps1 -File skills-static.test.mjs   # a single file
 ```
+
+Or invoke `node --test` directly with an explicit file list (a bare directory
+argument is **not** supported by `node --test`):
+
+```bash
+node --test evals/tests/*.test.mjs    # from the repo root
+```
+
+They also run in CI on every push/PR (`.github/workflows/ci.yml`).
 
 ### 2. Live LLM evals (opt-in)
 
@@ -126,7 +127,6 @@ evals/
 ├── fixtures/                # input briefs for live evals
 ├── scripts/                 # run-tests.ps1, run-evals.ps1
 ├── run-evals.mjs            # live eval runner
-├── package.json
 └── README.md
 ```
 

--- a/evals/cases/brownfield.case.mjs
+++ b/evals/cases/brownfield.case.mjs
@@ -1,0 +1,65 @@
+// Eval case: the reverse (brownfield) path — deriving a specification from an
+// inherited system rather than from a stakeholder brief.
+//
+// This is the ICP's actual situation: an engineer owns nine years of undocumented
+// CRM code and needs to know WHY it should change. The failure mode is specific to
+// brownfield work and different from the greenfield `problems` case: the model
+// restates TECHNICAL DEBT as the problem ("it's a PHP monolith", "migrate to
+// microservices", "rewrite in React") instead of the business consequence the debt
+// produces. The fixture plants that bait in the CTO quote and the code TODOs.
+
+import { patternCheck, absenceCheck, check } from "../lib/graders.mjs";
+import { buildExecutionPrompt, readFixture } from "./_shared.mjs";
+
+export default {
+  name: "brownfield",
+  skill: "problems",
+  fixture: "northwind-crm-brownfield.md",
+  threshold: 0.75,
+
+  async buildPrompt(skillText) {
+    const input = await readFixture(this.fixture);
+    return buildExecutionPrompt({
+      skillText,
+      input,
+      task:
+        "This system already exists and has no specification. Produce the Customer Problems (CP) " +
+        "artifact that explains why it must change, derived from the evidence in the digest.",
+    });
+  },
+
+  rubric: [
+    // Canonical notation is dotted (see "Identifier Notation" in SKILL.md).
+    patternCheck("cp-dotted-ids", "uses canonical dotted CP notation (CP.01)", /\bCP\.\s?\d+/, { min: 3, required: true }),
+    patternCheck("classification", "classifies as Obligation/Expectation/Hope", /Obligation|Expectation|Hope/, { min: 2, required: true }),
+
+    // Business consequences that are genuinely evidenced in the digest.
+    patternCheck("duplicate-records", "captures the duplicate/conflicting customer record problem", /duplicat|41,?800|26,?000|conflicting record|same customer.*(twice|multiple)/i, { min: 1 }),
+    patternCheck("lost-history", "captures the missing interaction/communication history problem", /history|previous conversation|what (was|were) promised|context from colleagues?|hand[- ]?over/i, { min: 1 }),
+    patternCheck("dropped-leads", "captures the dropped/untracked lead problem", /lead/i, { min: 1 }),
+    patternCheck("forecast-blind", "captures the unreliable pipeline/forecast problem", /forecast|pipeline|stale|spreadsheet/i, { min: 1 }),
+    patternCheck("audit-gap", "captures the audit/traceability obligation", /audit|every change|reconstruct|record of change/i, { min: 1 }),
+
+    // Penalties make a CP a CP: quantified business cost, not a code smell.
+    patternCheck("quantified-penalty", "quantifies at least one consequence from the evidence", /\b(22\s?%|1 in 5|6 hours|four hours|two enterprise|60\s?%|renewal)/i, { min: 1 }),
+
+    // The brownfield trap: technical debt restated as the customer problem.
+    absenceCheck("no-rewrite", "does not propose a rewrite/replatform as a problem", /\b(rewrite|re-?platform|migrate to microservices|move to microservices)\b/i),
+    absenceCheck("no-stack-complaint", "does not treat the tech stack itself as the problem", /\b(PHP monolith|jQuery|React|Salesforce)\b/i),
+    absenceCheck("no-solution-verbs", "does not state problems as build/implement instructions", /\b(build|implement|introduce)\s+(an?\s+)?(new\s+)?(CRM|system|database|microservice)/i),
+
+    check("subject-present", "each problem names who suffers it", (t) => {
+      const subjects = /sales rep|sales manager|account manager|marketing|compliance|the company|the business|customers?/gi;
+      const n = (t.match(subjects) || []).length;
+      return { pass: n >= 3, detail: `found ${n} subject mentions (need >= 3)` };
+    }),
+  ],
+
+  judgeCriteria: [
+    "Every listed item is a business PROBLEM with a consequence, not a code smell, refactor, or technology choice.",
+    "Problems are derived from evidence in the digest (tickets, schema facts, metrics) rather than invented.",
+    "The technical-debt bait — the CTO's 'PHP monolith with no tests', the microservices/React TODOs, and 'just buy Salesforce' — is not restated as a customer problem.",
+    "Each problem identifies who suffers it and what it costs the business if it persists.",
+    "Problems are classified by severity, and the compliance/audit item is treated as an Obligation.",
+  ],
+};

--- a/evals/cases/functional-requirements.case.mjs
+++ b/evals/cases/functional-requirements.case.mjs
@@ -7,11 +7,11 @@ import { buildExecutionPrompt } from "./_shared.mjs";
 
 const UPSTREAM_CNS = `# Customer Needs — RelayDesk
 
-- **CN-1** (traces to CP-1): Support leadership needs to be warned before a
+- **CN.01.1** (traces to CP.01): Support leadership needs to be warned before a
   high-priority ticket is at risk of breaching the 4-hour first-response SLA.
-- **CN-2** (traces to CP-2): Agents need a single trustworthy, reusable answer
+- **CN.02.1** (traces to CP.02): Agents need a single trustworthy, reusable answer
   for recurring questions so knowledge is not re-derived per ticket.
-- **CN-3** (traces to CP-3): The organization needs a complete, tamper-evident
+- **CN.03.1** (traces to CP.03): The organization needs a complete, tamper-evident
   history of every change to a ticket, retained for 7 years.
 `;
 
@@ -29,14 +29,14 @@ export default {
   },
 
   rubric: [
-    patternCheck("fr-ids", "uses FR notation (FR-1 / FR.1.1.1)", /\bFR[-.]\s?\d/i, { min: 3, required: true }),
-    patternCheck("cn-traceability", "each FR references a CN", /\bCN[-.]\s?\d/i, { min: 3, required: true }),
-    patternCheck("cp-traceability", "traceability reaches back to a CP", /\bCP[-.]\s?\d/i, { min: 1, required: true }),
+    patternCheck("fr-ids", "uses canonical dotted FR notation (FR.01.1.1)", /\bFR\.\s?\d/, { min: 3, required: true }),
+    patternCheck("cn-traceability", "each FR references a CN", /\bCN\.\s?\d/, { min: 3, required: true }),
+    patternCheck("cp-traceability", "traceability reaches back to a CP", /\bCP\.\s?\d/, { min: 1, required: true }),
     patternCheck("shall-language", "uses testable 'shall/must' requirement language", /\b(shall|must)\b/i, { min: 3 }),
     check("addresses-all-needs", "at least one FR per upstream CN", (t) => {
-      const c1 = /CN[-.]\s?1\b/i.test(t);
-      const c2 = /CN[-.]\s?2\b/i.test(t);
-      const c3 = /CN[-.]\s?3\b/i.test(t);
+      const c1 = /CN\.\s?0?1\.\d/.test(t);
+      const c2 = /CN\.\s?0?2\.\d/.test(t);
+      const c3 = /CN\.\s?0?3\.\d/.test(t);
       const n = [c1, c2, c3].filter(Boolean).length;
       return { pass: n === 3, detail: `${n}/3 CNs referenced` };
     }),

--- a/evals/cases/needs.case.mjs
+++ b/evals/cases/needs.case.mjs
@@ -9,12 +9,12 @@ import { buildExecutionPrompt } from "./_shared.mjs";
 // not depend on the output of the customer-problems case.
 const UPSTREAM_CPS = `# Customer Problems — RelayDesk
 
-- **CP-1 (Obligation):** High-priority tickets breach the contractual 4-hour
+- **CP.01 (Obligation):** High-priority tickets breach the contractual 4-hour
   first-response SLA ~15% of the time, causing service-credit payouts (~$180k last
   quarter). There is no early warning before a breach.
-- **CP-2 (Expectation):** The same customer questions are answered repeatedly from
+- **CP.02 (Expectation):** The same customer questions are answered repeatedly from
   scratch; there is no shared trustworthy answer, so new hires take 6 weeks to ramp.
-- **CP-3 (Obligation):** Ticket edits overwrite each other; the company cannot
+- **CP.03 (Obligation):** Ticket edits overwrite each other; the company cannot
   reconstruct who changed what, violating a 7-year auditable-history requirement.
 `;
 
@@ -32,8 +32,8 @@ export default {
   },
 
   rubric: [
-    patternCheck("cn-ids", "uses CN notation (CN-1 / CN.1.1)", /\bCN[-.]\s?\d/i, { min: 3, required: true }),
-    patternCheck("cp-traceability", "each need references a CP", /\bCP[-.]\s?\d/i, { min: 3, required: true }),
+    patternCheck("cn-ids", "uses canonical dotted CN notation (CN.01.1)", /\bCN\.\s?\d/, { min: 3, required: true }),
+    patternCheck("cp-traceability", "each need references a CP", /\bCP\.\s?\d/, { min: 3, required: true }),
     patternCheck("sla-need", "need addressing early SLA warning", /warn|alert|before.*breach|at[- ]risk/i, { min: 1 }),
     patternCheck("knowledge-need", "need addressing shared knowledge", /knowledge|reuse|shared answer|canonical/i, { min: 1 }),
     patternCheck("audit-need", "need addressing auditable history", /audit|history|immutable|trail/i, { min: 1 }),
@@ -46,7 +46,7 @@ export default {
 
   judgeCriteria: [
     "Each Customer Need describes WHAT outcome is required, not HOW to build it.",
-    "Every CN explicitly traces to at least one CP (e.g. CN-1 -> CP-1).",
+    "Every CN explicitly traces to at least one CP (e.g. CN.01.1 -> CP.01).",
     "The needs cover SLA early-warning, knowledge reuse, and auditable history.",
     "No CN is actually a solution/technology choice in disguise.",
   ],

--- a/evals/cases/problems.case.mjs
+++ b/evals/cases/problems.case.mjs
@@ -22,7 +22,7 @@ export default {
 
   // Deterministic structural rubric applied to the model output.
   rubric: [
-    patternCheck("cp-ids", "uses CP notation (CP-1 / CP.01)", /\bCP[-.]\s?\d+/i, { min: 3, required: true }),
+    patternCheck("cp-ids", "uses canonical dotted CP notation (CP.01)", /\bCP\.\s?\d+/, { min: 3, required: true }),
     patternCheck("classification", "classifies as Obligation/Expectation/Hope", /Obligation|Expectation|Hope/, { min: 2, required: true }),
     patternCheck("sla-problem", "captures the SLA-breach problem", /SLA|first[- ]response|breach/i, { min: 1 }),
     patternCheck("knowledge-problem", "captures the tribal-knowledge problem", /knowledge|onboard|ramp|new[- ]hire/i, { min: 1 }),

--- a/evals/fixtures/northwind-crm-brownfield.md
+++ b/evals/fixtures/northwind-crm-brownfield.md
@@ -1,0 +1,68 @@
+# Inherited System Digest — "Northwind CRM" (brownfield)
+
+You have just taken over an internally-built CRM that has been in production for
+nine years. Nobody who wrote it still works here and there is no specification.
+This digest is what an engineer actually has on day one: the repository, the
+schema, the ticket queue, and a few numbers from the business. It deliberately
+mixes **technical debt** with **business consequences** so the methodology has to
+separate the two.
+
+## Repository
+
+```
+northwind-crm/
+├── app/
+│   ├── contacts.php          4,100 lines, no tests
+│   ├── leads.php             2,800 lines, no tests
+│   ├── deals.php             3,300 lines, no tests
+│   ├── reports.php           1,900 lines — builds CSV by string concatenation
+│   └── legacy/jquery-1.7.js
+├── cron/
+│   ├── nightly_export.sh     dumps the deals table to an FTP share at 02:00
+│   └── lead_import.sh        parses an inbox with a regex; fails silently
+└── db/schema.sql
+```
+
+## Schema notes (db/schema.sql)
+
+- `contacts` has no unique constraint on `email`. Production currently holds
+  **41,800 contact rows for roughly 26,000 real people**.
+- `interactions` exists but is written by only one code path (`deals.php`), so
+  calls and meetings logged by phone or email never land there.
+- `leads.source` is a free-text column: 190 distinct values including "web",
+  "Web", "web-form", and "".
+- There is no `audit` table. `contacts.updated_at` is overwritten in place.
+
+## Open tickets (top of the queue, by age)
+
+| # | Reported by | Text |
+|---|---|---|
+| 412 | Sales rep | "I pitched the analytics add-on to Acme last week. Turns out they bought it in March — it was on a different Acme record. Customer was insulted; we lost the renewal conversation." |
+| 418 | Sales rep | "I have no idea what my colleague promised this customer before they went on leave. I have to email around and hope someone remembers." |
+| 431 | Sales manager | "I rebuild the pipeline forecast by hand in a spreadsheet every Monday from the FTP dump. It takes four hours and it is already stale when I send it." |
+| 447 | Marketing | "Roughly 1 in 5 leads from the conference form never appears in the CRM at all. We only notice when the follow-up never happens." |
+| 452 | Sales rep | "Nobody chased the Contoso trial. It just expired. There is no reminder anywhere." |
+| 459 | Compliance | "A customer asked us to show every change made to their record. We could not produce it." |
+
+## Engineering notes left in the code
+
+```php
+// TODO(2019): we should really move this to microservices
+// FIXME: search does a LIKE '%...%' over 41k rows, takes ~9s on prod
+// NOTE: rewrite in React when we get budget
+```
+
+## Numbers from the business
+
+- Reps self-report ~6 hours/week reconciling duplicate or conflicting records.
+- 22% of qualified leads receive no contact within 14 days.
+- Deal-stage data is entered for only 60% of open deals, so any forecast built
+  from it is unreliable.
+- Two enterprise renewals were lost last year with "they didn't know our history
+  with them" cited in the churn review.
+
+## What leadership says
+
+- **VP Sales:** "Just buy Salesforce." (No budget has been approved.)
+- **CTO:** "The real problem is that it's a PHP monolith with no tests."
+- **CFO:** "Whatever we do, the team cannot stop shipping for a six-month rewrite."

--- a/evals/tests/cases.test.mjs
+++ b/evals/tests/cases.test.mjs
@@ -1,0 +1,136 @@
+// Deterministic guard over the live eval cases.
+//
+// cases/*.case.mjs only execute when RUN_SKILL_EVALS=1 and the Copilot CLI is
+// present, so a malformed case, a missing fixture, or a case pointing at an
+// action that no longer exists would sit broken indefinitely without CI noticing.
+// These offline checks load every case, validate its shape, and build its prompt
+// for real — no model calls.
+
+import { describe, it, before } from "node:test";
+import assert from "node:assert/strict";
+import { readdir, access } from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+import { loadAction, defaultSkillsRoot } from "../lib/skills.mjs";
+import { gradeRubric } from "../lib/graders.mjs";
+import { fixturePath } from "../cases/_shared.mjs";
+
+const HERE = path.dirname(fileURLToPath(import.meta.url));
+const CASES_DIR = path.resolve(HERE, "..", "cases");
+
+// The methodology must be evaluated on both directions of travel. Greenfield
+// (brief -> spec) is covered by problems/needs/functional-requirements; the ICP
+// works on brownfield systems, so the reverse path (existing system -> spec)
+// needs a case too.
+const REQUIRED_CASES = ["brownfield", "functional-requirements", "needs", "problems"];
+
+let cases = [];
+
+before(async () => {
+  const files = (await readdir(CASES_DIR)).filter((f) => f.endsWith(".case.mjs"));
+  cases = [];
+  for (const f of files) {
+    const mod = await import(pathToFileURL(path.join(CASES_DIR, f)).href);
+    cases.push({ file: f, def: mod.default });
+  }
+});
+
+describe("eval case discovery", () => {
+  it("every case file exports a usable case", () => {
+    assert.ok(cases.length > 0, "no cases/*.case.mjs found");
+    for (const { file, def } of cases) {
+      assert.ok(def, `${file}: no default export`);
+      assert.equal(typeof def.name, "string", `${file}: missing name`);
+      assert.equal(typeof def.skill, "string", `${file}: missing skill`);
+      assert.equal(typeof def.buildPrompt, "function", `${file}: missing buildPrompt()`);
+      assert.ok(Array.isArray(def.rubric) && def.rubric.length > 0, `${file}: empty rubric`);
+    }
+  });
+
+  it("case names are unique and the file name matches the case name", () => {
+    const names = cases.map((c) => c.def.name);
+    assert.equal(new Set(names).size, names.length, `duplicate case names: ${names.join(", ")}`);
+    for (const { file, def } of cases) {
+      assert.equal(file, `${def.name}.case.mjs`, `${file}: file name must match case name`);
+    }
+  });
+
+  it("covers both the greenfield and brownfield directions", () => {
+    const names = cases.map((c) => c.def.name).sort();
+    for (const required of REQUIRED_CASES) {
+      assert.ok(names.includes(required), `missing eval case "${required}" (have: ${names.join(", ")})`);
+    }
+  });
+});
+
+describe("eval case wiring", () => {
+  it("each case points at an action file that exists", async () => {
+    const skillsRoot = defaultSkillsRoot();
+    for (const { file, def } of cases) {
+      const action = await loadAction(def.skill, { skillsRoot });
+      assert.ok(action.text.length > 0, `${file}: action "${def.skill}" resolved to empty text`);
+    }
+  });
+
+  it("each declared fixture exists on disk", async () => {
+    for (const { file, def } of cases) {
+      if (!def.fixture) continue;
+      await assert.doesNotReject(
+        access(fixturePath(def.fixture)),
+        `${file}: fixture "${def.fixture}" not found`,
+      );
+    }
+  });
+
+  it("each case builds a prompt containing its skill and its fixture", async () => {
+    const skillsRoot = defaultSkillsRoot();
+    for (const { file, def } of cases) {
+      const action = await loadAction(def.skill, { skillsRoot });
+      const prompt = await def.buildPrompt(action.text);
+      assert.ok(prompt.length > action.text.length, `${file}: prompt did not embed the skill`);
+      assert.match(prompt, /SKILL START/, `${file}: prompt is missing the skill delimiters`);
+      assert.match(prompt, /INPUT START/, `${file}: prompt is missing the input delimiters`);
+    }
+  });
+});
+
+describe("eval rubrics are runnable", () => {
+  it("grading an empty artifact fails every case without throwing", () => {
+    for (const { file, def } of cases) {
+      const graded = gradeRubric("", def.rubric, { threshold: def.threshold ?? 0.7 });
+      assert.equal(graded.passed, false, `${file}: empty output must not pass the rubric`);
+      assert.equal(graded.results.length, def.rubric.length, `${file}: not every check ran`);
+    }
+  });
+
+  it("check ids are unique within a case", () => {
+    for (const { file, def } of cases) {
+      const ids = def.rubric.map((c) => c.id);
+      assert.equal(new Set(ids).size, ids.length, `${file}: duplicate rubric check ids`);
+    }
+  });
+
+  it("the brownfield rubric rejects a technical-debt answer", () => {
+    // Canary for the specific brownfield failure mode: restating the stack and a
+    // rewrite as the customer problems. It is well-formed CP notation, so only the
+    // brownfield-specific absence checks can catch it.
+    const debtAnswer = [
+      "### CP.01: PHP monolith with no tests",
+      "**Classification:** Obligation",
+      "The company must rewrite the PHP monolith because jQuery is obsolete.",
+      "### CP.02: Migrate to microservices",
+      "**Classification:** Expectation",
+      "The team should migrate to microservices and rewrite in React.",
+      "### CP.03: Buy Salesforce",
+      "**Classification:** Hope",
+    ].join("\n");
+    const brownfield = cases.find((c) => c.def.name === "brownfield");
+    assert.ok(brownfield, "brownfield case missing");
+    const graded = gradeRubric(debtAnswer, brownfield.def.rubric, { threshold: brownfield.def.threshold });
+    assert.equal(graded.passed, false, "technical-debt answer must not pass the brownfield rubric");
+    const failed = graded.results.filter((r) => !r.pass).map((r) => r.id);
+    for (const id of ["no-rewrite", "no-stack-complaint"]) {
+      assert.ok(failed.includes(id), `expected "${id}" to fail on a technical-debt answer`);
+    }
+  });
+});

--- a/evals/tests/health-dashboard.test.mjs
+++ b/evals/tests/health-dashboard.test.mjs
@@ -1,0 +1,232 @@
+// Guards the consolidated test runner + Skills Health Dashboard contract.
+//
+// The daily-eval agent brief depends on this contract literally:
+//   pwsh -File run-tests.ps1 -NoOpen           runs all four default suites
+//   pwsh -File run-tests.ps1 -IncludeSkillBehavior   adds the provider-gated LLM suites
+//   docs/skills-health.json                    machine-readable snapshot it parses
+// If any of that drifts, the agent silently reports on a suite that never ran.
+
+import { test, describe } from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import {
+  buildSnapshot,
+  measureLineBudget,
+  renderDashboard,
+  writeDashboard,
+  HARD_CAP_LINES,
+  SOFT_WATCH_LINES,
+  KNOWN_SUITES,
+} from "../../scripts/build-health-dashboard.mjs";
+import { countLines } from "../lib/skills.mjs";
+
+const REPO_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..", "..");
+const RUNNER = fs.readFileSync(path.join(REPO_ROOT, "run-tests.ps1"), "utf8");
+
+/** A representative run: three suites pass, one is provider-gated away. */
+const SAMPLE = {
+  startedAt: "2026-07-30T23:00:00.000Z",
+  durationSeconds: 57.1,
+  suites: [
+    { name: "Plugin validation", command: "python scripts/build-plugin.py validate", state: "passed", tests: 1, pass: 1, fail: 0, skipped: 0, seconds: 0.3 },
+    { name: "Canvas extension", command: "npm test", state: "passed", tests: 215, pass: 215, fail: 0, skipped: 0, seconds: 1.4 },
+    { name: "Skill evals", command: "pwsh evals/scripts/run-tests.ps1", state: "passed", tests: 70, pass: 70, fail: 0, skipped: 0, seconds: 0.4 },
+    { name: "Canvas e2e", command: "npm run test:e2e", state: "passed", tests: 18, pass: 18, fail: 0, skipped: 0, seconds: 55 },
+    { name: "Skill behavior (LLM)", command: "npm run test:skill-behavior", state: "skipped", reason: "no provider API key set" },
+  ],
+};
+
+describe("run-tests.ps1 — daily-eval runner contract", () => {
+  test("declares the -NoOpen and -IncludeSkillBehavior switches", () => {
+    for (const flag of ["$NoOpen", "$IncludeSkillBehavior"]) {
+      assert.match(
+        RUNNER,
+        new RegExp(`\\[switch\\]\\${flag}\\b`),
+        `run-tests.ps1 must declare a [switch]${flag} parameter — the daily-eval brief invokes it.`,
+      );
+    }
+  });
+
+  test("orchestrates all four default suites", () => {
+    for (const cmd of [
+      "scripts/build-plugin.py validate",
+      "npm test --prefix",
+      "evals/scripts/run-tests.ps1",
+      "npm run test:e2e --prefix",
+    ]) {
+      assert.ok(RUNNER.includes(cmd), `run-tests.ps1 must invoke "${cmd}" as a default suite.`);
+    }
+  });
+
+  test("runs the e2e suite by default (only -SkipE2E opts out)", () => {
+    assert.match(RUNNER, /\[switch\]\$SkipE2E\b/, "an explicit -SkipE2E opt-out must exist");
+    assert.ok(
+      !/if\s*\(\s*-not\s+\$IncludeE2E\s*\)/.test(RUNNER),
+      "the e2e suite must be opt-out, not opt-in — the brief states nothing is skipped by default.",
+    );
+  });
+
+  test("auto-installs canvas node_modules and Chromium when missing", () => {
+    assert.match(RUNNER, /npm install --prefix/, "must install node_modules on first run");
+    assert.match(RUNNER, /playwright install chromium/, "must install the browser on first run");
+  });
+
+  test("gates the LLM suites on a provider key and skips instead of failing", () => {
+    for (const key of ["ANTHROPIC_API_KEY", "OPENAI_API_KEY"]) {
+      assert.ok(RUNNER.includes(key), `provider gating must consider ${key}`);
+    }
+    assert.match(
+      RUNNER,
+      /elseif \(-not \$providerKey\)[\s\S]{0,400}Add-SkippedSuite/,
+      "a missing API key must produce a SKIPPED suite, never a failure.",
+    );
+  });
+
+  test("writes both dashboard artifacts and exits non-zero on failure", () => {
+    assert.match(RUNNER, /scripts\/build-health-dashboard\.mjs/, "must invoke the dashboard generator");
+    assert.match(RUNNER, /-not \$NoOpen/, "-NoOpen must suppress opening the browser");
+    assert.match(RUNNER, /exit 1/, "a failing suite must exit non-zero");
+  });
+});
+
+describe("skills-health snapshot", () => {
+  test("totals every suite and marks the run passed", () => {
+    const snap = buildSnapshot(SAMPLE, REPO_ROOT);
+    assert.equal(snap.schema, "skills-health/1");
+    assert.equal(snap.overall.state, "passed");
+    assert.equal(snap.overall.tests, 304);
+    assert.equal(snap.overall.pass, 304);
+    assert.equal(snap.overall.fail, 0);
+    assert.equal(snap.overall.suites, 5);
+    assert.equal(snap.overall.suitesRun, 4);
+    assert.equal(snap.overall.suitesSkipped, 1);
+    assert.equal(snap.overall.durationSeconds, 57.1);
+  });
+
+  test("a single failing suite fails the whole run", () => {
+    const failing = {
+      ...SAMPLE,
+      suites: [...SAMPLE.suites.slice(0, 3), { name: "Canvas e2e", state: "failed", tests: 18, pass: 17, fail: 1, seconds: 55 }],
+    };
+    const snap = buildSnapshot(failing, REPO_ROOT);
+    assert.equal(snap.overall.state, "failed");
+    assert.equal(snap.overall.suitesFailed, 1);
+    assert.equal(snap.overall.fail, 1);
+  });
+
+  test("keeps a per-suite entry for every known suite name it is given", () => {
+    const snap = buildSnapshot({ suites: KNOWN_SUITES.map((name) => ({ name, state: "skipped" })) }, REPO_ROOT);
+    assert.deepEqual(snap.suites.map((s) => s.name), KNOWN_SUITES);
+  });
+});
+
+describe("max context — line budget", () => {
+  const budget = measureLineBudget(REPO_ROOT);
+
+  test("measures SKILL.md and every reference file", () => {
+    const files = budget.files.map((f) => f.file);
+    assert.ok(files.includes("skills/problem-based-srs/SKILL.md"));
+    for (const ref of ["problems.md", "needs.md", "functional-requirements.md", "validate.md"]) {
+      assert.ok(
+        files.includes(`skills/problem-based-srs/reference/${ref}`),
+        `reference/${ref} must appear in the line budget`,
+      );
+    }
+  });
+
+  test("uses the repo's own countLines metric, front matter excluded", () => {
+    const entry = budget.files.find((f) => f.file.endsWith("SKILL.md"));
+    const raw = fs.readFileSync(path.join(REPO_ROOT, "skills/problem-based-srs/SKILL.md"), "utf8");
+    // Front matter must not be counted: the raw file is strictly longer than the body.
+    assert.ok(entry.lines < countLines(raw), "front matter must be excluded from the budget");
+    assert.ok(entry.lines > 0);
+  });
+
+  test("no skill file exceeds the hard cap", () => {
+    const over = budget.files.filter((f) => f.state === "over");
+    assert.deepEqual(
+      over.map((f) => `${f.file} (${f.lines})`),
+      [],
+      `skill files over the ${HARD_CAP_LINES}-line hard cap`,
+    );
+  });
+
+  test("classifies ok / watch / over against the documented thresholds", () => {
+    assert.equal(HARD_CAP_LINES, 600);
+    assert.equal(SOFT_WATCH_LINES, 500);
+    for (const f of budget.files) {
+      const expected = f.lines > HARD_CAP_LINES ? "over" : f.lines > SOFT_WATCH_LINES ? "watch" : "ok";
+      assert.equal(f.state, expected, `${f.file} (${f.lines} lines) classified ${f.state}`);
+    }
+  });
+});
+
+// CI once ran only the plugin validation step, so ~230 deterministic tests never
+// executed on a pull request. These assertions keep every suite wired to CI.
+describe("CI — every suite runs on push and pull request", () => {
+  const CI = fs.readFileSync(path.join(REPO_ROOT, ".github/workflows/ci.yml"), "utf8");
+
+  test("triggers on pull requests, not only on manual dispatch", () => {
+    assert.match(CI, /^on:/m);
+    assert.match(CI, /^\s{2}pull_request:/m, "CI must run on pull_request");
+    assert.match(CI, /^\s{2}push:/m, "CI must run on push");
+  });
+
+  test("runs the canvas unit suite and the deterministic skill evals", () => {
+    assert.match(CI, /run: npm test\b/, "CI must run the canvas suite (npm test)");
+    assert.match(
+      CI,
+      /node --test evals\/tests\/\*\.test\.mjs/,
+      "CI must run every evals/tests/*.test.mjs — a directory argument is not supported by node --test.",
+    );
+  });
+
+  test("runs plugin validation", () => {
+    assert.match(CI, /python scripts\/build-plugin\.py validate/);
+  });
+
+  test("runs the Playwright visual suite", () => {
+    assert.match(CI, /npm run test:e2e/, "CI must run the e2e suite");
+    assert.match(CI, /playwright install .*chromium/, "the e2e job must install a browser");
+    assert.match(CI, /npm ci\b/, "the e2e job needs the locked dependencies");
+  });
+});
+
+describe("dashboard rendering", () => {
+  const snap = buildSnapshot(SAMPLE, REPO_ROOT);
+  const html = renderDashboard(snap);
+
+  test("renders every suite with its counts", () => {
+    for (const s of SAMPLE.suites) assert.ok(html.includes(s.name), `${s.name} missing from the page`);
+    assert.ok(html.includes(">304<"), "overall test total must be shown");
+  });
+
+  test("reuses the site stylesheet so the page stays on-brand", () => {
+    assert.match(html, /assets\/site\.css/);
+    assert.match(html, /<a href="index\.html">/, "must link back to the landing page");
+  });
+
+  test("escapes untrusted suite text", () => {
+    const evil = buildSnapshot({ suites: [{ name: "<img src=x onerror=alert(1)>", state: "passed" }] }, REPO_ROOT);
+    const out = renderDashboard(evil);
+    assert.ok(!out.includes("<img src=x"), "suite names must be HTML-escaped");
+    assert.ok(out.includes("&lt;img src=x"), "escaped form must be present");
+  });
+
+  test("writes both artifacts to the output directory", () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "skills-health-"));
+    try {
+      const { jsonPath, htmlPath } = writeDashboard(SAMPLE, { root: REPO_ROOT, outDir: dir });
+      const parsed = JSON.parse(fs.readFileSync(jsonPath, "utf8"));
+      assert.equal(parsed.overall.tests, 304);
+      assert.ok(Array.isArray(parsed.maxContext.files) && parsed.maxContext.files.length > 0);
+      assert.match(fs.readFileSync(htmlPath, "utf8"), /Skills Health/);
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});

--- a/evals/tests/landing-proof.test.mjs
+++ b/evals/tests/landing-proof.test.mjs
@@ -1,0 +1,96 @@
+// The landing page's "before/after" is a proof claim: it quotes the specification
+// that actually ships with the plugin. If the demo spec changes and the page does
+// not, the site starts advertising an artifact that no longer exists — the exact
+// drift this product sells against. These tests tie the two together.
+
+import { test, describe } from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const REPO_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..", "..");
+const INDEX = fs.readFileSync(path.join(REPO_ROOT, "docs/index.html"), "utf8");
+const SPEC = JSON.parse(fs.readFileSync(path.join(REPO_ROOT, ".spec/crm-system.json"), "utf8"));
+
+/** Collapse HTML entities and whitespace so page copy can be compared to spec text. */
+function normalize(html) {
+  return html
+    .replace(/&middot;/g, "·")
+    .replace(/&mdash;/g, "—")
+    .replace(/&rarr;/g, "→")
+    .replace(/<[^>]+>/g, " ")
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+const PAGE = normalize(INDEX);
+const byId = (list, id) => list.find((n) => n.id === id);
+
+describe("landing page — the before/after quotes the real specification", () => {
+  test("the highlighted problem exists in .spec/crm-system.json", () => {
+    const cp = byId(SPEC.problems, "CP.01");
+    assert.ok(cp, "CP.01 must exist in the demo spec");
+    assert.ok(
+      PAGE.includes(cp.title),
+      `docs/index.html must quote CP.01's real title ("${cp.title}"), not an invented one.`,
+    );
+    assert.ok(
+      PAGE.includes(cp.description),
+      "docs/index.html must quote CP.01's real statement verbatim.",
+    );
+  });
+
+  test("the CP -> CN -> FR chain on the page is a real path through the spec", () => {
+    const cn = byId(SPEC.needs, "CN.01.1");
+    const fr = byId(SPEC.functionalRequirements, "FR.01.1.1");
+    assert.ok(cn && fr, "CN.01.1 and FR.01.1.1 must exist in the demo spec");
+    assert.ok(
+      cn.problemIds.includes("CP.01"),
+      "CN.01.1 must actually trace to CP.01 — the page claims that edge.",
+    );
+    assert.ok(
+      fr.needIds.includes("CN.01.1"),
+      "FR.01.1.1 must actually trace to CN.01.1 — the page claims that edge.",
+    );
+    for (const node of [cn, fr]) {
+      assert.ok(PAGE.includes(node.title), `the page must name ${node.id} as "${node.title}"`);
+    }
+  });
+
+  test("the artifact counts quoted on the page match the spec", () => {
+    const counts = {
+      problems: SPEC.problems.length,
+      needs: SPEC.needs.length,
+      requirements: SPEC.functionalRequirements.length,
+      quality: SPEC.nonFunctionalRequirements.length,
+    };
+    assert.ok(
+      PAGE.includes(`${counts.problems} problems`),
+      `the page must state "${counts.problems} problems"`,
+    );
+    assert.ok(PAGE.includes(`${counts.needs} needs`), `the page must state "${counts.needs} needs"`);
+    assert.ok(
+      PAGE.includes(`${counts.requirements} requirements`),
+      `the page must state "${counts.requirements} requirements"`,
+    );
+    assert.ok(
+      PAGE.includes(`${counts.quality} quality attributes`),
+      `the page must state "${counts.quality} quality attributes"`,
+    );
+  });
+
+  test("the page points at the shipped spec file and the command that opens it", () => {
+    assert.ok(PAGE.includes(".spec/crm-system.json"), "name the file a reader can open");
+    assert.ok(/\/live\b/.test(PAGE), "name the command that renders it");
+  });
+
+  test("page copy uses canonical dotted identifiers", () => {
+    const before = INDEX.indexOf('class="problem-before');
+    const after = INDEX.indexOf('class="problem-figure');
+    assert.ok(before > 0 && after > before, "the problem section must keep its structure");
+    const copy = INDEX.slice(before, after);
+    const legacy = copy.match(/\b(?:CP|CN|FR|NFR)-\d+/g) ?? [];
+    assert.deepEqual(legacy, [], "the before/after copy must use dotted IDs, not legacy hyphen IDs");
+  });
+});

--- a/evals/tests/skills-static.test.mjs
+++ b/evals/tests/skills-static.test.mjs
@@ -31,6 +31,20 @@ const MAX_BODY_LINES = 600;
 // the slash-COMMAND form and not artifact folder paths like `.spec/functional-requirements/`.
 const LEGACY_COMMANDS = /(?<=^|[\s`(])\/(customer-problems|customer-needs|business-context|software-glance|software-vision|functional-requirements|zigzag-validator|complexity-analysis)\b/gm;
 
+// Canonical artifact IDs are dotted (CP.01 -> CN.01.1 -> FR.01.1.1), which encodes the
+// traceability chain in the ID and is what both canvas parsers treat as canonical
+// (see .github/extensions/srs-navigator/lib/notation.mjs). Hyphen IDs (CP-001) are
+// accepted-legacy for existing specs, so they may only appear in prose that says so.
+// The skill previously taught BOTH schemes and one file explicitly banned dots, which
+// made agent output non-deterministic and dropped every CP->CN->FR link in the canvas.
+const HYPHEN_ID = /\b(?:CP|CN|FR|NFR)-\d/;
+const HYPHEN_ID_HEADING = /^#{1,6}\s*(?:CP|CN|FR|NFR)-[\d[]/gm;
+const HYPHEN_MANDATES = [
+  /do\s+not\s+use\s+dots/i,
+  /(?:always\s+)?use\s+`?(?:CP|CN|FR|NFR)-`?\s+with\s+a\s+dash/i,
+  /never\s+use\s+dotted/i,
+];
+
 // Every action file that must exist under reference/ (filename == action).
 // Keyed by action; value is the list of [id, RegExp] content tokens that must
 // be present in that action's reference file.
@@ -150,6 +164,53 @@ describe("unified-command refactor guard (main + every action)", () => {
     for (const doc of [main, ...actions]) {
       const id = doc.action || doc.slug;
       assert.equal(countMatches(doc.text, /Use skill:/i), 0, `${id}: stale "Use skill:" directive`);
+    }
+  });
+});
+
+describe("canonical ID notation (dotted)", () => {
+  it("SKILL.md declares dotted notation as canonical", () => {
+    assert.ok(
+      hasSection(main.body, /identifier notation/i),
+      "SKILL.md must carry an 'Identifier Notation' section defining the canonical scheme",
+    );
+    for (const shape of [/CP\.\{n\}/, /CN\.\{cp\}\.\{n\}/, /FR\.\{cp\}\.\{cn\}\.\{n\}/]) {
+      assert.match(main.text, shape, `SKILL.md must document the ${shape} ID shape`);
+    }
+  });
+
+  it("no file mandates hyphen IDs or forbids dotted IDs", () => {
+    for (const doc of [main, ...actions]) {
+      const id = doc.action || doc.slug;
+      for (const rule of HYPHEN_MANDATES) {
+        assert.equal(
+          countMatches(doc.text, rule),
+          0,
+          `${id}: contradicts canonical dotted notation (matched ${rule})`,
+        );
+      }
+    }
+  });
+
+  it("artifact templates emit dotted IDs in their headings", () => {
+    for (const doc of [main, ...actions]) {
+      const id = doc.action || doc.slug;
+      const hits = doc.text.match(HYPHEN_ID_HEADING) || [];
+      assert.equal(hits.length, 0, `${id}: legacy hyphen heading(s) ${[...new Set(hits)].join(", ")}`);
+    }
+  });
+
+  it("mentions hyphen IDs only when labelling them legacy", () => {
+    for (const doc of [main, ...actions]) {
+      const id = doc.action || doc.slug;
+      for (const line of doc.text.split(/\r?\n/)) {
+        if (!HYPHEN_ID.test(line)) continue;
+        assert.match(
+          line,
+          /legacy/i,
+          `${id}: hyphen ID outside a legacy note -> ${line.trim()}`,
+        );
+      }
     }
   });
 });

--- a/evals/tests/skills-static.test.mjs
+++ b/evals/tests/skills-static.test.mjs
@@ -213,6 +213,65 @@ describe("canonical ID notation (dotted)", () => {
       }
     }
   });
+  it("uses no placeholder IDs in legacy hyphen form", () => {
+    for (const doc of [main, ...actions]) {
+      const id = doc.action || doc.slug;
+      const hits = doc.text.match(/\b(?:CP|CN|FR|NFR)-(?:XXX|YYY|NNN|N)\b/g) || [];
+      assert.equal(
+        hits.length,
+        0,
+        `${id}: placeholder ID(s) in hyphen form ${[...new Set(hits)].join(", ")} — use FR.[CP].[CN].[N]`,
+      );
+    }
+  });
+});
+
+// SKILL.md is the orchestrator; detailed artifact shapes belong to the action
+// file that owns the step. Two copies of a template drift, and an agent then
+// emits a different FR depending on which file it happened to load.
+describe("single source of truth for artifact templates", () => {
+  it("the FR and NFR templates live in the Step 5 action file", () => {
+    const frAction = byAction.get("functional-requirements");
+    assert.ok(frAction, "functional-requirements action must be loaded");
+    for (const heading of [/Individual FR File Template/i, /Individual NFR File Template/i]) {
+      assert.match(frAction.text, heading, `functional-requirements.md must own ${heading}`);
+    }
+  });
+
+  it("SKILL.md does not carry a second copy of them", () => {
+    assert.equal(
+      countMatches(main.body, /^#+ .*Individual (?:FR|NFR) File Template/gim),
+      0,
+      "SKILL.md must point at reference/functional-requirements.md instead of duplicating the templates",
+    );
+    assert.equal(
+      countMatches(main.body, /^\*\*ID:\*\* (?:FR|NFR)\./gim),
+      0,
+      "SKILL.md must not restate the requirement template fields",
+    );
+    assert.match(
+      main.body,
+      /reference\/functional-requirements\.md/,
+      "SKILL.md must tell the agent where the templates live",
+    );
+  });
+
+  it("the canonical templates keep the no-code-snippets guardrail", () => {
+    const frAction = byAction.get("functional-requirements");
+    for (const heading of ["Individual FR File Template", "Individual NFR File Template"]) {
+      const start = frAction.text.indexOf(heading);
+      assert.ok(start > 0, `${heading} must exist`);
+      const fence = frAction.text.slice(start);
+      const open = fence.indexOf("```markdown");
+      const close = fence.indexOf("```", open + 3);
+      assert.ok(open > 0 && close > open, `${heading} must contain a fenced template`);
+      assert.match(
+        fence.slice(open, close),
+        /NO CODE SNIPPETS/,
+        `the ${heading} block must warn against embedding implementation detail in a requirement`,
+      );
+    }
+  });
 });
 
 describe("cross-reference links resolve (main + every action)", () => {

--- a/run-tests.ps1
+++ b/run-tests.ps1
@@ -1,61 +1,173 @@
-# Run every test suite in the repository.
+# Run every test suite in the repository and publish the Skills Health Dashboard.
 #
-#   pwsh run-tests.ps1                 # run all suites
-#   pwsh run-tests.ps1 -SkipCanvas     # skip the canvas extension suite
-#   pwsh run-tests.ps1 -SkipEvals      # skip the skill-eval deterministic suite
-#   pwsh run-tests.ps1 -SkipValidate   # skip the plugin manifest/skill validation
+#   pwsh run-tests.ps1                          # run all four default suites
+#   pwsh run-tests.ps1 -NoOpen                  # ...without opening the dashboard (CI / agents)
+#   pwsh run-tests.ps1 -IncludeSkillBehavior    # also run the provider-gated LLM suites
+#   pwsh run-tests.ps1 -SkipE2E                 # skip the Playwright visual suite
 #
-# Suites:
+# Default suites (nothing is skipped unless you ask):
 #   1. Plugin validation  — scripts/build-plugin.py validate (manifest + skills)
 #   2. Canvas extension   — .github/extensions/srs-navigator (node --test)
 #   3. Skill evals        — evals/ deterministic tests (node --test, offline)
+#   4. Canvas e2e         — Playwright visual suite (auto-starts scripts/serve-canvas.mjs)
 #
-# Live LLM evals are NOT run here (they call the model and are opt-in);
-# use evals/scripts/run-evals.ps1 for those.
+# Opt-in, provider-gated (-IncludeSkillBehavior). These need an API key; without
+# one they are reported as SKIPPED and never fail the run:
+#   5. Skill behavior     — npm run test:skill-behavior (LLM traces the skill)
+#   6. Live skill evals   — node evals/run-evals.mjs (LLM scores the skill)
+#
+# Output: docs/skills-health.html (human) + docs/skills-health.json (machine).
+# Exit code is non-zero when any suite fails.
 
 [CmdletBinding()]
 param(
     [switch]$SkipValidate,
     [switch]$SkipCanvas,
-    [switch]$SkipEvals
+    [switch]$SkipEvals,
+    [switch]$SkipE2E,
+    [switch]$IncludeSkillBehavior,
+    # Do not open the dashboard in a browser when the run finishes.
+    [switch]$NoOpen,
+    # Do not write docs/skills-health.{json,html}.
+    [switch]$NoDashboard
 )
 
 $ErrorActionPreference = 'Stop'
 $RepoRoot = $PSScriptRoot
+$CanvasDir = Join-Path $RepoRoot '.github/extensions/srs-navigator'
+$StartedAt = (Get-Date).ToUniversalTime().ToString('o')
+$RunTimer = [System.Diagnostics.Stopwatch]::StartNew()
 
 $results = [System.Collections.Generic.List[object]]::new()
+
+# API keys the LLM-backed suites accept. Any one of them enables the suite.
+$ProviderKeys = @(
+    'ANTHROPIC_API_KEY', 'OPENAI_API_KEY',
+    'GOOGLE_GENERATIVE_AI_API_KEY', 'GOOGLE_CLOUD_API_KEY', 'DEEPSEEK_API_KEY'
+)
+
+function Test-ProviderKey {
+    foreach ($k in $ProviderKeys) {
+        if (-not [string]::IsNullOrWhiteSpace([Environment]::GetEnvironmentVariable($k))) { return $k }
+    }
+    return $null
+}
+
+# Pull "tests / pass / fail / skipped" out of a suite's captured stdout. Handles
+# both the node --test summary block and Playwright's "N passed" line.
+function Get-SuiteCounts {
+    param([string]$Text)
+
+    $counts = @{ tests = 0; pass = 0; fail = 0; skipped = 0 }
+    $matched = $false
+    foreach ($key in 'tests', 'pass', 'fail', 'skipped') {
+        # node --test prints "<glyph> tests 215"; \D* absorbs the glyph whatever its encoding.
+        $m = [regex]::Matches($Text, "(?m)^\D*\b$key\s+(\d+)\s*$")
+        if ($m.Count -gt 0) {
+            $matched = $true
+            foreach ($hit in $m) { $counts[$key] += [int]$hit.Groups[1].Value }
+        }
+    }
+    if ($matched) { return $counts }
+
+    # Playwright reporter: "18 passed (5.4s)", "2 failed", "1 skipped".
+    foreach ($pair in @(@('passed', 'pass'), @('failed', 'fail'), @('skipped', 'skipped'))) {
+        $m = [regex]::Match($Text, "(?m)^\s*(\d+)\s+$($pair[0])\b")
+        if ($m.Success) { $matched = $true; $counts[$pair[1]] = [int]$m.Groups[1].Value }
+    }
+    if ($matched) { $counts.tests = $counts.pass + $counts.fail + $counts.skipped }
+    return $counts
+}
 
 function Invoke-Suite {
     param(
         [string]$Name,
-        [scriptblock]$Action
+        [string]$Command,
+        [scriptblock]$Action,
+        # Optional: count "tests" by matching this pattern instead of a summary block.
+        [string]$CountPattern
     )
     Write-Host ''
     Write-Host "==================== $Name ====================" -ForegroundColor Cyan
     $sw = [System.Diagnostics.Stopwatch]::StartNew()
+    $captured = ''
     try {
-        & $Action
+        $lines = & $Action 2>&1 | ForEach-Object { Write-Host $_; $_ }
+        $captured = ($lines | Out-String)
         $code = $LASTEXITCODE
         if ($null -eq $code) { $code = 0 }
     }
     catch {
         Write-Host $_.Exception.Message -ForegroundColor Red
+        $captured = $_.Exception.Message
         $code = 1
     }
     $sw.Stop()
+
+    $counts = Get-SuiteCounts -Text $captured
+    if ($CountPattern) {
+        $n = ([regex]::Matches($captured, $CountPattern)).Count
+        if ($n -gt 0) {
+            $counts.tests = $n
+            $counts.pass = if ($code -eq 0) { $n } else { 0 }
+            $counts.fail = if ($code -eq 0) { 0 } else { $n }
+        }
+    }
+    if ($counts.tests -eq 0 -and $code -ne 0) { $counts.tests = 1; $counts.fail = 1 }
+
     $script:results.Add([pscustomobject]@{
-        Suite    = $Name
-        ExitCode = $code
-        Passed   = ($code -eq 0)
-        Seconds  = [math]::Round($sw.Elapsed.TotalSeconds, 1)
-    })
+            name    = $Name
+            command = $Command
+            state   = if ($code -eq 0) { 'passed' } else { 'failed' }
+            tests   = $counts.tests
+            pass    = $counts.pass
+            fail    = $counts.fail
+            skipped = $counts.skipped
+            seconds = [math]::Round($sw.Elapsed.TotalSeconds, 1)
+            reason  = ''
+        })
+}
+
+function Add-SkippedSuite {
+    param([string]$Name, [string]$Command, [string]$Reason)
+    Write-Host ''
+    Write-Host "==================== $Name ====================" -ForegroundColor Cyan
+    Write-Host "  SKIPPED — $Reason" -ForegroundColor DarkGray
+    $script:results.Add([pscustomobject]@{
+            name   = $Name; command = $Command; state = 'skipped'
+            tests  = 0; pass = 0; fail = 0; skipped = 0; seconds = 0
+            reason = $Reason
+        })
+}
+
+# The canvas suites need node_modules; the e2e suite also needs a browser binary.
+function Install-CanvasDeps {
+    param([switch]$WithBrowser)
+    if (-not (Test-Path (Join-Path $CanvasDir 'node_modules'))) {
+        Write-Host '  installing canvas node_modules (first run)...' -ForegroundColor DarkGray
+        npm install --prefix $CanvasDir --no-audit --no-fund | Out-Host
+        if ($LASTEXITCODE -ne 0) { throw 'npm install failed.' }
+    }
+    if ($WithBrowser) {
+        $marker = Join-Path $CanvasDir 'node_modules/.playwright-chromium-installed'
+        if (-not (Test-Path $marker)) {
+            Write-Host '  installing Playwright Chromium (first run)...' -ForegroundColor DarkGray
+            Push-Location $CanvasDir
+            try { npx --yes playwright install chromium | Out-Host } finally { Pop-Location }
+            if ($LASTEXITCODE -eq 0) { New-Item -ItemType File -Path $marker -Force | Out-Null }
+            else { throw 'playwright install chromium failed.' }
+        }
+    }
 }
 
 Push-Location $RepoRoot
 try {
     # 1. Plugin validation (manifest + every SKILL.md).
-    if (-not $SkipValidate) {
-        Invoke-Suite 'Plugin validation' {
+    if ($SkipValidate) {
+        Add-SkippedSuite 'Plugin validation' 'python scripts/build-plugin.py validate' '-SkipValidate'
+    }
+    else {
+        Invoke-Suite 'Plugin validation' 'python scripts/build-plugin.py validate' -CountPattern 'skill OK:' {
             $py = Get-Command python -ErrorAction SilentlyContinue
             if (-not $py) { $py = Get-Command py -ErrorAction SilentlyContinue }
             if (-not $py) { throw 'Python was not found on PATH; skip with -SkipValidate.' }
@@ -64,42 +176,112 @@ try {
     }
 
     # 2. Canvas extension test suite.
-    if (-not $SkipCanvas) {
-        Invoke-Suite 'Canvas extension (srs-navigator)' {
+    if ($SkipCanvas) {
+        Add-SkippedSuite 'Canvas extension' 'npm test' '-SkipCanvas'
+    }
+    else {
+        Invoke-Suite 'Canvas extension' 'npm test' {
             if (-not (Get-Command node -ErrorAction SilentlyContinue)) {
                 throw 'Node.js was not found on PATH.'
             }
-            Push-Location (Join-Path $RepoRoot '.github/extensions/srs-navigator')
-            try { npm test } finally { Pop-Location }
+            npm test --prefix $CanvasDir
         }
     }
 
     # 3. Skill eval deterministic tests (offline).
-    if (-not $SkipEvals) {
-        Invoke-Suite 'Skill evals (deterministic)' {
+    if ($SkipEvals) {
+        Add-SkippedSuite 'Skill evals' 'pwsh evals/scripts/run-tests.ps1' '-SkipEvals'
+    }
+    else {
+        Invoke-Suite 'Skill evals' 'pwsh evals/scripts/run-tests.ps1' {
             & (Join-Path $RepoRoot 'evals/scripts/run-tests.ps1')
+        }
+    }
+
+    # 4. Playwright visual suite — self-contained via the webServer block.
+    if ($SkipE2E) {
+        Add-SkippedSuite 'Canvas e2e' 'npm run test:e2e' '-SkipE2E'
+    }
+    else {
+        Invoke-Suite 'Canvas e2e' 'npm run test:e2e' {
+            if (-not (Get-Command node -ErrorAction SilentlyContinue)) {
+                throw 'Node.js was not found on PATH.'
+            }
+            Install-CanvasDeps -WithBrowser
+            npm run test:e2e --prefix $CanvasDir
+        }
+    }
+
+    # 5 & 6. Provider-gated LLM suites (opt-in, never fail on a missing key).
+    $providerKey = Test-ProviderKey
+    if (-not $IncludeSkillBehavior) {
+        Add-SkippedSuite 'Skill behavior (LLM)' 'npm run test:skill-behavior' 'not requested (-IncludeSkillBehavior)'
+        Add-SkippedSuite 'Live skill evals (LLM)' 'node evals/run-evals.mjs' 'not requested (-IncludeSkillBehavior)'
+    }
+    elseif (-not $providerKey) {
+        $why = 'no provider API key set (' + ($ProviderKeys -join ', ') + ')'
+        Add-SkippedSuite 'Skill behavior (LLM)' 'npm run test:skill-behavior' $why
+        Add-SkippedSuite 'Live skill evals (LLM)' 'node evals/run-evals.mjs' $why
+    }
+    else {
+        Write-Host ''
+        Write-Host "  provider key detected: $providerKey" -ForegroundColor DarkGray
+        Invoke-Suite 'Skill behavior (LLM)' 'npm run test:skill-behavior' {
+            Install-CanvasDeps
+            npm run test:skill-behavior --prefix $CanvasDir
+        }
+        Invoke-Suite 'Live skill evals (LLM)' 'node evals/run-evals.mjs' {
+            node (Join-Path $RepoRoot 'evals/run-evals.mjs')
         }
     }
 }
 finally {
     Pop-Location
+    $RunTimer.Stop()
 }
 
 # Summary.
 Write-Host ''
 Write-Host '==================== Summary ====================' -ForegroundColor Cyan
 foreach ($r in $results) {
-    $label = if ($r.Passed) { 'PASS' } else { 'FAIL' }
-    $color = if ($r.Passed) { 'Green' } else { 'Red' }
-    Write-Host ("  [{0}] {1,-34} {2,5}s" -f $label, $r.Suite, $r.Seconds) -ForegroundColor $color
+    $label = switch ($r.state) { 'passed' { 'PASS' } 'failed' { 'FAIL' } default { 'SKIP' } }
+    $color = switch ($r.state) { 'passed' { 'Green' } 'failed' { 'Red' } default { 'DarkGray' } }
+    $counts = if ($r.state -eq 'skipped') { $r.reason } else { "$($r.pass)/$($r.tests) passing" }
+    Write-Host ("  [{0}] {1,-24} {2,6}s  {3}" -f $label, $r.name, $r.seconds, $counts) -ForegroundColor $color
 }
 
-$failed = @($results | Where-Object { -not $_.Passed })
+# Skills Health Dashboard.
+if (-not $NoDashboard) {
+    $payload = [pscustomobject]@{
+        startedAt       = $StartedAt
+        durationSeconds = [math]::Round($RunTimer.Elapsed.TotalSeconds, 1)
+        suites          = @($results)
+    }
+    $tmp = Join-Path ([System.IO.Path]::GetTempPath()) ("skills-health-{0}.json" -f [guid]::NewGuid())
+    try {
+        $payload | ConvertTo-Json -Depth 6 | Set-Content -Path $tmp -Encoding utf8
+        Write-Host ''
+        node (Join-Path $RepoRoot 'scripts/build-health-dashboard.mjs') --results $tmp
+        if ($LASTEXITCODE -eq 0 -and -not $NoOpen) {
+            Invoke-Item (Join-Path $RepoRoot 'docs/skills-health.html')
+        }
+    }
+    catch {
+        Write-Host "  dashboard generation failed: $($_.Exception.Message)" -ForegroundColor Yellow
+    }
+    finally {
+        Remove-Item $tmp -ErrorAction SilentlyContinue
+    }
+}
+
+$failed = @($results | Where-Object { $_.state -eq 'failed' })
+$ran = @($results | Where-Object { $_.state -ne 'skipped' })
 Write-Host ''
 if ($failed.Count -eq 0) {
-    Write-Host ("==> All {0} suite(s) passed." -f $results.Count) -ForegroundColor Green
+    Write-Host ("==> All {0} suite(s) passed." -f $ran.Count) -ForegroundColor Green
     exit 0
-} else {
-    Write-Host ("==> {0} of {1} suite(s) failed." -f $failed.Count, $results.Count) -ForegroundColor Red
+}
+else {
+    Write-Host ("==> {0} of {1} suite(s) failed." -f $failed.Count, $ran.Count) -ForegroundColor Red
     exit 1
 }

--- a/scripts/build-health-dashboard.mjs
+++ b/scripts/build-health-dashboard.mjs
@@ -1,0 +1,284 @@
+#!/usr/bin/env node
+/**
+ * Build the Skills Health Dashboard from a run of the consolidated test suite.
+ *
+ * Reads a results JSON produced by run-tests.ps1 (suite states + counts),
+ * computes the "max context" line budget for every skill file, and writes
+ *   docs/skills-health.json  — machine-readable snapshot (the daily-eval contract)
+ *   docs/skills-health.html  — human-readable page, publishable via GitHub Pages
+ *
+ * Usage:
+ *   node scripts/build-health-dashboard.mjs --results <path.json> [--out-dir docs]
+ */
+
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { countLines, parseSkill } from "../evals/lib/skills.mjs";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+export const REPO_ROOT = path.resolve(__dirname, "..");
+
+/** AgentSkills "max context" budget: hard cap and soft watch threshold. */
+export const HARD_CAP_LINES = 600;
+export const SOFT_WATCH_LINES = 500;
+
+/** Suites the runner is expected to report on, in display order. */
+export const KNOWN_SUITES = [
+  "Plugin validation",
+  "Canvas extension",
+  "Skill evals",
+  "Canvas e2e",
+  "Skill behavior (LLM)",
+  "Live skill evals (LLM)",
+];
+
+/**
+ * Measure the line budget of every skill markdown file.
+ * @param {string} [root]
+ * @returns {{hardCap:number,softWatch:number,state:string,files:Array<object>}}
+ */
+export function measureLineBudget(root = REPO_ROOT) {
+  const skillDir = path.join(root, "skills", "problem-based-srs");
+  const targets = [];
+  const skillMd = path.join(skillDir, "SKILL.md");
+  if (fs.existsSync(skillMd)) targets.push(skillMd);
+  const refDir = path.join(skillDir, "reference");
+  if (fs.existsSync(refDir)) {
+    for (const name of fs.readdirSync(refDir).sort()) {
+      if (name.endsWith(".md")) targets.push(path.join(refDir, name));
+    }
+  }
+
+  const files = targets.map((abs) => {
+    const raw = fs.readFileSync(abs, "utf8");
+    // SKILL.md carries YAML front matter that does not count toward the budget.
+    const body = abs.endsWith("SKILL.md") ? parseSkill(raw).body : raw;
+    const lines = countLines(body);
+    return {
+      file: path.relative(root, abs).split(path.sep).join("/"),
+      lines,
+      state: lines > HARD_CAP_LINES ? "over" : lines > SOFT_WATCH_LINES ? "watch" : "ok",
+      pctOfCap: Math.round((lines / HARD_CAP_LINES) * 1000) / 10,
+    };
+  });
+
+  const state = files.some((f) => f.state === "over")
+    ? "over"
+    : files.some((f) => f.state === "watch")
+      ? "watch"
+      : "ok";
+  return { hardCap: HARD_CAP_LINES, softWatch: SOFT_WATCH_LINES, state, files };
+}
+
+/**
+ * Fold the runner's per-suite results into the dashboard snapshot.
+ * @param {{suites?:Array<object>, startedAt?:string, durationSeconds?:number}} results
+ * @param {string} [root]
+ */
+export function buildSnapshot(results, root = REPO_ROOT) {
+  const suites = (results.suites ?? []).map((s) => ({
+    name: String(s.name ?? "unnamed"),
+    state: String(s.state ?? "skipped"),
+    command: s.command ?? "",
+    tests: Number(s.tests ?? 0),
+    pass: Number(s.pass ?? 0),
+    fail: Number(s.fail ?? 0),
+    skipped: Number(s.skipped ?? 0),
+    seconds: Math.round(Number(s.seconds ?? 0) * 10) / 10,
+    reason: s.reason ?? "",
+  }));
+
+  const sum = (key) => suites.reduce((n, s) => n + s[key], 0);
+  const ran = suites.filter((s) => s.state !== "skipped");
+  const failed = suites.filter((s) => s.state === "failed");
+
+  const versionFile = path.join(root, "VERSION");
+  const version = fs.existsSync(versionFile) ? fs.readFileSync(versionFile, "utf8").trim() : "";
+
+  return {
+    schema: "skills-health/1",
+    generatedAt: results.startedAt ?? new Date().toISOString(),
+    repo: "RafaelGorski/Problem-Based-SRS",
+    version,
+    overall: {
+      state: failed.length ? "failed" : "passed",
+      suites: suites.length,
+      suitesRun: ran.length,
+      suitesFailed: failed.length,
+      suitesSkipped: suites.length - ran.length,
+      tests: sum("tests"),
+      pass: sum("pass"),
+      fail: sum("fail"),
+      skipped: sum("skipped"),
+      durationSeconds: Math.round(Number(results.durationSeconds ?? 0) * 10) / 10,
+    },
+    suites,
+    maxContext: measureLineBudget(root),
+  };
+}
+
+const esc = (v) =>
+  String(v).replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;").replace(/"/g, "&quot;");
+
+const STATE_LABEL = { passed: "Passed", failed: "Failed", skipped: "Skipped", ok: "OK", watch: "Watch", over: "Over" };
+
+/**
+ * Render the dashboard HTML. Self-contained: no build step, no JS required.
+ * @param {ReturnType<typeof buildSnapshot>} snap
+ */
+export function renderDashboard(snap) {
+  const o = snap.overall;
+  const when = new Date(snap.generatedAt);
+  const stamp = Number.isNaN(when.valueOf()) ? snap.generatedAt : when.toISOString().replace("T", " ").slice(0, 16) + " UTC";
+
+  const suiteRows = snap.suites
+    .map(
+      (s) => `        <tr class="state-${esc(s.state)}">
+          <td class="name">${esc(s.name)}${s.command ? `<code>${esc(s.command)}</code>` : ""}</td>
+          <td><span class="pill pill-${esc(s.state)}">${esc(STATE_LABEL[s.state] ?? s.state)}</span></td>
+          <td class="num">${s.state === "skipped" ? "—" : s.tests}</td>
+          <td class="num">${s.state === "skipped" ? "—" : s.pass}</td>
+          <td class="num ${s.fail ? "bad" : ""}">${s.state === "skipped" ? "—" : s.fail}</td>
+          <td class="num">${s.state === "skipped" ? "—" : s.seconds + "s"}</td>
+          <td class="note">${esc(s.reason)}</td>
+        </tr>`,
+    )
+    .join("\n");
+
+  const budgetRows = snap.maxContext.files
+    .map(
+      (f) => `        <tr class="state-${esc(f.state)}">
+          <td class="name"><code>${esc(f.file)}</code></td>
+          <td class="num">${f.lines}</td>
+          <td class="bar-cell"><span class="bar"><i style="width:${Math.min(100, f.pctOfCap)}%"></i></span></td>
+          <td><span class="pill pill-${esc(f.state)}">${esc(STATE_LABEL[f.state] ?? f.state)}</span></td>
+        </tr>`,
+    )
+    .join("\n");
+
+  return `<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Skills Health — Problem-Based SRS</title>
+<meta name="description" content="Test-suite and context-budget health for the Problem-Based SRS plugin and the SRS Navigator canvas app.">
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Bricolage+Grotesque:wght@700;800&family=Figtree:wght@400;500;600&family=JetBrains+Mono:wght@400&display=swap" rel="stylesheet">
+<link rel="stylesheet" href="assets/site.css">
+<style>
+  .health { max-width: 68rem; margin: 0 auto; padding: var(--space-xl) var(--space-md) var(--space-2xl); }
+  .health h1 { font-family: var(--font-display); font-size: var(--text-3xl); color: var(--ink-heading); margin: 0 0 var(--space-xs); }
+  .health .sub { color: var(--muted); font-size: var(--text-sm); margin: 0 0 var(--space-lg); }
+  .health h2 { font-family: var(--font-display); font-size: var(--text-xl); color: var(--ink-heading); margin: var(--space-xl) 0 var(--space-sm); }
+  .cards { display: grid; grid-template-columns: repeat(auto-fit, minmax(9rem, 1fr)); gap: var(--space-sm); }
+  .card { background: var(--bg-elevated); border: 1px solid var(--surface-border); border-radius: 0.75rem; padding: var(--space-md); }
+  .card .k { display: block; font-size: var(--text-xs); text-transform: uppercase; letter-spacing: 0.06em; color: var(--muted); }
+  .card .v { display: block; font-family: var(--font-display); font-size: var(--text-2xl); color: var(--ink-heading); line-height: 1.1; }
+  .card.verdict-passed { border-color: oklch(0.55 0.12 150 / 0.45); }
+  .card.verdict-failed { border-color: oklch(0.55 0.18 27 / 0.5); }
+  .card.verdict-passed .v { color: oklch(0.45 0.12 150); }
+  .card.verdict-failed .v { color: oklch(0.50 0.18 27); }
+  table.health-table { width: 100%; border-collapse: collapse; font-size: var(--text-sm); background: var(--bg-elevated); border: 1px solid var(--surface-border); border-radius: 0.75rem; overflow: hidden; }
+  .health-table th { text-align: left; font-size: var(--text-xs); text-transform: uppercase; letter-spacing: 0.06em; color: var(--muted); font-weight: 600; padding: 0.6rem 0.75rem; border-bottom: 1px solid var(--surface-border); }
+  .health-table td { padding: 0.6rem 0.75rem; border-bottom: 1px solid var(--surface); vertical-align: top; color: var(--ink); }
+  .health-table tr:last-child td { border-bottom: 0; }
+  .health-table .num { text-align: right; font-family: var(--font-mono); font-variant-numeric: tabular-nums; }
+  .health-table .num.bad { color: oklch(0.50 0.18 27); font-weight: 600; }
+  .health-table .name { font-weight: 600; }
+  .health-table .name code { display: block; font-family: var(--font-mono); font-size: var(--text-xs); font-weight: 400; color: var(--muted); margin-top: 0.15rem; }
+  .health-table .note { color: var(--muted); font-size: var(--text-xs); }
+  .pill { display: inline-block; padding: 0.1rem 0.5rem; border-radius: 999px; font-size: var(--text-xs); font-weight: 600; }
+  .pill-passed, .pill-ok { background: oklch(0.55 0.12 150 / 0.14); color: oklch(0.40 0.12 150); }
+  .pill-failed, .pill-over { background: oklch(0.55 0.18 27 / 0.14); color: oklch(0.46 0.18 27); }
+  .pill-skipped { background: var(--surface); color: var(--muted); }
+  .pill-watch { background: oklch(0.61 0.18 48 / 0.16); color: oklch(0.45 0.15 48); }
+  .bar-cell { width: 40%; }
+  .bar { display: block; height: 0.4rem; border-radius: 999px; background: var(--surface); overflow: hidden; }
+  .bar i { display: block; height: 100%; background: var(--accent); }
+  .state-watch .bar i { background: var(--step-why); }
+  .state-over .bar i { background: oklch(0.55 0.18 27); }
+  .legend { color: var(--muted); font-size: var(--text-xs); margin-top: var(--space-sm); }
+</style>
+</head>
+<body>
+<main class="health">
+  <h1>Skills Health</h1>
+  <p class="sub">Problem-Based SRS ${snap.version ? `v${esc(snap.version)} · ` : ""}generated ${esc(stamp)} · <a href="index.html">back to the site</a></p>
+
+  <div class="cards">
+    <div class="card verdict-${esc(o.state)}"><span class="k">Verdict</span><span class="v">${esc(STATE_LABEL[o.state] ?? o.state)}</span></div>
+    <div class="card"><span class="k">Tests</span><span class="v">${o.tests}</span></div>
+    <div class="card"><span class="k">Passing</span><span class="v">${o.pass}</span></div>
+    <div class="card"><span class="k">Failing</span><span class="v">${o.fail}</span></div>
+    <div class="card"><span class="k">Suites run</span><span class="v">${o.suitesRun}/${o.suites}</span></div>
+    <div class="card"><span class="k">Duration</span><span class="v">${o.durationSeconds}s</span></div>
+  </div>
+
+  <h2>Suites</h2>
+  <table class="health-table">
+    <thead><tr><th>Suite</th><th>Result</th><th class="num">Tests</th><th class="num">Pass</th><th class="num">Fail</th><th class="num">Time</th><th>Note</th></tr></thead>
+    <tbody>
+${suiteRows}
+    </tbody>
+  </table>
+
+  <h2>Max context — skill line budget</h2>
+  <table class="health-table">
+    <thead><tr><th>File</th><th class="num">Lines</th><th>Share of cap</th><th>State</th></tr></thead>
+    <tbody>
+${budgetRows}
+    </tbody>
+  </table>
+  <p class="legend">Hard cap ${snap.maxContext.hardCap} lines · soft watch ${snap.maxContext.softWatch} lines. Front matter is excluded; the metric matches <code>evals/lib/skills.mjs</code>.</p>
+</main>
+</body>
+</html>
+`;
+}
+
+/**
+ * Write both artifacts and return their paths.
+ * @param {object} results
+ * @param {{root?:string,outDir?:string}} [opts]
+ */
+export function writeDashboard(results, opts = {}) {
+  const root = opts.root ?? REPO_ROOT;
+  const outDir = opts.outDir ?? path.join(root, "docs");
+  fs.mkdirSync(outDir, { recursive: true });
+  const snapshot = buildSnapshot(results, root);
+  const jsonPath = path.join(outDir, "skills-health.json");
+  const htmlPath = path.join(outDir, "skills-health.html");
+  fs.writeFileSync(jsonPath, JSON.stringify(snapshot, null, 2) + "\n", "utf8");
+  fs.writeFileSync(htmlPath, renderDashboard(snapshot), "utf8");
+  return { snapshot, jsonPath, htmlPath };
+}
+
+function parseArgs(argv) {
+  const out = {};
+  for (let i = 0; i < argv.length; i += 1) {
+    if (argv[i] === "--results") out.results = argv[++i];
+    else if (argv[i] === "--out-dir") out.outDir = argv[++i];
+  }
+  return out;
+}
+
+const invokedDirectly =
+  process.argv[1] && path.resolve(process.argv[1]) === path.resolve(fileURLToPath(import.meta.url));
+
+if (invokedDirectly) {
+  const args = parseArgs(process.argv.slice(2));
+  if (!args.results) {
+    console.error("usage: node scripts/build-health-dashboard.mjs --results <path.json> [--out-dir docs]");
+    process.exit(2);
+  }
+  const results = JSON.parse(fs.readFileSync(args.results, "utf8"));
+  const { snapshot, jsonPath, htmlPath } = writeDashboard(results, { outDir: args.outDir });
+  console.log(`Skills Health Dashboard -> ${htmlPath}`);
+  console.log(`Snapshot                -> ${jsonPath}`);
+  console.log(
+    `Overall: ${snapshot.overall.state} · ${snapshot.overall.pass}/${snapshot.overall.tests} passing · max context ${snapshot.maxContext.state}`,
+  );
+}

--- a/skills/problem-based-srs/SKILL.md
+++ b/skills/problem-based-srs/SKILL.md
@@ -101,6 +101,30 @@ artifact, and follow it exactly:
 For a **full** run (bare `/problem-based-srs`), work through the steps in order,
 reading each `reference/<action>.md` as you reach that step.
 
+## 🔖 Identifier Notation (CANONICAL)
+
+Every artifact ID uses **dotted notation**, which encodes the traceability chain in
+the ID itself — reading an ID tells you what it descends from:
+
+| Artifact | Format | Example | Reads as |
+|----------|--------|---------|----------|
+| Customer Problem | `CP.{n}` | `CP.01` | the first customer problem |
+| Sub-problem | `CP.{n}.{m}` | `CP.01.1` | first facet of `CP.01` |
+| Customer Need | `CN.{cp}.{n}` | `CN.01.1` | first need addressing `CP.01` |
+| Functional Requirement | `FR.{cp}.{cn}.{n}` | `FR.01.1.1` | first FR implementing `CN.01.1` |
+| Non-Functional Requirement | `NFR.{n}` | `NFR.01` | the first quality requirement |
+
+**Rules:**
+
+1. **Always emit dotted IDs.** `CP.01`, `CN.01.1`, `FR.01.1.1` — never `CP.1.1` for a
+   need or other ad-hoc shapes.
+2. **An ID must state its parent.** `FR.01.1.1` implements `CN.01.1`, which addresses
+   `CP.01`. If you cannot name the parent, the artifact is not ready to be written.
+3. **Hyphen IDs (`CP-001`, `FR-002`) are legacy.** Existing specs that use them stay
+   valid and the tooling still reads them, but do NOT produce new ones.
+4. **Reference IDs verbatim in prose** (e.g. "Addresses CP.01") so traceability can be
+   extracted automatically.
+
 ## 📁 Saving Progress (CRITICAL)
 
 **IMPORTANT:** At each step, you MUST save the produced artifacts to files. Progress is NOT automatically saved between sessions.
@@ -126,12 +150,12 @@ Create the following folder structure as you progress through each step:
 ├── 04-software-vision.md             # Step 4: Architecture and scope
 ├── functional-requirements/          # Step 5: Individual FR files
 │   ├── _index.md                     # FR summary and traceability matrix
-│   ├── FR-001.md                     # Individual FR file
-│   ├── FR-002.md                     # Individual FR file
+│   ├── FR.01.1.1-[short-name].md     # Individual FR file
+│   ├── FR.01.1.2-[short-name].md     # Individual FR file
 │   └── ...                           # One file per FR
 ├── non-functional-requirements/      # NFR files (quality attributes)
 │   ├── _index.md                     # NFR summary
-│   ├── NFR-001.md                    # Individual NFR file
+│   ├── NFR.01-[short-name].md        # Individual NFR file
 │   └── ...                           # One file per NFR
 └── traceability-matrix.md            # CP → CN → FR complete mapping
 ```
@@ -238,14 +262,14 @@ Example handoff for Step 5:
 
 📁 Saved to: .spec/functional-requirements/
    ├── _index.md (summary with 8 FRs)
-   ├── FR-001.md → CN-001 (User Registration)
-   ├── FR-002.md → CN-001 (User Authentication)
-   ├── FR-003.md → CN-002 (Data Validation)
-   ├── FR-004.md → CN-002 (Error Handling)
-   ├── FR-005.md → CN-003 (Report Generation)
-   ├── FR-006.md → CN-003 (Export Functionality)
-   ├── FR-007.md → CN-004 (Search Capability)
-   └── FR-008.md → CN-004 (Filter Options)
+   ├── FR.01.1.1-user-registration.md   → CN.01.1 (User Registration)
+   ├── FR.01.1.2-user-authentication.md → CN.01.1 (User Authentication)
+   ├── FR.01.2.1-data-validation.md     → CN.01.2 (Data Validation)
+   ├── FR.01.2.2-error-handling.md      → CN.01.2 (Error Handling)
+   ├── FR.02.1.1-report-generation.md   → CN.02.1 (Report Generation)
+   ├── FR.02.1.2-export-functionality.md→ CN.02.1 (Export Functionality)
+   ├── FR.02.2.1-search-capability.md   → CN.02.2 (Search Capability)
+   └── FR.02.2.2-filter-options.md      → CN.02.2 (Filter Options)
 
 📁 Updated: .spec/traceability-matrix.md
 
@@ -459,9 +483,9 @@ Example:
 📁 Saved to: .spec/03-customer-needs.md
 
 Outputs:
-- CN-001: [Information] User needs system to display...
-- CN-002: [Control] Admin needs system to manage...
-- CN-003: [Information] Manager needs system to report...
+- CN.01.1: [Information] User needs system to display...
+- CN.01.2: [Control] Admin needs system to manage...
+- CN.02.1: [Information] Manager needs system to report...
 
 Gate Check:
 - [x] All CNs use structured notation

--- a/skills/problem-based-srs/SKILL.md
+++ b/skills/problem-based-srs/SKILL.md
@@ -170,82 +170,12 @@ Each Functional Requirement and Non-Functional Requirement is saved as a **separ
 4. **Traceability** is maintained at the file level
 5. **Status tracking** is easier (draft, approved, implemented, tested)
 
-### FR File Template (FR-XXX.md)
+### FR and NFR File Templates
 
-Each FR file follows this template:
-
-```markdown
-# FR-XXX: [Brief Title]
-
-## Requirement
-
-**Statement:** The [System] shall [verb] [object] [constraint] [condition].
-
-**Priority:** [Must Have | Should Have | Could Have | Won't Have]
-**Status:** [Draft | Review | Approved | Implemented | Tested]
-
-## Traceability
-
-| Traces To | ID | Description |
-|-----------|-----|-------------|
-| Customer Need | CN-XXX | [Brief CN description] |
-| Customer Problem | CP-XXX | [Brief CP description] |
-
-## Acceptance Criteria
-
-- [ ] Criterion 1 (testable)
-- [ ] Criterion 2 (testable)
-- [ ] Criterion 3 (testable)
-
-## Notes
-
-[Any additional context, assumptions, or dependencies]
-
-<!-- ⚠️ NO CODE SNIPPETS: Do not include code examples, SQL, or implementation details here.
-     Construction details belong in design/ folder (see design/implementation-notes/) -->
-
----
-*Created: [Date]*
-*Last Updated: [Date]*
-*Author: [Name]*
-```
-
-### NFR File Template (NFR-XXX.md)
-
-```markdown
-# NFR-XXX: [Brief Title]
-
-## Requirement
-
-**Category:** [Performance | Security | Usability | Reliability | Scalability | Maintainability]
-**Statement:** The [System] shall [quality attribute with measurable criteria].
-
-**Priority:** [Must Have | Should Have | Could Have | Won't Have]
-**Status:** [Draft | Review | Approved | Implemented | Tested]
-
-## Traceability
-
-| Traces To | ID | Description |
-|-----------|-----|-------------|
-| Customer Need | CN-XXX | [Brief CN description] |
-| Applies To FRs | FR-XXX, FR-YYY | [Related functional requirements] |
-
-## Acceptance Criteria
-
-- [ ] Criterion 1 (measurable)
-- [ ] Criterion 2 (measurable)
-
-## Measurement Method
-
-[How this NFR will be verified/tested]
-
-<!-- ⚠️ NO CODE SNIPPETS: Do not include code examples or implementation details here.
-     Technical specifications belong in design/ folder -->
-
----
-*Created: [Date]*
-*Last Updated: [Date]*
-```
+Both templates live in the Step 5 action file — see **Individual FR File Template**
+and **Individual NFR File Template** in `reference/functional-requirements.md`.
+Load that file before writing any requirement file so every FR/NFR has the same
+shape, the same traceability table, and the same acceptance-criteria format.
 
 ### Save After Each Step
 
@@ -380,7 +310,7 @@ Determine current step by checking what artifacts exist:
 **Input:** CNs + Software Vision  
 **Output:** Individual FR and NFR files with traceability  
 **Syntax FR:** `The [System] shall [Verb] [Object] [Constraint] [Condition]`  
-**Save to:** `functional-requirements/FR-XXX.md` and `non-functional-requirements/NFR-XXX.md`  
+**Save to:** `functional-requirements/FR.[CP].[CN].[N]-[short-name].md` and `non-functional-requirements/NFR.[N]-[short-name].md`  
 **Action:** `/problem-based-srs functional-requirements`
 
 ## Quality Gates

--- a/skills/problem-based-srs/reference/functional-requirements.md
+++ b/skills/problem-based-srs/reference/functional-requirements.md
@@ -64,7 +64,7 @@ This is a required interaction. STOP and ask the user to clarify what you cannot
 #### What to Ask (adapt to context)
 
 **Round 1 — Scope and Detail:**
-- Should we specify requirements for ALL Customer Needs, or focus on a specific subset? (e.g., "Start with CN-001 through CN-003 for the MVP")
+- Should we specify requirements for ALL Customer Needs, or focus on a specific subset? (e.g., "Start with CN.01.1 through CN.01.3 for the MVP")
 - What level of detail is needed? (Full acceptance criteria per FR, or high-level "shall" statements first?)
 - Are there known technical constraints that should shape the requirements? (e.g., "must work offline", "must support REST APIs")
 
@@ -92,7 +92,7 @@ When skipping, state in one line what you're using as the basis and proceed.
 **Every FR in the response MUST include:**
 
 1. **The "shall" statement** — written out explicitly using the grammar: `The [System] shall [verb] [object]`
-2. **CN traceability** — each FR MUST show which CN it traces to (e.g., `→ CN-001`)
+2. **CN traceability** — each FR MUST show which CN it traces to (e.g., `→ CN.01.1`)
 3. **Acceptance criteria** — at least 2 testable criteria per FR
 
 **Example of CORRECT response format:**
@@ -100,8 +100,8 @@ When skipping, state in one line what you're using as the basis and proceed.
 ```markdown
 ## Functional Requirements
 
-### FR-001: Client Registration
-**Traces to:** CN-001 — Client data management
+### FR.01.1.1: Client Registration
+**Traces to:** CN.01.1 — Client data management
 
 The CRM system shall allow the Account Manager to register a new client in the database.
 
@@ -109,8 +109,8 @@ The CRM system shall allow the Account Manager to register a new client in the d
 - [ ] System accepts client name, contact info, and company details
 - [ ] System assigns unique client ID upon successful registration
 
-### FR-002: Client Data Update
-**Traces to:** CN-001 — Client data management
+### FR.01.1.2: Client Data Update
+**Traces to:** CN.01.1 — Client data management
 
 The CRM system shall allow the Account Manager to update existing client records.
 
@@ -123,7 +123,7 @@ The CRM system shall allow the Account Manager to update existing client records
 ```
 | CN | Functional Requirements |
 |----|------------------------|
-| CN.1 | FR-001 Registration, FR-002 Update |
+| CN.1 | FR.01.1.1 Registration, FR.01.1.2 Update |
 ```
 
 The wrong format above lacks "shall" statements, acceptance criteria, and proper traceability.
@@ -142,27 +142,30 @@ The wrong format above lacks "shall" statements, acceptance criteria, and proper
 .spec/
 ├── functional-requirements/
 │   ├── _index.md                    # Summary and traceability matrix
-│   ├── FR-001-[short-name].md       # Individual FR file
-│   ├── FR-002-[short-name].md
+│   ├── FR.01.1.1-[short-name].md    # Individual FR file
+│   ├── FR.01.1.2-[short-name].md
 │   └── ...
 └── non-functional-requirements/
     ├── _index.md                    # Summary
-    ├── NFR-001-[short-name].md      # Individual NFR file
+    ├── NFR.01-[short-name].md       # Individual NFR file
     └── ...
 ```
 
 ### File Naming Convention
 
 ```
-FR-[NNN]-[short-descriptive-name].md
-NFR-[NNN]-[short-descriptive-name].md
+FR.[CP].[CN].[N]-[short-descriptive-name].md
+NFR.[N]-[short-descriptive-name].md
 ```
 
+Where `[CP]`/`[CN]` are the parent Customer Problem and Customer Need numbers, so the
+filename itself carries the traceability chain (see "Identifier Notation" in `SKILL.md`).
+
 Examples:
-- `FR-001-client-registration.md`
-- `FR-002-client-data-modification.md`
-- `NFR-001-response-time.md`
-- `NFR-002-data-encryption.md`
+- `FR.01.1.1-client-registration.md`
+- `FR.01.1.2-client-data-modification.md`
+- `NFR.01-response-time.md`
+- `NFR.02-data-encryption.md`
 
 ---
 
@@ -202,11 +205,11 @@ Where:
 Each FR file MUST follow this template:
 
 ```markdown
-## FR-[NNN]: [Brief Title]
+## FR.[CP].[CN].[N]: [Brief Title]
 
 ## Requirement
 
-**ID:** FR-[NNN]  
+**ID:** FR.[CP].[CN].[N]  
 **Title:** [Descriptive title]  
 **Priority:** [Must Have | Should Have | Could Have | Won't Have]  
 **Status:** [Draft | Review | Approved | In Progress | Implemented | Tested]
@@ -219,8 +222,8 @@ The [System] shall [verb] [object] [constraint] [condition].
 
 | Traces To | ID | Description |
 |-----------|-----|-------------|
-| Customer Need | CN-[X] | [CN description] |
-| Customer Problem | CP-[Y] | [CP description] |
+| Customer Need | CN.[CP].[X] | [CN description] |
+| Customer Problem | CP.[Y] | [CP description] |
 
 ## Acceptance Criteria
 
@@ -249,11 +252,11 @@ The [System] shall [verb] [object] [constraint] [condition].
 Each NFR file MUST follow this template:
 
 ```markdown
-## NFR-[NNN]: [Brief Title]
+## NFR.[N]: [Brief Title]
 
 ## Requirement
 
-**ID:** NFR-[NNN]  
+**ID:** NFR.[N]  
 **Title:** [Descriptive title]  
 **Category:** [Performance | Security | Usability | Reliability | Scalability | Maintainability]  
 **Priority:** [Must Have | Should Have | Could Have | Won't Have]  
@@ -267,8 +270,8 @@ The [System] shall [quality attribute] [measurable target] [condition].
 
 | Traces To | ID | Description |
 |-----------|-----|-------------|
-| Customer Need | CN-[X] | [CN description] |
-| Applies To FRs | FR-[A], FR-[B] | [Related FRs] |
+| Customer Need | CN.[CP].[X] | [CN description] |
+| Applies To FRs | FR.[A], FR.[B] | [Related FRs] |
 
 ## Measurement Criteria
 
@@ -339,14 +342,14 @@ Construction and implementation details belong in separate design documents:
 
 ## Examples
 
-### Example FR File: FR-001-client-registration.md
+### Example FR File: FR.01.1.1-client-registration.md
 
 ```markdown
-## FR-001: Client Registration
+## FR.01.1.1: Client Registration
 
 ## Requirement
 
-**ID:** FR-001  
+**ID:** FR.01.1.1  
 **Title:** Client Registration  
 **Priority:** Must Have  
 **Status:** Draft
@@ -359,8 +362,8 @@ The CRM system shall allow the Account Manager to register a new client in the d
 
 | Traces To | ID | Description |
 |-----------|-----|-------------|
-| Customer Need | CN-001 | Account Manager needs system to maintain client records |
-| Customer Problem | CP-001 | Company must maintain accurate client data for compliance |
+| Customer Need | CN.01.1 | Account Manager needs system to maintain client records |
+| Customer Problem | CP.01 | Company must maintain accurate client data for compliance |
 
 ## Acceptance Criteria
 
@@ -375,14 +378,14 @@ The CRM system shall allow the Account Manager to register a new client in the d
 *Author: Requirements Team*
 ```
 
-### Example NFR File: NFR-001-response-time.md
+### Example NFR File: NFR.01-response-time.md
 
 ```markdown
-## NFR-001: Response Time
+## NFR.01: Response Time
 
 ## Requirement
 
-**ID:** NFR-001  
+**ID:** NFR.01  
 **Title:** Search Response Time  
 **Category:** Performance  
 **Priority:** Must Have  
@@ -396,8 +399,8 @@ The CRM system shall return client search results within 2 seconds under normal 
 
 | Traces To | ID | Description |
 |-----------|-----|-------------|
-| Customer Need | CN-002 | Users need quick access to client information |
-| Applies To FRs | FR-004, FR-007 | Client search and filtering functions |
+| Customer Need | CN.01.2 | Users need quick access to client information |
+| Applies To FRs | FR.01.2.1, FR.01.2.2 | Client search and filtering functions |
 
 ## Measurement Criteria
 
@@ -422,7 +425,7 @@ The CRM system shall return client search results within 2 seconds under normal 
 Before finalizing, verify:
 
 - [ ] Every FR uses syntax: The [Subject] shall [Verb] [Object] [Constraint] [Condition]
-- [ ] Every FR saved as individual file (FR-NNN-name.md)
+- [ ] Every FR saved as individual file (`FR.[CP].[CN].[N]-name.md`)
 - [ ] Every FR traces to at least one CN
 - [ ] Every CN from input is addressed by at least one FR
 - [ ] All FRs are testable with clear acceptance criteria
@@ -457,13 +460,13 @@ After completing this step:
 
 📁 Created: functional-requirements/
    ├── _index.md (N FRs total)
-   ├── FR-001-*.md → CN-001
-   ├── FR-002-*.md → CN-001
+   ├── FR.01.1.1-*.md → CN.01.1
+   ├── FR.01.1.2-*.md → CN.01.1
    └── ...
 
 📁 Created: non-functional-requirements/
    ├── _index.md (N NFRs total)
-   └── NFR-001-*.md
+   └── NFR.01-*.md
 
 📁 Updated: traceability-matrix.md
 

--- a/skills/problem-based-srs/reference/functional-requirements.md
+++ b/skills/problem-based-srs/reference/functional-requirements.md
@@ -235,6 +235,9 @@ The [System] shall [verb] [object] [constraint] [condition].
 
 <!-- Engineers add notes here during implementation -->
 
+<!-- ⚠️ NO CODE SNIPPETS: do not include code examples, SQL, or implementation
+     details in the requirement itself. Construction details belong in design/. -->
+
 ## Test Cases
 
 <!-- QA adds test case references here -->
@@ -287,6 +290,9 @@ The [System] shall [quality attribute] [measurable target] [condition].
 ## Implementation Notes
 
 <!-- Engineers add notes here during implementation -->
+
+<!-- ⚠️ NO CODE SNIPPETS: do not include code examples or technical
+     specifications in the requirement itself; those belong in design/. -->
 
 ---
 *Created: [Date]*  

--- a/skills/problem-based-srs/reference/problems.md
+++ b/skills/problem-based-srs/reference/problems.md
@@ -152,14 +152,16 @@ Classify each CP by severity:
 
 ## Output Format
 
-**⚠ ID Format:** Always use `CP-` with a dash (e.g., `CP-001`, `CP-002`). Do NOT use dots (e.g., `CP.01`).
+**⚠ ID Format:** Always use canonical dotted notation — `CP.01`, `CP.02`, and `CP.01.1` for
+sub-problems. Hyphen IDs (`CP-001`) are legacy: still readable, but do not produce new ones.
+See "Identifier Notation" in `SKILL.md`.
 
 ### For Mode 1 (Generation)
 
 For each identified problem, produce:
 
 ```markdown
-### CP-001: [Brief Title]
+### CP.01: [Brief Title]
 
 **Statement:** [Subject] [Verb] [Object] [Penalty]
 
@@ -196,7 +198,7 @@ For each identified problem, produce:
 
 ### Example 1: Obligation
 ```markdown
-### CP-001: Regulatory Compliance
+### CP.01: Regulatory Compliance
 
 **Statement:** The company must submit emission compliance reports within 30 days of each quarter end otherwise faces fines up to 5% of revenue.
 
@@ -217,7 +219,7 @@ For each identified problem, produce:
 
 ### Example 2: Expectation
 ```markdown
-### CP-002: Customer Response Time
+### CP.02: Customer Response Time
 
 **Statement:** Customers expect responses to support inquiries within 24 hours otherwise they become dissatisfied and may switch to competitors.
 
@@ -238,7 +240,7 @@ For each identified problem, produce:
 
 ### Example 3: Hope
 ```markdown
-### CP-003: Sales Forecasting
+### CP.03: Sales Forecasting
 
 **Statement:** Management hopes to predict quarterly sales with 85% accuracy otherwise strategic planning remains reactive rather than proactive.
 
@@ -280,37 +282,37 @@ Decompose a CP into sub-CPs when:
 
 | Trigger | Example |
 |---------|---------|
-| Multiple distinct facets | CP-001 has communication AND frequency aspects |
-| Different subjects affected | CP-001 affects both company AND customers |
+| Multiple distinct facets | CP.01 has communication AND frequency aspects |
+| Different subjects affected | CP.01 affects both company AND customers |
 | Independent penalties | Failure of one aspect doesn't cause all penalties |
 | Separate solutions likely | Each facet could be solved by different FRs |
 
 ### Numbering Convention
 
 ```
-CP-001        → Main problem
-CP-001.1      → First sub-problem of CP-001
-CP-001.2      → Second sub-problem of CP-001
-CP-001.2.1    → Sub-sub-problem (rarely needed)
+CP.01          → Main problem
+CP.01.1        → First sub-problem of CP.01
+CP.01.2        → Second sub-problem of CP.01
+CP.01.2.1      → Sub-sub-problem (rarely needed)
 ```
 
 ### Decomposition Example
 
 **Before decomposition:**
 ```
-CP-001: The company must ensure effective communication with customers, 
+CP.01: The company must ensure effective communication with customers, 
       otherwise it loses customers affecting marketing and sales.
 ```
 
 **After decomposition:**
 ```
-CP-001: The company must ensure effective communication with customers, 
+CP.01: The company must ensure effective communication with customers, 
       otherwise it loses customers affecting marketing and sales.
 
-CP-001.1: The company must ensure it can contact all customers 
+CP.01.1: The company must ensure it can contact all customers 
         (having valid contact information).
 
-CP-001.2: The company must ensure each customer is contacted regularly 
+CP.01.2: The company must ensure each customer is contacted regularly 
         (frequency of communication).
 ```
 


### PR DESCRIPTION
Implements the ranked backlog from #62. The plan held, but tracing each item to the code that implements it turned up defects that reframed the work: the product's own canonical notation could not survive its own tooling, and CI was not running the tests that would have caught it.

## Why

Three things were true before this branch:

1. **CI ran zero tests.** `ci.yml` only ran `build-plugin.py validate` and `package`. There was no Node step, so roughly 233 deterministic tests never executed on a push or PR. `release-canvas.yml` runs `npm test` but only on manual dispatch.
2. **The methodology and the tooling disagreed about identifiers.** `reference/problems.md` mandated `CP-` with a dash and explicitly forbade dots, while `reference/validate.md` (the file that defines traceability) used dotted IDs in all 52 of its references.
3. **The Playwright suite was dead code.** No local `@playwright/test`, no `webServer` block, and nothing serving the canvas. Its 18 rendering assertions guarded nothing.

## What broke because of the notation split

The disagreement was not cosmetic. Following the canonical form documented in `validate.md` produced:

- **No traceability at all.** `parser.mjs` matched `/\[(\w+-\d+)\]/`. `\w` excludes `.`, so `### [CP.01]` never matched, IDs fell back to `P-1`/`N-1`, and every CP -> CN -> FR link was dropped. `/live` rendered an unlinked graph.
- **A hard validation failure.** `lib/validation.mjs` required `/^(CP|P)-\d+$/`, so a spec in the methodology's own notation was rejected with `Problem ID must match format (got CP.01)`.
- **A silent decompose bug.** `nextId` matched `/^FR-(\d+)$/`; against a dotted spec nothing matched, so it returned `FR-1` every time and collided on the second call.
- **Skipped files.** `spec-compiler.mjs` filtered `/^FR-\d+\.md$/i`, so the documented `FR-001-[short-name].md` layout was never read.

## Approach

**One canonical notation, one place that knows it.** Dotted (`CP.01` / `CN.01.1` / `FR.01.1.1`) is now canonical and documented in a new `Identifier Notation` section in `SKILL.md`. Rather than patch four regexes, a new `lib/notation.mjs` is the single source of truth; `parser.mjs`, `spec-compiler.mjs`, `validation.mjs`, and `decompose.mjs` all route through it. Legacy hyphen IDs still parse, so existing specs keep working. `decompose` now extends the parent (`CP.01` -> `CP.01.1`) instead of counting, which matches the documented sub-problem convention.

**Make the tests real, then make CI run them.** `scripts/serve-canvas.mjs` renders the demo canvas over HTTP with a `/health` readiness probe, and `playwright.config.mjs` starts it via `webServer`, so `npm run test:e2e` is one self-contained command. `ci.yml` gains both a `test` job and an `e2e` job.

**Make the state of the suites visible.** `run-tests.ps1` v1.1 orchestrates all four default suites, auto-installs `node_modules` and Chromium on first run, and adds `-NoOpen` and `-IncludeSkillBehavior`. It writes `docs/skills-health.json` (machine readable) and `docs/skills-health.html`, which reuses `docs/assets/site.css` and is publishable through GitHub Pages.

![Skills Health dashboard showing all four suites passing, 334 tests, and the per-file skill line budget](https://github.com/user-attachments/assets/213d3d3f-3cab-4fc5-a685-eb62c39d1738)

**Ground the landing page in evidence.** The "before/after" argued with an invented anecdote about a 20-chart dashboard nobody built. It now quotes `.spec/crm-system.json` verbatim, including the real chain `CP.01 -> CN.01.1 -> FR.01.1.1`, so a reader can open the file or run `/live` and see the same graph.

## Results

Tests go from 233 to **334 passing**.

| Suite | Before | After |
|---|---|---|
| Plugin validation | 1 | 1 |
| Canvas extension | 176 | 215 |
| Skill evals | 57 | 100 |
| Canvas e2e | 0, never ran | 18 |

`SKILL.md` body drops from 549 to 479 lines, back under the 500-line soft watch.

## Worth a careful look

**The line-budget fix was a duplication bug, not a trimming exercise.** `SKILL.md` and `reference/functional-requirements.md` each carried a full FR and NFR template, and the two had drifted: legacy `# FR-XXX:` headings with `CN-XXX` placeholders in one, canonical dotted headings with ID/Title/Test Cases in the other. An agent emitted a different requirement file depending on which it had loaded. Consolidating into the Step 5 action file removed the 70 lines that had pushed the file over budget. The only content unique to the deleted copies, the `NO CODE SNIPPETS` warning, moved into both canonical templates.

**One known gap, left deliberately.** The landing illustration (`docs/assets/srs-problems.svg`) still shows the older VagrantChefHubot spec in hyphen notation beside canonical dotted copy. I reconstructed its graph from the SVG geometry to attempt a faithful relabel and found that `CN-1` has three parent problems and `FR-9` has two parent needs, which single-parent dotted IDs cannot encode. Relabelling would have misrepresented the graph. Regenerating the figure from a real spec is the correct fix and is now cheap, since `serve-canvas.mjs` can render one. Its `alt` text, which wrongly announced "CP.01 through CP.05", is corrected in the meantime.

**`node --test <dir>` is unsupported on Node 25** and fails with `MODULE_NOT_FOUND`, so CI passes an explicit glob. There is an assertion guarding this so it does not regress back to a directory argument.

**`docs/skills-health.{json,html}` are committed** so the page can be published through Pages. The trade-off is that a local test run leaves a timestamp diff in the working tree.

## Drift guards

Repo policy requires every behaviour change to ship a test that fails on regression. Seven guard files were added or extended, and **every assertion was negative-tested** by mutating the source, confirming the failure, and restoring:

- `tests/test-wiring.test.mjs` catches any `tests/*.test.mjs` missing from `npm test`. It found two real omissions during this work, including one of my own new files.
- `tests/notation.test.mjs` pins both notations across parser, compiler, validation, and decompose.
- `tests/serve-canvas.test.mjs` pins the server and the `webServer` wiring.
- `evals/tests/health-dashboard.test.mjs` pins the runner switches, four-suite orchestration, provider gating, budget thresholds, HTML escaping, and that CI actually runs every suite on a pull request.
- `evals/tests/landing-proof.test.mjs` ties the landing page to the shipped spec: the quoted problem, both claimed traceability edges, and all four artifact counts must match `.spec/crm-system.json`.
- `evals/tests/cases.test.mjs` validates every eval case offline, including a canary asserting the new brownfield rubric rejects a technical-debt-shaped answer.
- `evals/tests/skills-static.test.mjs` gains canonical-notation assertions, a no-hyphen-placeholder check, and single-owner template checks.

One guard was too weak when first written: the no-code-snippets check counted matches file-wide and survived deleting a warning. It now inspects each fenced template block individually.

## Verify locally

```
pwsh -File run-tests.ps1 -NoOpen
```

Runs all four suites and writes `docs/skills-health.html`. Both release packagers were re-run and still build.