### PR TITLE
Make the documented install paths work on a clean machine

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Distribution paths are documented and tested.** The README and landing page name the
   `skills.sh` listing and an explicit install path for the SRS Navigator canvas extension,
   with a deterministic test asserting both surfaces carry them.
+- **Clean-machine install guard** (`evals/tests/install-path.test.mjs`). Stages the canvas
+  archive with the real packager and asserts the documentation against what it emits: one
+  top-level directory, the files the Copilot app needs to load the extension, no development
+  payload, a size budget, and — derived from the packager's own archive root — that every
+  documented extract target is the *parent* of that root rather than the root itself. Also
+  gates the release-fallback link and the AgentSkills CLI install location on both surfaces.
 
 ### Changed
 
@@ -58,6 +64,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   They previously required an undocumented `cd evals` while every neighbouring command ran
   from the repository root.
 - **Corrected stale comments** claiming the shipped skill templates emit legacy hyphen IDs.
+- **The canvas extension extract instruction no longer nests the archive.** The README said
+  to extract into `~/.copilot/extensions/srs-navigator/` while the landing page said
+  `~/.copilot/extensions/`. The archive already contains a `srs-navigator/` root, so the
+  README's version produced `…/srs-navigator/srs-navigator/extension.mjs`, which does not
+  load. Both surfaces now name the parent directory and show the resulting path.
+- **The archive fallback links a release that actually carries the archive.** Both surfaces
+  pointed at the bare releases page, but the canvas app ships on `vX.Y.Z` tags interleaved
+  with the plugin's `vX.Y` releases, so the newest release has no canvas archive at all.
+  They now link a filtered release view and explain the two trains.
+- **The AgentSkills CLI section says where the skill lands.** `npx skills add` installs into
+  `.agents/skills/problem-based-srs/` and writes a `skills-lock.json`; neither was named
+  anywhere, while the surrounding docs pointed readers at `.github/skills/`.
+- **`scripts/package-extension.mjs` is importable without side effects.** `main()` now runs
+  only when the file is invoked as a script, and `ARCHIVE_ROOT`, `EXCLUDE`, `EXCLUDE_FILES`
+  and `stage()` are exported so the install guard derives archive facts from the packager
+  rather than restating them.
 
 [2.5.0]: https://github.com/RafaelGorski/Problem-Based-SRS/releases/tag/v2.5.0
 

--- a/README.md
+++ b/README.md
@@ -228,6 +228,11 @@ claude --plugin-dir ./Problem-Based-SRS
 npx skills add RafaelGorski/Problem-Based-SRS
 ```
 
+This installs the single skill the repository publishes into
+`.agents/skills/problem-based-srs/` — the shared location AgentSkills-aware agents read,
+GitHub Copilot included — and records what it took in a `skills-lock.json` beside it. That
+is where to look to confirm the install landed; the CLI does not write to `.github/skills/`.
+
 Browse the published listing at
 [**skills.sh/rafaelgorski/problem-based-srs**](https://skills.sh/rafaelgorski/problem-based-srs).
 
@@ -240,14 +245,19 @@ skills. Ask the Copilot app to install it directly from this repository:
 Install the canvas extension from https://github.com/RafaelGorski/Problem-Based-SRS/tree/main/.github/extensions/srs-navigator
 ```
 
