### PR TITLE
Prove the skills install is self-sufficient

### DIFF
--- a/.github/extensions/srs-navigator/skills/functional-requirements.md
+++ b/.github/extensions/srs-navigator/skills/functional-requirements.md
@@ -308,7 +308,7 @@ The [System] shall [quality attribute] [measurable target] [condition].
 - One CN typically requires MULTIPLE FRs
 - Every CN MUST be addressed by at least one FR
 
-## Quality Rules (per [ISO/IEC/IEEE 29148:2018](../../../docs/references/iso-iec-ieee-29148-2018.md))
+## Quality Rules (per [ISO/IEC/IEEE 29148:2018](https://www.iso.org/standard/72089.html))
 
 - **Complete**: All customer needs MUST be met by requirements
 - **Correct**: All requirements MUST meet some customer need

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,49 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- **The installed skill no longer points at files only the maintainer has.**
+  `reference/functional-requirements.md` headed its **Quality Rules** section — the rules
+  that decide whether a requirement is well-formed — with a link to
+  `../../../docs/references/iso-iec-ieee-29148-2018.md`. `npx skills add` copies
+  `skills/problem-based-srs/**` and nothing else, so once installed that link escapes the
+  skill root into the reader's own `.agents/` directory and finds nothing. It now cites the
+  standard by its public URL, the way every RFC 2119 reference in the skill already did.
+- **`/live`'s recovery instruction works outside the monorepo.** `reference/live.md` told an
+  agent that hit a missing canvas that the extension "lives at
+  `.github/extensions/srs-navigator/`" — a path that exists only for someone who cloned this
+  repository. The one instruction whose job is to fix "the extension is not installed" now
+  hands over the install URL and the filtered release list, and says plainly that the canvas
+  is a separate install from the skills.
+- **`reference/live.md` stopped teaching an ID shape the methodology forbids.** Its
+  machine-readable spec example emitted `"id": "NFR.1.0"` while SKILL.md's own Identifier
+  Notation table declares `NFR.{n}` → `NFR.01`, and the shipped demo spec uses `NFR.01`. The
+  notation guard added in #63/#66 only rejects *hyphen* IDs, so a wrong-arity dotted ID
+  walked straight through.
+
+### Added
+
+- **The skills install is executed, not inferred from a file count**
+  (`evals/tests/skills-install.test.mjs`, 14 assertions). #69 checked its "follow the README
+  install path for the skills" box on the evidence "12 files landed" — presence, which is the
+  same claim #73 had to disprove for the canvas archive. The suite now stages exactly what
+  `npx skills add` copies — derived by walking `skills/problem-based-srs/`, not from a
+  hard-coded list — into a temp directory **outside** the checkout, and asserts the result is
+  self-sufficient: every relative link resolves *inside* the installed skill, every action in
+  the orchestrator's dispatch table is present, the frontmatter still names the directory it
+  landed in, any repository-only path is accompanied by the URL that reaches it, and every ID
+  in a JSON example matches an arity parsed out of SKILL.md's notation table at runtime rather
+  than restated in the test.
+
+  This closes a blind spot rather than adding a second copy of an existing check:
+  `skills-static.test.mjs` does resolve every relative link, but from the file's location *in
+  the checkout*, where `../../../docs/` exists. It was green while the installed copy was
+  broken — the same "exercises the branch an installer never takes" hole #73 found in the
+  canvas skill fallback.
+
 ## [2.6.0] - 2026-07-31
 
 ### Added