-Or install it by hand from a
-[release archive](https://github.com/RafaelGorski/Problem-Based-SRS/releases)
-(`srs-navigator-<version>.zip` / `.tar.gz`):
+Or install it by hand from a release archive. The canvas app ships on its own `vX.Y.Z`
+tags, interleaved with the methodology plugin's `vX.Y` releases — so the newest release is
+usually *not* the one that carries it. Use the
+[filtered release list](https://github.com/RafaelGorski/Problem-Based-SRS/releases?q=srs-navigator&expanded=true)
+to find the latest `srs-navigator-<version>.zip` / `.tar.gz`.
 
-| Scope | Extract into |
-|-------|--------------|
-| Personal (all projects) | `~/.copilot/extensions/srs-navigator/` |
-| Project (this repo only) | `.github/extensions/srs-navigator/` |
+The archive already contains a `srs-navigator/` folder, so extract it into the directory
+*above* the one the extension will occupy:
+
+| Scope | Extract into | Produces |
+|-------|--------------|----------|
+| Personal (all projects) | `~/.copilot/extensions/` | `~/.copilot/extensions/srs-navigator/extension.mjs` |
+| Project (this repo only) | `.github/extensions/` | `.github/extensions/srs-navigator/extension.mjs` |
 
 Then run `/live` in the Copilot app to open the canvas.
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -336,7 +336,7 @@
                     <h3>Add the app</h3>
                     <p style="margin-bottom: var(--space-sm);">The SRS Navigator graph is a GitHub Copilot canvas extension, installed separately:</p>
                     <pre><code>Install the canvas extension from https://github.com/RafaelGorski/Problem-Based-SRS/tree/main/.github/extensions/srs-navigator</code></pre>
-                    <p style="color: var(--muted); font-size: var(--text-sm); margin-top: var(--space-sm);">Then run <code>/live</code> to open it. Prefer a file? Grab <code>srs-navigator-&lt;version&gt;.zip</code> from the <a href="https://github.com/RafaelGorski/Problem-Based-SRS/releases" target="_blank" rel="noopener">releases page</a> and extract it into <code>~/.copilot/extensions/</code>.</p>
+                    <p style="color: var(--muted); font-size: var(--text-sm); margin-top: var(--space-sm);">Then run <code>/live</code> to open it. Prefer a file? Grab <code>srs-navigator-&lt;version&gt;.zip</code> from the <a href="https://github.com/RafaelGorski/Problem-Based-SRS/releases?q=srs-navigator&amp;expanded=true" target="_blank" rel="noopener">canvas releases</a> &mdash; the app has its own <code>vX.Y.Z</code> tags, so the newest release is usually not the one carrying it &mdash; and extract it into <code>~/.copilot/extensions/</code>. The archive brings its own <code>srs-navigator/</code> folder, so that is the parent directory, not the target.</p>
                 </div>
 
                 <div class="reveal" style="margin-top: var(--space-xl);">

--- a/evals/tests/install-path.test.mjs
+++ b/evals/tests/install-path.test.mjs
@@ -1,0 +1,357 @@
+// An install path that works because the reader already has the repository is not an
+// install path. This suite exists because a clean-directory run of the documented
+// instructions found three things that a reader could not have recovered from:
+//
+//   1. README said to extract the canvas archive into `~/.copilot/extensions/srs-navigator/`
+//      while the landing page said `~/.copilot/extensions/`. The archive already contains a
+//      `srs-navigator/` root, so the README's version nests it one level too deep and the
+//      extension never loads. Two surfaces, one of them wrong, nothing to catch it.
+//   2. Both surfaces linked the bare /releases page for `srs-navigator-<version>.zip`, but
+//      the canvas app and the methodology plugin ship on interleaved tag trains — the newest
+//      release carries no canvas archive at all.
+//   3. `npx skills add` installs into `.agents/skills/`, a directory neither surface named.
+//
+// The assertions below deliberately derive the archive's shape from the packager itself
+// rather than restating it: if the layout changes, the documentation assertion changes
+// with it. A test that hard-codes the same string the docs hard-code is just a second copy
+// of the docs.
+import { describe, it, before, after } from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { ARCHIVE_ROOT, EXCLUDE, EXCLUDE_FILES, stage } from "../../scripts/package-extension.mjs";
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(here, "../..");
+const read = (rel) => fs.readFileSync(path.join(repoRoot, rel), "utf8");
+
+const README = read("README.md");
+const LANDING = read("docs/index.html");
+
+// The canvas app is released from VERSION on its own vX.Y.Z train, so a link to the
+// "latest" release is a link to the methodology plugin. The fallback must be filtered.
+const CANVAS_RELEASE_FILTER = "q=srs-navigator";
+
+// Budgets, set against the measured staging output (26 files / ~402 KB) with headroom.
+// The published srs-navigator-1.1.0.zip carried 223 entries and 4.3 MB because it bundled
+// node_modules/ (Playwright); these bounds make that shape impossible to ship again.
+const MAX_PACKAGED_FILES = 80;
+const MAX_PACKAGED_BYTES = 1_500_000;
+
+/* ------------------------------------------------------------------ helpers */
+
+/** Split a markdown table row into trimmed cells, discarding the outer pipes. */
+export function tableRow(line) {
+  return line
+    .trim()
+    .replace(/^\|/, "")
+    .replace(/\|$/, "")
+    .split("|")
+    .map((c) => c.trim());
+}
+
+/**
+ * Values under the column titled `header` in the first markdown table that has it.
+ * Backticks are stripped so callers compare paths rather than formatting.
+ */
+export function tableColumn(md, header) {
+  const lines = md.split("\n");
+  const head = lines.findIndex((l) => l.trim().startsWith("|") && tableRow(l).includes(header));
+  if (head === -1) return [];
+  const col = tableRow(lines[head]).indexOf(header);
+  const out = [];
+  for (let i = head + 2; i < lines.length; i++) {
+    if (!lines[i].trim().startsWith("|")) break;
+    const cell = tableRow(lines[i])[col];
+    if (cell !== undefined) out.push(cell.replaceAll("`", "").trim());
+  }
+  return out;
+}
+
+/**
+ * The body of a markdown section: from its heading to the next heading of the same or a
+ * higher level. Asserting against the whole README would let a claim made in one section
+ * satisfy a requirement about another.
+ */
+export function section(md, heading) {
+  const lines = md.split("\n");
+  const start = lines.findIndex((l) => new RegExp(`^#{1,6}\\s+${heading}\\s*$`).test(l));
+  if (start === -1) return "";
+  const level = lines[start].match(/^#+/)[0].length;
+  let end = lines.length;
+  for (let i = start + 1; i < lines.length; i++) {
+    const m = lines[i].match(/^(#+)\s/);
+    if (m && m[1].length <= level) {
+      end = i;
+      break;
+    }
+  }
+  return lines.slice(start + 1, end).join("\n");
+}
+
+/** Markdown link targets: [text](target). */
+export function linkTargets(md) {
+  return [...md.matchAll(/\[[^\]]*\]\(([^)\s]+)/g)].map((m) => m[1]);
+}
+
+/** Directories the landing page tells the reader to extract the archive into. */
+export function htmlExtractTargets(html) {
+  return [...html.matchAll(/extract(?:\s+it)?\s+into\s*<code>([^<]+)<\/code>/gi)].map((m) =>
+    m[1].trim(),
+  );
+}
+
+/** True when `target` is the archive's own root rather than the directory above it. */
+export function nestsArchiveRoot(target, root = ARCHIVE_ROOT) {
+  return new RegExp(`(^|[\\\\/])${root}[\\\\/]?$`).test(target.trim());
+}
+
+/** Every file in a directory tree, as paths relative to it. */
+export function walk(dir, base = dir) {
+  return fs.readdirSync(dir, { withFileTypes: true }).flatMap((e) => {
+    const full = path.join(dir, e.name);
+    return e.isDirectory() ? walk(full, base) : [path.relative(base, full).replaceAll("\\", "/")];
+  });
+}
+
+/* ------------------------------------------------------- what ships in the archive */
+
+describe("the canvas archive the docs point at", () => {
+  let tmp;
+  let staged;
+  let files;
+
+  before(() => {
+    tmp = fs.mkdtempSync(path.join(os.tmpdir(), "pbsrs-package-"));
+    staged = stage(tmp);
+    files = walk(staged);
+  });
+
+  after(() => fs.rmSync(tmp, { recursive: true, force: true }));
+
+  it("puts everything under one top-level directory", () => {
+    assert.deepEqual(
+      fs.readdirSync(tmp),
+      [ARCHIVE_ROOT],
+      `the archive must contain exactly one root (${ARCHIVE_ROOT}/) — the extract ` +
+        "instructions in README.md and docs/index.html are written against that shape",
+    );
+  });
+
+  it("contains what the Copilot app needs to load the extension", () => {
+    for (const required of ["extension.mjs", "copilot-extension.json", "package.json"]) {
+      assert.ok(
+        files.includes(required),
+        `${required} is missing from the archive — an extracted directory without it is ` +
+          "not an installed extension",
+      );
+    }
+    assert.ok(
+      files.some((f) => f.startsWith("skills/") && f.endsWith(".md")),
+      "the bundled methodology skills must ship with the extension: a standalone install " +
+        "has no skills/ directory to fall back to",
+    );
+    assert.ok(
+      files.some((f) => f.startsWith("lib/")),
+      "the renderer/parser library must ship with the extension",
+    );
+  });
+
+  it("carries no development payload", () => {
+    const dev = files.filter(
+      (f) =>
+        f.split("/").some((seg) => EXCLUDE.has(seg)) ||
+        EXCLUDE_FILES.has(f.split("/").pop()) ||
+        /\.test\.mjs$/.test(f) ||
+        /playwright/i.test(f),
+    );
+    assert.deepEqual(
+      dev,
+      [],
+      "the published srs-navigator-1.1.0.zip shipped 187 node_modules entries (Playwright) " +
+        "plus tests/ and docs/, at 4.3 MB. Nothing asserted the archive's shape, so it went " +
+        "out unnoticed. These entries must never reappear",
+    );
+  });
+
+  it("stays inside its size budget", () => {
+    const bytes = files.reduce((n, f) => n + fs.statSync(path.join(staged, f)).size, 0);
+    assert.ok(
+      files.length <= MAX_PACKAGED_FILES,
+      `archive holds ${files.length} files, budget is ${MAX_PACKAGED_FILES}`,
+    );
+    assert.ok(
+      bytes <= MAX_PACKAGED_BYTES,
+      `archive weighs ${bytes} bytes, budget is ${MAX_PACKAGED_BYTES} — a jump of this ` +
+        "size means a dependency tree got swept in",
+    );
+  });
+});
+
+/* ----------------------------------------------- what the documentation tells the reader */
+
+describe("the documented extract target matches the archive", () => {
+  const canvas = section(README, "SRS Navigator canvas app");
+
+  it("has a canvas install section with an extract table", () => {
+    assert.notEqual(canvas, "", "README.md must keep an `SRS Navigator canvas app` section");
+    assert.ok(
+      tableColumn(canvas, "Extract into").length > 0,
+      "that section must keep its `Extract into` table — the table is the instruction",
+    );
+  });
+
+  it("names the directory above the archive root, not the archive root itself", () => {
+    for (const target of tableColumn(canvas, "Extract into")) {
+      assert.ok(
+        !nestsArchiveRoot(target),
+        `README.md tells the reader to extract into "${target}", which ends in the ` +
+          `archive's own root (${ARCHIVE_ROOT}/). The archive already contains that ` +
+          `folder, so this yields ${target.replace(/[\\/]$/, "")}/${ARCHIVE_ROOT}/extension.mjs ` +
+          "— a nested copy the Copilot app will not load. Document the parent directory.",
+      );
+    }
+  });
+
+  it("agrees with the landing page about where the archive goes", () => {
+    const fromLanding = htmlExtractTargets(LANDING);
+    assert.ok(
+      fromLanding.length > 0,
+      'docs/index.html must keep an "extract it into <code>…</code>" instruction',
+    );
+    for (const target of fromLanding) {
+      assert.ok(
+        !nestsArchiveRoot(target),
+        `docs/index.html tells the reader to extract into "${target}", which nests the ` +
+          "archive root",
+      );
+    }
+    const fromReadme = tableColumn(canvas, "Extract into").map((t) => t.replace(/[\\/]$/, ""));
+    for (const target of fromLanding) {
+      assert.ok(
+        fromReadme.includes(target.replace(/[\\/]$/, "")),
+        `docs/index.html says "${target}" but README.md's table says ` +
+          `${fromReadme.join(", ")}. Two surfaces disagreeing about one path is how the ` +
+          "nesting bug survived: each looked correct on its own page.",
+      );
+    }
+  });
+});
+
+describe("the release fallback link finds the canvas archive", () => {
+  it("is filtered in the README, not a link to the newest release", () => {
+    const canvas = section(README, "SRS Navigator canvas app");
+    const releaseLinks = linkTargets(canvas).filter((t) => t.includes("/releases"));
+    assert.ok(releaseLinks.length > 0, "the canvas section must link the releases page");
+    assert.ok(
+      releaseLinks.some((t) => t.includes(CANVAS_RELEASE_FILTER)),
+      `the archive fallback must link a filtered releases view (${CANVAS_RELEASE_FILTER}). ` +
+        "The canvas app ships on vX.Y.Z tags and the methodology plugin on vX.Y, so they " +
+        `interleave: the newest release carries no canvas archive. Found: ${releaseLinks.join(", ")}`,
+    );
+  });
+
+  it("is filtered on the landing page too", () => {
+    const releaseLinks = [...LANDING.matchAll(/href\s*=\s*["']([^"']*\/releases[^"']*)["']/g)].map(
+      (m) => m[1],
+    );
+    assert.ok(
+      releaseLinks.some((t) => t.includes(CANVAS_RELEASE_FILTER)),
+      `docs/index.html must link the same filtered view for the archive fallback; found: ${releaseLinks.join(", ")}`,
+    );
+  });
+
+  it("names an archive whose prefix matches what the packager emits", () => {
+    assert.ok(
+      README.includes(`${ARCHIVE_ROOT}-<version>.zip`),
+      `the documented archive name must start with ${ARCHIVE_ROOT}- so it matches the ` +
+        "artifact the release workflow attaches",
+    );
+  });
+});
+
+describe("the AgentSkills CLI section says where the skill lands", () => {
+  const cli = section(README, "AgentSkills CLI");
+
+  it("exists", () => {
+    assert.notEqual(cli, "", "README.md must keep an `AgentSkills CLI` section");
+  });
+
+  it("names the directory the CLI actually writes to", () => {
+    assert.match(
+      cli,
+      /\.agents\/skills\//,
+      "a clean-directory run of `npx skills add RafaelGorski/Problem-Based-SRS` installs " +
+        "into `.agents/skills/problem-based-srs`, but the README only ever names " +
+        "`.github/skills/` and `~/.copilot/skills/`. A reader who runs the documented " +
+        "command and checks the documented directory finds nothing and concludes it failed.",
+    );
+  });
+
+  it("mentions the lockfile the CLI writes alongside it", () => {
+    assert.match(
+      cli,
+      /skills-lock\.json/,
+      "the CLI also writes skills-lock.json into the working directory; an unexplained " +
+        "new file at the repo root is a surprise, not an install",
+    );
+  });
+});
+
+/* ------------------------------------------------------------------- negative canaries */
+
+describe("negative canaries", () => {
+  it("nestsArchiveRoot() distinguishes the parent from the archive root", () => {
+    assert.equal(nestsArchiveRoot("~/.copilot/extensions/"), false);
+    assert.equal(nestsArchiveRoot(".github/extensions"), false);
+    assert.equal(nestsArchiveRoot("~/.copilot/extensions/srs-navigator/"), true);
+    assert.equal(nestsArchiveRoot("~/.copilot/extensions/srs-navigator"), true);
+    assert.equal(nestsArchiveRoot(".github\\extensions\\srs-navigator\\"), true);
+    assert.equal(
+      nestsArchiveRoot("~/.copilot/extensions/srs-navigator-old/"),
+      false,
+      "a different directory that merely starts with the same name is not the archive root",
+    );
+  });
+
+  it("section() does not leak into the next section", () => {
+    const md = "## A\nkeep\n### A.1\nalso keep\n## B\ndrop";
+    assert.equal(section(md, "A"), "keep\n### A.1\nalso keep");
+    assert.equal(section(md, "B"), "drop");
+    assert.equal(section(md, "Missing"), "");
+  });
+
+  it("tableColumn() reads the named column and skips the separator row", () => {
+    const md = "| Scope | Extract into |\n|---|---|\n| Personal | `~/x/` |\n| Project | `y/` |\nafter";
+    assert.deepEqual(tableColumn(md, "Extract into"), ["~/x/", "y/"]);
+    assert.deepEqual(tableColumn(md, "Scope"), ["Personal", "Project"]);
+    assert.deepEqual(tableColumn(md, "Nope"), []);
+  });
+
+  it("htmlExtractTargets() ignores prose that merely mentions a directory", () => {
+    assert.deepEqual(htmlExtractTargets("<p>the <code>~/.copilot/extensions/</code> folder</p>"), []);
+    assert.deepEqual(
+      htmlExtractTargets("<p>extract it into <code>~/.copilot/extensions/</code>.</p>"),
+      ["~/.copilot/extensions/"],
+    );
+  });
+
+  it("the extract assertion actually fails on the shape that shipped", () => {
+    const broken = "| Scope | Extract into |\n|---|---|\n| Personal | `~/.copilot/extensions/srs-navigator/` |";
+    assert.ok(
+      tableColumn(broken, "Extract into").some((t) => nestsArchiveRoot(t)),
+      "the guard must notice the exact instruction that was wrong on main",
+    );
+  });
+
+  it("the release-link assertion actually fails on an unfiltered link", () => {
+    const bare = "[release archive](https://github.com/o/r/releases)";
+    assert.ok(
+      !linkTargets(bare).some((t) => t.includes(CANVAS_RELEASE_FILTER)),
+      "the guard must notice a bare /releases link",
+    );
+  });
+});

--- a/scripts/package-extension.mjs
+++ b/scripts/package-extension.mjs
@@ -23,7 +23,7 @@ import {
   cpSync,
 } from "node:fs";
 import { execFileSync, execSync } from "node:child_process";
-import { fileURLToPath } from "node:url";
+import { fileURLToPath, pathToFileURL } from "node:url";
 import { dirname, resolve } from "node:path";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
@@ -31,15 +31,21 @@ const repoRoot = resolve(__dirname, "..");
 const extDir = resolve(repoRoot, ".github", "extensions", "srs-navigator");
 const buildDir = resolve(repoRoot, "build");
 
+// The single top-level directory every archive unpacks into. Install instructions are
+// written against it: because the archive already carries this folder, the documented
+// extract target must be its *parent*. Exported so the docs guard derives that from the
+// packager instead of restating it.
+export const ARCHIVE_ROOT = "srs-navigator";
+
 // Paths (relative to the extension dir) that must never be packaged.
-const EXCLUDE = new Set([
+export const EXCLUDE = new Set([
   "node_modules",
   "test-results",
   "playwright-report",
   "tests",
   "docs",
 ]);
-const EXCLUDE_FILES = new Set([
+export const EXCLUDE_FILES = new Set([
   ".sync-state.json", // skills/.sync-state.json — per-machine runtime state
   "playwright.config.mjs",
   "README.md",
@@ -54,7 +60,7 @@ function parseArgs(argv) {
   return out;
 }
 
-function resolveVersion(explicit) {
+export function resolveVersion(explicit) {
   if (explicit) return explicit;
   const versionFile = resolve(repoRoot, "VERSION");
   if (existsSync(versionFile)) return readFileSync(versionFile, "utf-8").trim();
@@ -62,8 +68,9 @@ function resolveVersion(explicit) {
   return pkg.version;
 }
 
-function stage(stageRoot) {
-  const dest = resolve(stageRoot, "srs-navigator");
+/** Copy the shippable extension tree into `stageRoot/<ARCHIVE_ROOT>`; returns that path. */
+export function stage(stageRoot) {
+  const dest = resolve(stageRoot, ARCHIVE_ROOT);
   cpSync(extDir, dest, {
     recursive: true,
     filter: (src) => {
@@ -90,7 +97,7 @@ function hasBinary(bin) {
 function main() {
   const { version: explicit } = parseArgs(process.argv.slice(2));
   const version = resolveVersion(explicit);
-  const base = `srs-navigator-${version}`;
+  const base = `${ARCHIVE_ROOT}-${version}`;
 
   rmSync(buildDir, { recursive: true, force: true });
   mkdirSync(buildDir, { recursive: true });
@@ -103,7 +110,7 @@ function main() {
 
   // tar.gz (tar is available on Linux, macOS, and Windows 10+/bsdtar).
   const tgz = resolve(buildDir, `${base}.tar.gz`);
-  execFileSync("tar", ["-czf", tgz, "-C", stageRoot, "srs-navigator"], {
+  execFileSync("tar", ["-czf", tgz, "-C", stageRoot, ARCHIVE_ROOT], {
     stdio: "inherit",
   });
   artifacts.push(tgz);
@@ -112,7 +119,7 @@ function main() {
   // zip (best-effort: only when the zip binary exists, e.g. on CI runners).
   if (hasBinary("zip")) {
     const zip = resolve(buildDir, `${base}.zip`);
-    execSync(`zip -r -q "${zip}" srs-navigator`, { cwd: stageRoot, stdio: "inherit" });
+    execSync(`zip -r -q "${zip}" ${ARCHIVE_ROOT}`, { cwd: stageRoot, stdio: "inherit" });
     artifacts.push(zip);
     console.log(`Created ${zip}`);
   } else {
@@ -128,4 +135,8 @@ function main() {
   console.log(`\nPackaged ${base}: ${artifacts.length} archive(s).`);
 }
 
-main();
+// Only package when run as a script. Importing this module must stay side-effect free so
+// the install-path guard can call stage() into a temp directory without building anything.
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  main();
+}


### PR DESCRIPTION
Closes the in-repo half of #69. Implementation plan and full evidence: https://github.com/RafaelGorski/Problem-Based-SRS/issues/69#issuecomment-5142476386

#69 framed itself as work no test in CI could assert. That is true of *submitting to a registry*. It is not true of the clean-machine run — the run is what finds the documentation gaps, and the gaps it found are ordinary repository facts a deterministic test can hold in place. So I ran it first, from a fresh directory with no prior checkout, following the README as written.

## What the run found

**The canvas extract instruction was wrong, and the two surfaces disagreed about it.** `README.md` said extract into `~/.copilot/extensions/srs-navigator/`; `docs/index.html` said `~/.copilot/extensions/`. Running the shipped packager settles it — every entry sits under a single `srs-navigator/` root. The README's version therefore produced `~/.copilot/extensions/srs-navigator/srs-navigator/extension.mjs`, a nested copy the Copilot app will not load. The one instruction whose only job is to put files in the right place put them one level too deep, and each page looked correct on its own, which is how it survived.

**The linked page did not contain the file it named.** Both surfaces sent the reader to the bare `/releases` page for `srs-navigator-<version>.zip`. The canvas app ships on its own `vX.Y.Z` tags, interleaved with the methodology plugin's `vX.Y` releases: the latest release (`v2.4.1`) carries only `problem-based-srs-v2.4.1.zip`, and the sole canvas archive sits on `v1.1.0`, sixth in the list. A reader landing there and looking at the top release cannot find it.

**`npx skills add` installs somewhere the docs never mention.** The CLI works — it resolves the correct single skill and installs non-interactively — but it writes to `.agents/skills/problem-based-srs/` plus a `skills-lock.json`, and neither appears on either surface, while the surrounding docs point at `.github/skills/`. Someone who runs the documented command and checks the documented directory finds an empty folder and concludes it failed.

**The published archive is 42× larger than what the packager produces.** `srs-navigator-1.1.0.zip` downloads at 4.32 MB / 223 entries, **187 of them `node_modules/`** (Playwright), plus `tests/` and `docs/`. The current packager excludes all of that and yields 30 entries / 102 KB. Nothing asserted the archive's shape, so the bloat shipped unnoticed and is still on the release page.

## The change

Docs on both surfaces now name the parent directory (with the resulting path spelled out), link a filtered release view, explain the two tag trains, and say where the AgentSkills CLI actually puts things.

The guard is `evals/tests/install-path.test.mjs` (19 tests). Its point is that it **derives the archive's shape from the packager instead of restating it**: it stages the extension into a temp directory with the real `stage()`, reads the real `ARCHIVE_ROOT`, and asserts no documented extract target ends in it. Change the archive layout and the documentation assertion moves with it. A test that hard-codes the same string the docs hard-code is just a second copy of the docs.

It also gates the archive itself — one top-level root, the files needed to load an extension, no development payload, and a size budget — so the 4.3 MB shape cannot ship again.

To make that possible, `scripts/package-extension.mjs` exports `ARCHIVE_ROOT`, `EXCLUDE`, `EXCLUDE_FILES` and `stage()`, and runs `main()` only when invoked as a script. Importing it now builds nothing. Behavior as a CLI is unchanged (verified: same 30 entries, same root).

## TDD and negative testing

Written test-first. The suite was **red on 6 assertions** against `main` — the nesting bug, the cross-surface disagreement, both unfiltered release links, and both missing CLI facts — while the archive-shape assertions passed, confirming the packager was already correct and only the documentation had drifted.

Then every new guard was negative-tested by mutating the real tracked file, not a fixture. All 7 fired:

| Mutation | Guard that caught it |
|---|---|
| README extract target nests the archive root | names the directory above the archive root; agrees with the landing page |
| README release link loses its filter | is filtered in the README |
| README drops the `.agents/skills` target | names the directory the CLI actually writes to |
| README drops the `skills-lock.json` note | mentions the lockfile |
| Landing extract target nests the archive root | agrees with the landing page |
| Landing release link loses its filter | is filtered on the landing page too |
| Packager stops excluding `tests/` | carries no development payload |

Six synthetic canaries also pin the parsing helpers so they cannot start matching everything.

## Verification

| Suite | Result |
|---|---|
| `node --test evals/tests/*.test.mjs` | **207 / 207** (188 → 207) |
| `npm test` (canvas) | **231 / 231** |
| `npm run test:e2e` (Playwright, canvas + site) | **31 / 31** |
| `python scripts/build-plugin.py validate` | pass |
| `node scripts/package-extension.mjs` | 30 entries, single `srs-navigator/` root — unchanged |

Wired automatically: CI already runs `node --test evals/tests/*.test.mjs`, so the new file needs no registration. No version bump — 2.5.0 is unreleased, so the entries go in its existing section, and `VERSION` is left for `release-canvas.yml`.

## Left open on #69 deliberately

- **Registry refresh.** The listing resolves (200) and renders the current description, but advertises **9 skills** — the pre-#50 snapshot. Eight of those names no longer exist in the repo, and the README links that page. Now diagnosed with evidence, but the fix is a third-party cache.
- **Re-cutting a canvas release** so a current archive sits on a recent tag. That runs `release-canvas.yml`, which bumps `VERSION` and pushes a tag — a release action, not a pull request. The doc fix makes the existing archive findable meanwhile, and the new guard makes the next one correct.

Not merging — for review.