--- a/evals/tests/skills-install.test.mjs
+++ b/evals/tests/skills-install.test.mjs
@@ -1,0 +1,332 @@
+// A skill that installs is not the same as a skill that works once installed. #69 checked
+// its "follow the README install path for the skills" box on this evidence:
+//
+//   npx skills add … → Found 1 skill → installed 12 files. Works, non-interactively.
+//
+// That is presence, and this issue has been burned by presence-not-function once already:
+// #73's whole subject was that "the archive contains extension.mjs" is not "the extension
+// loads with no node_modules". Twelve files landing is the same claim about the skills.
+//
+// `npx skills add RafaelGorski/Problem-Based-SRS --skill problem-based-srs` copies
+// skills/problem-based-srs/** into <cwd>/.agents/skills/problem-based-srs/ and NOTHING
+// else from the repository. That is the whole contract of a standalone install, and it is
+// the thing no suite held the skill to: skills-static.test.mjs resolves every relative link
+// from the file's location *in the checkout*, where `../../../docs/` exists. It is green
+// today and would stay green while the installed copy points into a directory the user
+// does not have — the same "exercises the branch an installer never takes" hole #73 found
+// in the canvas skill fallback.
+//
+// So this suite stages exactly what the CLI copies into a temp directory outside the
+// monorepo and asserts against that tree. The staged file set is derived by walking the
+// source directory rather than hard-coded, so a new reference file is covered the moment
+// it is added. Offline: no npx, no network, no clone.
+import { describe, it, after } from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(here, "../..");
+const skillSource = path.join(repoRoot, "skills", "problem-based-srs");
+
+// Where `npx skills add` puts a copied skill, verified against a clean-directory run.
+const INSTALL_PREFIX = path.join(".agents", "skills");
+const SKILL_SLUG = "problem-based-srs";
+
+// Paths that exist only in this repository's checkout. A skill shipped to arbitrary
+// machines may still name them — telling a reader where the canvas extension lives is
+// useful — but it must also hand over the public URL, or the instruction is unusable by
+// the only people who read it.
+const REPO_ONLY_PATHS = [".github/extensions/srs-navigator", ".spec/crm-system.json"];
+const PROJECT_URL = "https://github.com/RafaelGorski/Problem-Based-SRS";
+
+/* ------------------------------------------------------------------ helpers */
+
+/** Every file in a tree, as forward-slash paths relative to it. */
+export function walkFiles(dir, base = dir) {
+  return fs
+    .readdirSync(dir, { withFileTypes: true })
+    .flatMap((e) => {
+      const full = path.join(dir, e.name);
+      return e.isDirectory()
+        ? walkFiles(full, base)
+        : [path.relative(base, full).replaceAll("\\", "/")];
+    })
+    .sort();
+}
+
+/** Copy a directory tree, the way the installer copies a skill. */
+export function copyTree(from, to) {
+  fs.mkdirSync(to, { recursive: true });
+  for (const entry of fs.readdirSync(from, { withFileTypes: true })) {
+    const src = path.join(from, entry.name);
+    const dest = path.join(to, entry.name);
+    if (entry.isDirectory()) copyTree(src, dest);
+    else fs.copyFileSync(src, dest);
+  }
+}
+
+/**
+ * Relative markdown link targets: `[text](target)`, dropping anchors, absolute URLs and
+ * bare fragments. These are the links whose meaning changes when the file is copied
+ * somewhere else, which is the whole subject of this suite.
+ */
+export function relativeLinks(md) {
+  return [...md.matchAll(/\[[^\]]*\]\(([^)\s]+)\)/g)]
+    .map((m) => m[1].split("#")[0])
+    .filter((t) => t && !/^(?:[a-z][a-z0-9+.-]*:|\/\/|#)/i.test(t));
+}
+
+/**
+ * Arity of each artifact ID, parsed out of SKILL.md's Identifier Notation table rather
+ * than restated here: `| Customer Need | `CN.{cp}.{n}` | … |` yields CN -> 2. Reading the
+ * table at runtime keeps the table and the examples bound together — a test that
+ * hard-codes what the docs hard-code is a second copy of the docs.
+ *
+ * A prefix may legitimately appear on more than one row (CP is both `CP.{n}` and the
+ * sub-problem `CP.{n}.{m}`), so every declared arity is kept.
+ */
+export function notationArities(skillMd) {
+  const arities = new Map();
+  for (const m of skillMd.matchAll(/^\|[^|]*\|\s*`((?:CP|CN|FR|NFR))((?:\.\{[a-z]+\})+)`\s*\|/gm)) {
+    const [, prefix, levels] = m;
+    const arity = (levels.match(/\{/g) || []).length;
+    if (!arities.has(prefix)) arities.set(prefix, new Set());
+    arities.get(prefix).add(arity);
+  }
+  return arities;
+}
+
+/** Fenced code blocks of the given languages, as raw strings. */
+export function fencedBlocks(md, languages) {
+  const langs = languages.join("|");
+  const re = new RegExp("^```(?:" + langs + ")\\r?\\n([\\s\\S]*?)^```", "gm");
+  return [...md.matchAll(re)].map((m) => m[1]);
+}
+
+/** Every dotted artifact ID in a chunk of text, with its arity. */
+export function dottedIds(text) {
+  return [...text.matchAll(/\b(NFR|CP|CN|FR)((?:\.\d+)+)\b/g)].map((m) => ({
+    id: m[0],
+    prefix: m[1],
+    arity: m[2].split(".").length - 1,
+  }));
+}
+
+/** Actions the orchestrator routes to a reference file, from its dispatch table. */
+export function dispatchTable(skillMd) {
+  return [...skillMd.matchAll(/^\|\s*`([a-z-]+)`\s*\|\s*\[`(reference\/[a-z-]+\.md)`\]/gm)].map(
+    (m) => ({ action: m[1], file: m[2] }),
+  );
+}
+
+/* -------------------------------------------------------------------- suite */
+
+// Staged eagerly: every describe below reads the same install, and a hook inside one
+// describe would not run for the others.
+const installRoot = fs.mkdtempSync(path.join(os.tmpdir(), "srs-skills-install-"));
+const skillRoot = path.join(installRoot, INSTALL_PREFIX, SKILL_SLUG);
+copyTree(skillSource, skillRoot);
+const staged = walkFiles(skillRoot);
+const read = (rel) => fs.readFileSync(path.join(skillRoot, rel), "utf8");
+
+after(() => {
+  fs.rmSync(installRoot, { recursive: true, force: true });
+});
+
+describe("skills install (staged the way `npx skills add` stages it)", () => {
+  it("stages outside the monorepo, so repo-relative paths cannot accidentally resolve", () => {
+    const inside = !path.relative(repoRoot, installRoot).startsWith("..");
+    assert.ok(
+      !inside,
+      `staging directory ${installRoot} is inside the checkout; every escaping link would ` +
+        "resolve against the repo and this suite would prove nothing",
+    );
+    for (const leaked of ["docs", ".spec", "evals", "scripts", ".github"]) {
+      assert.ok(
+        !fs.existsSync(path.join(installRoot, leaked)),
+        `${leaked}/ must not exist next to the install — the CLI copies the skill directory ` +
+          "and nothing else, and this suite must reproduce that",
+      );
+    }
+  });
+
+  it("copies the whole skill directory, deriving the file set from the source", () => {
+    assert.deepEqual(
+      staged,
+      walkFiles(skillSource),
+      "the staged tree must match skills/problem-based-srs/ exactly; a hard-coded list would " +
+        "stop covering the next reference file someone adds",
+    );
+    assert.ok(staged.includes("SKILL.md"), "SKILL.md must be installed");
+  });
+
+  it("keeps frontmatter that names the directory it was installed into", () => {
+    const frontmatter = /^---\r?\n([\s\S]*?)\r?\n---/.exec(read("SKILL.md"));
+    assert.ok(frontmatter, "SKILL.md must keep YAML frontmatter through the copy");
+    const name = /^name:\s*(\S+)/m.exec(frontmatter[1]);
+    assert.ok(name, "frontmatter must declare a name");
+    assert.equal(
+      name[1],
+      path.basename(skillRoot),
+      "the declared name must match the installed directory or the agent cannot resolve the skill",
+    );
+  });
+
+  it("routes every advertised action to a file that is actually installed", () => {
+    const routes = dispatchTable(read("SKILL.md"));
+    assert.ok(routes.length >= 9, `expected the dispatch table to list the actions, got ${routes.length}`);
+    for (const { action, file } of routes) {
+      assert.ok(
+        staged.includes(file),
+        `/problem-based-srs ${action} routes to ${file}, which is not in the install`,
+      );
+    }
+  });
+});
+
+describe("the installed skill is self-contained", () => {
+  it("every relative link resolves inside the installed skill", () => {
+    const escaping = [];
+    const missing = [];
+    for (const rel of staged.filter((f) => f.endsWith(".md"))) {
+      const dir = path.dirname(path.join(skillRoot, rel));
+      for (const target of relativeLinks(read(rel))) {
+        const resolved = path.resolve(dir, target);
+        const outside = path.relative(skillRoot, resolved).startsWith("..");
+        if (outside) escaping.push(`${rel} -> ${target}`);
+        else if (!fs.existsSync(resolved)) missing.push(`${rel} -> ${target}`);
+      }
+    }
+    assert.deepEqual(
+      escaping,
+      [],
+      "these links point outside the installed skill, so they resolve into the user's own " +
+        "project and find nothing. Cite external material by absolute URL — the way every " +
+        "RFC 2119 reference in this skill already does",
+    );
+    assert.deepEqual(missing, [], "these links point at files the install does not carry");
+  });
+
+  it("names a repository-only path only alongside the URL that reaches it", () => {
+    const offenders = [];
+    for (const rel of staged.filter((f) => f.endsWith(".md"))) {
+      const text = read(rel);
+      for (const repoPath of REPO_ONLY_PATHS) {
+        if (text.includes(repoPath) && !text.includes(PROJECT_URL)) {
+          offenders.push(`${rel} mentions ${repoPath}`);
+        }
+      }
+    }
+    assert.deepEqual(
+      offenders,
+      [],
+      `a path like ${REPO_ONLY_PATHS[0]} exists only for someone who cloned the monorepo. ` +
+        `An installed reader needs ${PROJECT_URL}… in the same file, or the instruction is ` +
+        "unusable by the only audience that reads it",
+    );
+  });
+
+  it("does not tell an installed reader to reload an extension it never shipped", () => {
+    const live = read("reference/live.md");
+    const recovery = live.slice(live.indexOf("not installed"));
+    assert.ok(
+      recovery.includes(PROJECT_URL),
+      "the /live recovery note must hand over the install URL: the one instruction whose job " +
+        "is to fix “the extension is not installed” cannot assume the extension's source tree " +
+        "is already on disk",
+    );
+  });
+});
+
+describe("machine-readable examples obey the notation table they ship with", () => {
+  it("every ID in a JSON example matches an arity SKILL.md declares", () => {
+    const arities = notationArities(read("SKILL.md"));
+    assert.ok(arities.size >= 4, "SKILL.md must declare CP/CN/FR/NFR formats in its notation table");
+
+    const wrong = [];
+    for (const rel of staged.filter((f) => f.endsWith(".md"))) {
+      for (const block of fencedBlocks(read(rel), ["json", "jsonc"])) {
+        for (const { id, prefix, arity } of dottedIds(block)) {
+          const allowed = arities.get(prefix);
+          if (allowed && !allowed.has(arity)) {
+            wrong.push(`${rel}: ${id} (${arity} level(s); SKILL.md allows ${[...allowed].join(", ")})`);
+          }
+        }
+      }
+    }
+    assert.deepEqual(
+      wrong,
+      [],
+      "a machine-readable example that contradicts the orchestrator's own notation table " +
+        "teaches an agent to emit IDs the methodology forbids, and the hyphen-ID guard cannot " +
+        "see a wrong-arity dotted ID",
+    );
+  });
+});
+
+describe("negative canaries", () => {
+  it("relativeLinks() keeps repo-relative targets and drops absolute ones", () => {
+    assert.deepEqual(relativeLinks("[a](../../../docs/x.md)"), ["../../../docs/x.md"]);
+    assert.deepEqual(relativeLinks("[a](https://iso.org/standard/72089.html)"), []);
+    assert.deepEqual(relativeLinks("[a](reference/needs.md#top)"), ["reference/needs.md"]);
+    assert.deepEqual(relativeLinks("[a](#section)"), []);
+  });
+
+  it("an escaping link is detected even though it resolves fine inside the checkout", () => {
+    const fromRepo = path.resolve(
+      path.join(skillSource, "reference"),
+      "../../../docs/references/iso-iec-ieee-29148-2018.md",
+    );
+    assert.ok(
+      fs.existsSync(fromRepo),
+      "sanity: the repo-relative form is exactly the shape that resolves in a checkout",
+    );
+    const fromInstall = path.resolve(
+      path.join(skillRoot, "reference"),
+      "../../../docs/references/iso-iec-ieee-29148-2018.md",
+    );
+    assert.ok(
+      path.relative(skillRoot, fromInstall).startsWith(".."),
+      "…and the same link escapes the installed skill, which is what this suite must notice",
+    );
+  });
+
+  it("notationArities() reads the table instead of assuming it", () => {
+    const table = [
+      "| Customer Problem | `CP.{n}` | `CP.01` |",
+      "| Sub-problem | `CP.{n}.{m}` | `CP.01.1` |",
+      "| Customer Need | `CN.{cp}.{n}` | `CN.01.1` |",
+      "| Non-Functional Requirement | `NFR.{n}` | `NFR.01` |",
+    ].join("\n");
+    const arities = notationArities(table);
+    assert.deepEqual([...arities.get("CP")].sort(), [1, 2]);
+    assert.deepEqual([...arities.get("CN")], [2]);
+    assert.deepEqual([...arities.get("NFR")], [1]);
+    assert.equal(notationArities("no table here").size, 0);
+  });
+
+  it("dottedIds() reports the arity a wrong example would carry", () => {
+    assert.deepEqual(dottedIds('"id": "NFR.1.0"'), [
+      { id: "NFR.1.0", prefix: "NFR", arity: 2 },
+    ]);
+    assert.deepEqual(dottedIds('"id": "NFR.01"'), [{ id: "NFR.01", prefix: "NFR", arity: 1 }]);
+    assert.deepEqual(dottedIds("CP-001 is legacy"), []);
+  });
+
+  it("fencedBlocks() only returns the requested languages", () => {
+    const md = "```jsonc\n{\"id\":\"CP.01\"}\n```\n\n```bash\necho CP.01.2.3\n```\n";
+    assert.deepEqual(fencedBlocks(md, ["json", "jsonc"]), ['{"id":"CP.01"}\n']);
+    assert.deepEqual(fencedBlocks(md, ["json"]), []);
+  });
+
+  it("dispatchTable() reads routes, not prose that mentions an action", () => {
+    assert.deepEqual(
+      dispatchTable("| `needs` | [`reference/needs.md`](reference/needs.md) |"),
+      [{ action: "needs", file: "reference/needs.md" }],
+    );
+    assert.deepEqual(dispatchTable("run `needs` to see reference/needs.md"), []);
+  });
+});

--- a/skills/problem-based-srs/reference/functional-requirements.md
+++ b/skills/problem-based-srs/reference/functional-requirements.md
@@ -308,7 +308,7 @@ The [System] shall [quality attribute] [measurable target] [condition].
 - One CN typically requires MULTIPLE FRs
 - Every CN MUST be addressed by at least one FR
 
-## Quality Rules (per [ISO/IEC/IEEE 29148:2018](../../../docs/references/iso-iec-ieee-29148-2018.md))
+## Quality Rules (per [ISO/IEC/IEEE 29148:2018](https://www.iso.org/standard/72089.html))
 
 - **Complete**: All customer needs MUST be met by requirements
 - **Correct**: All requirements MUST meet some customer need

--- a/skills/problem-based-srs/reference/live.md
+++ b/skills/problem-based-srs/reference/live.md
@@ -5,8 +5,9 @@ render the current Problem-Based SRS specification as an interactive, force-dire
 graph. This is the UX layer for navigating the artifacts produced by the methodology
 skills (`business-context` → `customer-problems` → … → `functional-requirements`).
 
-The canvas extension ships in this repository at
-`.github/extensions/srs-navigator/` and registers a canvas with id **`srs-navigator`**
+The canvas extension is installed **separately from these skills**. Its source lives at
+[`.github/extensions/srs-navigator/`](https://github.com/RafaelGorski/Problem-Based-SRS/tree/main/.github/extensions/srs-navigator)
+in the Problem-Based-SRS project, and it registers a canvas with id **`srs-navigator`**
 plus the full methodology as agent tools.
 
 ## When to use
@@ -45,8 +46,9 @@ plus the full methodology as agent tools.
 
 ## Specification shape
 
-The navigator expects a JSON object with these arrays (see
-`.spec/crm-system.json` for a complete example):
+The navigator expects a JSON object with these arrays (the project repository ships a
+complete example at
+[`.spec/crm-system.json`](https://github.com/RafaelGorski/Problem-Based-SRS/blob/main/.spec/crm-system.json)):
 
 ```jsonc
 {
@@ -55,7 +57,7 @@ The navigator expects a JSON object with these arrays (see
   "problems": [ { "id": "CP.01", "label": "…", "description": "…" } ],
   "needs": [ { "id": "CN.01.1", "label": "…", "problem": "CP.01" } ],
   "functionalRequirements": [ { "id": "FR.01.1.1", "label": "…", "need": "CN.01.1" } ],
-  "nonFunctionalRequirements": [ { "id": "NFR.1.0", "label": "…" } ]
+  "nonFunctionalRequirements": [ { "id": "NFR.01", "label": "…" } ]
 }
 ```
 
@@ -66,8 +68,13 @@ consistent with the methodology naming convention (`CP → CN → FR`).
 
 - The canvas runs entirely inside the Copilot app on a loopback HTTP server — nothing
   leaves the machine.
-- If the `srs-navigator` canvas is not available, the extension may not be installed in
-  the current scope. It lives at `.github/extensions/srs-navigator/`; reload extensions
-  so the `srs-navigator` canvas and its tools are registered, then retry `open_canvas`.
+- If the `srs-navigator` canvas is not available, the extension is not installed in the
+  current scope. It is a **separate install** from these skills — do not assume its source
+  tree is on disk. Ask the Copilot app to install it from
+  `https://github.com/RafaelGorski/Problem-Based-SRS/tree/main/.github/extensions/srs-navigator`,
+  or extract a `srs-navigator-<version>` archive from the
+  [filtered release list](https://github.com/RafaelGorski/Problem-Based-SRS/releases?q=srs-navigator&expanded=true)
+  into `~/.copilot/extensions/` (the archive already carries its own `srs-navigator/`
+  folder, and needs no `npm install`). Then reload extensions and retry `open_canvas`.
 - This skill only handles **visualization**. To create or refine the underlying
   artifacts, use the `/problem-based-srs` command (e.g. `/problem-based-srs problems`).


### PR DESCRIPTION
Closes part of #69 — the **skills** half of "clean-machine install verification". Not merged.

`npx skills add RafaelGorski/Problem-Based-SRS --skill problem-based-srs` copies
`skills/problem-based-srs/**` into `.agents/skills/problem-based-srs/` and **nothing else**
from this repository. #69 checked its skills-install box on this evidence:

> `Found 1 skill` → installed 12 files. Works, non-interactively.

That is presence. #73's entire subject was that presence is not function — "the archive
contains `extension.mjs`" is not "the extension loads with no `node_modules`". Twelve files
landing is the same claim about the skills, and nothing had ever run it. So I staged what the
CLI actually copies into a directory outside the checkout and read the result as an installed
user would.

## What the run found

**1. The one normative standard the methodology cites is unreachable once installed.**
`reference/functional-requirements.md` headed its **Quality Rules** section — the rules that
decide whether a requirement is well-formed — with a link to
`../../../docs/references/iso-iec-ieee-29148-2018.md`. From
`.agents/skills/problem-based-srs/reference/` that resolves to `.agents/docs/references/…`:
outside the skill, inside the user's own project, and absent. Every other citation in the
skill is already an absolute public URL — RFC 2119 and RFC 8174 in all seven action files —
so this was a slip, not a policy.

Why it survived: `skills-static.test.mjs` **does** resolve every relative link, from
`path.dirname(doc.file)` — i.e. against the checkout, where `../../../docs/` exists. Green
today, green forever, while the installed copy points at nothing. That is exactly the hole
#73 found in the canvas standalone fallback: a test exercising the branch an installer never
takes.

**2. `/live`'s recovery instruction only worked for someone who already had the repo.**
`reference/live.md` told an agent that hit a missing canvas:

> the extension may not be installed in the current scope. It lives at
> `.github/extensions/srs-navigator/`; reload extensions …

An installed user has no such directory. The one instruction whose job is to recover from
"the extension is not installed" assumed its source tree was already on disk. #72 fixed this
exact class of defect in the README; the skill still shipped it.

**3. `live.md` taught an ID shape the methodology forbids.** Its machine-readable example
emitted `"id": "NFR.1.0"`, while SKILL.md's Identifier Notation table declares `NFR.{n}` →
`NFR.01` and the shipped demo spec uses `NFR.01`…`NFR.05`. The notation guard from #63/#66
only rejects *hyphen* IDs, so a wrong-arity dotted ID walked straight through.

## The change

| Fix | Guard |
|---|---|
| ISO 29148 cited by public URL | every relative link must resolve **inside the installed skill root** |
| `/live` recovery hands over the install URL + filtered release list, and says the canvas is a separate install | any repository-only path named in the skill must carry the URL that reaches it, in the same file |
| example emits `NFR.01` | JSON examples validated against an arity table **parsed out of SKILL.md at runtime** |
| — | every action in the dispatch table must be present in the install; frontmatter must still name the directory it landed in |

`evals/tests/skills-install.test.mjs` (14 assertions) derives the staged file set by walking
`skills/problem-based-srs/` rather than hard-coding it, so the next reference file is covered
the moment it is added, and stages into a temp dir it first asserts is **outside** the
checkout — otherwise every escaping link would resolve against the repo and the suite would
prove nothing. Offline: no `npx`, no clone, no network. `functional-requirements.md` is one of
the nine bundled canvas copies, so `sync-skills.mjs` was re-run.

The notation assertions read SKILL.md's table instead of restating it, matching how #72's
guard derives `ARCHIVE_ROOT` and #73's derives the install manifest from the packager. A test
that hard-codes what the docs hard-code is a second copy of the docs.

## Verification

- **RED first.** The suite failed on the current tree for the escaping ISO link, both
  repository-only paths in `live.md`, the recovery note, and `NFR.1.0` — confirmed before
  anything was fixed.
- **Every new assertion negative-tested** by mutating the real tracked file, not a fixture:
  reverting the ISO link, adding a link to a reference file that is not installed, stripping
  every project URL from `live.md`, stripping the URL from the recovery note only while the
  file keeps one elsewhere, reverting the example to `NFR.1.0`, removing an advertised
  action's reference file, breaking the frontmatter name, and deleting SKILL.md's notation
  table. 8 mutations, 8 red, tree restored.
- **Fidelity check.** The staged layout is byte-for-byte the same file set a real
  `npx skills add` produced in an empty directory — 12 files, identical relative paths.
- `node --test evals/tests/*.test.mjs` → **272/272** (was 258)
- canvas `npm test` → **231/231**
- `python scripts/build-plugin.py validate` → OK

## Still open on #69

Refreshing the stale skills.sh listing and the second-registry decision — both genuinely
outside this repository, and unchanged by any pull request.

Separately filed: the same scan that caught `NFR.1.0` shows the case studies
(`crm-example.md`, `microer-example.md`, `validate.md`, `complexity.md`) using `CN.1` / `FR.1`
shapes that carry no traceability under `CN.{cp}.{n}` / `FR.{cp}.{cn}.{n}`. Real, but a
different defect family and a large mechanical edit — kept out of an install-path PR.


