### PR TITLE
fix: Renumber case-study IDs to canonical dotted notation

### DIFF
--- a/.github/extensions/srs-navigator/skills/complexity.md
+++ b/.github/extensions/srs-navigator/skills/complexity.md
@@ -73,10 +73,10 @@ For each mapping (CP→CN and CN→FR), check:
 Create a design matrix to visualize relationships:
 
 ```
-         CN.1  CN.2  CN.3
-CP.1     [X]   [ ]   [ ]    ← Ideal: one X per row
-CP.2     [ ]   [X]   [ ]
-CP.3     [ ]   [ ]   [X]
+         CN.01.1  CN.02.1  CN.03.1
+CP.01      [X]      [ ]      [ ]    ← Ideal: one X per row
+CP.02      [ ]      [X]      [ ]
+CP.03      [ ]      [ ]      [X]
 ```
 
 **Matrix Types:**
@@ -96,10 +96,10 @@ Use **C** (Complete) and **P** (Partial) markers to indicate how well each eleme
 ### CP → CN Completeness Matrix
 
 ```
-         CN.1  CN.2  CN.3
-CP.1     [C]   [ ]   [ ]    C = CN completely solves CP
-CP.2     [P]   [P]   [ ]    P = CN partially solves CP
-CP.3     [ ]   [ ]   [C]
+         CN.01.1  CN.02.1  CN.02.2  CN.03.1
+CP.01      [C]      [ ]      [ ]      [ ]    C = CN completely solves CP
+CP.02      [ ]      [P]      [P]      [ ]    P = CN partially solves CP
+CP.03      [ ]      [ ]      [ ]      [C]
 ```
 
 **Interpretation:**
@@ -109,11 +109,16 @@ CP.3     [ ]   [ ]   [C]
 ### CN → FR Completeness Matrix
 
 ```
-         FR.1  FR.2  FR.3  FR.4
-CN.1     [C]   [ ]   [ ]   [ ]
-CN.2     [P]   [P]   [ ]   [ ]
-CN.3     [ ]   [ ]   [C]   [P]
+           FR.01.1.1  FR.01.1.2  FR.02.1.1  FR.03.1.1
+CN.01.1      [C]        [P]        [ ]        [ ]
+CN.02.1      [ ]        [P]        [C]        [ ]
+CN.03.1      [ ]        [ ]        [ ]        [C]
 ```
+
+Canonical IDs make coupling visible before the statements are even read: an
+`FR.{cp}.{cn}.{n}` sits on the diagonal of the `CN.{cp}.{n}` its own ID names. Every mark
+off that diagonal — `FR.01.1.2` in the `CN.02.1` row above — is a shared requirement, and
+each one has to be justified against Axiom 1 rather than discovered later.
 
 ### Completeness Rules
 
@@ -144,7 +149,7 @@ For each CN, estimate:
 
 **Example:**
 ```
-CN.1: Manager needs to know account balances within 24 hours
+CN.01.1: Manager needs to know account balances within 24 hours
 
 Need Range: 0-24 hours (acceptable)
 System Range: 0-2 hours (what system delivers)
@@ -206,7 +211,7 @@ When running complexity analysis, produce:
 
 | CN | Need Range | System Range | Overlap | IC Level |
 |----|------------|--------------|---------|----------|
-| CN.1 | [range] | [range] | [%] | [Low/Med/High] |
+| CN.01.1 | [range] | [range] | [%] | [Low/Med/High] |
 
 ### 5. Recommendations
 
@@ -241,15 +246,15 @@ When running complexity analysis, produce:
 
 **CP → CN Matrix:**
 ```
-         CN.1  CN.2  CN.3  CN.4  CN.5  CN.6
-CP.1     [C]   [P]   [ ]   [ ]   [ ]   [ ]
-CP.2     [ ]   [ ]   [C]   [ ]   [ ]   [ ]
-CP.3     [ ]   [ ]   [ ]   [C]   [ ]   [ ]
-CP.4     [ ]   [ ]   [ ]   [ ]   [C]   [P]
-CP.5     [ ]   [ ]   [ ]   [ ]   [ ]   [C]
+         CN.01.1  CN.01.2  CN.02.1  CN.03.1  CN.04.1  CN.05.1
+CP.01      [C]      [P]      [ ]      [ ]      [ ]      [ ]
+CP.02      [ ]      [ ]      [C]      [ ]      [ ]      [ ]
+CP.03      [ ]      [ ]      [ ]      [C]      [ ]      [ ]
+CP.04      [ ]      [ ]      [ ]      [ ]      [C]      [P]
+CP.05      [ ]      [ ]      [ ]      [ ]      [ ]      [C]
 ```
 
-**Result:** Semi-coupled (triangular tendency). CP.1 and CP.4 have multiple CNs but they don't compete. Acceptable.
+**Result:** Semi-coupled (triangular tendency). CP.01 and CP.04 have multiple CNs but they don't compete. Acceptable.
 
 ---
 

--- a/.github/extensions/srs-navigator/skills/functional-requirements.md
+++ b/.github/extensions/srs-navigator/skills/functional-requirements.md
@@ -123,7 +123,7 @@ The CRM system shall allow the Account Manager to update existing client records
 ```
 | CN | Functional Requirements |
 |----|------------------------|
-| CN.1 | FR.01.1.1 Registration, FR.01.1.2 Update |
+| CN.01.1 | FR.01.1.1 Registration, FR.01.1.2 Update |
 ```
 
 The wrong format above lacks "shall" statements, acceptance criteria, and proper traceability.

--- a/.github/extensions/srs-navigator/skills/problem-based-srs.md
+++ b/.github/extensions/srs-navigator/skills/problem-based-srs.md
@@ -110,6 +110,7 @@ the ID itself — reading an ID tells you what it descends from:
 |----------|--------|---------|----------|
 | Customer Problem | `CP.{n}` | `CP.01` | the first customer problem |
 | Sub-problem | `CP.{n}.{m}` | `CP.01.1` | first facet of `CP.01` |
+| Sub-sub-problem (rare) | `CP.{n}.{m}.{k}` | `CP.01.2.1` | first facet of `CP.01.2` |
 | Customer Need | `CN.{cp}.{n}` | `CN.01.1` | first need addressing `CP.01` |
 | Functional Requirement | `FR.{cp}.{cn}.{n}` | `FR.01.1.1` | first FR implementing `CN.01.1` |
 | Non-Functional Requirement | `NFR.{n}` | `NFR.01` | the first quality requirement |

--- a/.github/extensions/srs-navigator/skills/validate.md
+++ b/.github/extensions/srs-navigator/skills/validate.md
@@ -14,32 +14,45 @@ This skill is used **during and after** Steps 1, 3, and 5 to validate and refine
 
 > **Diagram preference:** When visualizing traceability mappings, prefer Mermaid UML diagrams (e.g., `flowchart` for hierarchy trees, `graph` for dependency maps) over ASCII art where rendering supports it.
 
+```mermaid
+flowchart LR
+    subgraph WHY["Customer Problems — WHY"]
+        direction TB
+        CP01["CP.01"]
+        CP011["CP.01.1"]
+        CP012["CP.01.2"]
+        CP01 --> CP011
+        CP01 --> CP012
+    end
+
+    subgraph WHAT["Customer Needs — WHAT"]
+        direction TB
+        CN011["CN.01.1"]
+        CN012["CN.01.2"]
+    end
+
+    subgraph HOW["Functional Requirements — HOW"]
+        direction TB
+        FR0111["FR.01.1.1"]
+        FR0112["FR.01.1.2"]
+        FR0121["FR.01.2.1"]
+    end
+
+    CP011 -- ZAG --> CN011
+    CP012 -- ZAG --> CN012
+    CN011 -- ZAG --> FR0111
+    CN011 -- ZAG --> FR0112
+    CN012 -- ZAG --> FR0121
+
+    CN011 -. ZIG .-> CP011
+    FR0111 -. ZIG .-> CN011
 ```
-┌─────────────────────────────────────────────────────────────────────────┐
-│                           ZIG ZAG DECOMPOSITION                         │
-│                                                                         │
-│   Customer        Customer         Functional                           │
-│   Problems        Needs            Requirements                         │
-│   Domain          Domain           Domain                               │
-│                                                                         │
-│   ┌─────┐        ┌─────┐          ┌─────┐                               │
-│   │ CP  │───────▶│ CN  │─────────▶│ FR  │                               │
-│   └──┬──┘        └──┬──┘          └──┬──┘                               │
-│      │    ◀─ZIG     │    ◀─ZIG      │                                   │
-│   ┌──▼──┐  ZAG─▶ ┌──▼──┐  ZAG─▶  ┌──▼──┐                               │
-│   │CP.1 │───────▶│CN.1 │─────────▶│FR.1 │                               │
-│   │CP.2 │───────▶│CN.2 │─────────▶│FR.2 │                               │
-│   └──┬──┘        └──┬──┘          └──┬──┘                               │
-│      │              │                │                                   │
-│   ┌──▼──┐        ┌──▼──┐          ┌──▼──┐                               │
-│   │CP.1.1│──────▶│CN.1.1│────────▶│FR.1.1│                              │
-│   │CP.1.2│──────▶│CN.1.2│────────▶│FR.1.2│                              │
-│   └─────┘        └─────┘          └─────┘                               │
-│                                                                         │
-│   "WHY"          "WHAT"           "HOW"                                 │
-│   (Problem)      (Outcome)        (Capability)                          │
-└─────────────────────────────────────────────────────────────────────────┘
-```
+
+**Reading the diagram:** the top of each domain is decomposition level 1 and the nodes
+below it are level 2 — the levels are the rows, not the ID scheme. Solid arrows ZAG
+forward (problem → outcome → capability); dashed arrows ZIG back to validate that each
+item still answers its source. Every ID names its own parent, so `FR.01.1.2` is traceable
+to `CN.01.1` and on to `CP.01` without consulting the diagram at all.
 
 ---
 
@@ -89,8 +102,8 @@ Output: Mapping table showing relationships
 Format:
 | Source | Target(s) | Relationship | Gap? |
 |--------|-----------|--------------|------|
-| CP.1   | CN.1, CN.2 | CP.1 addressed by CN.1 (primary), CN.2 (secondary) | No |
-| CP.2   | —          | No CN addresses CP.2 | YES |
+| CP.01  | CN.01.1, CN.01.2 | CP.01 addressed by CN.01.1 (primary), CN.01.2 (secondary) | No |
+| CP.02  | —          | No CN addresses CP.02 | YES |
 
 ### Operation 2: ZIG-VALIDATE (Backward Traceability)
 Verify each item traces back to its source.
@@ -101,27 +114,27 @@ Output: Validation report
 Format:
 | Item | Traces To | Valid? | Issue |
 |------|-----------|--------|-------|
-| FR.1 | CN.1      | ✅     | —     |
-| FR.7 | —         | ❌     | Orphan FR - no CN source |
+| FR.01.1.1 | CN.01.1 | ✅     | —     |
+| FR.07.1.1 | —         | ❌     | Orphan FR — its ID claims CN.07.1, which does not exist |
 
 ### Operation 3: DECOMPOSE (Hierarchical Breakdown)
 Decompose a high-level item into sub-items, zigzagging between domains.
 
 Process:
-1. Start with high-level CP (e.g., CP.1)
-2. ZAG → Identify CN(s) that address CP.1
+1. Start with high-level CP (e.g., CP.01)
+2. ZAG → Identify CN(s) that address CP.01
 3. ZIG → Review if CN decomposition suggests CP refinement
 4. ZAG → For each CN, identify FR(s)
 5. ZIG → Review if FR decomposition suggests CN refinement
 
 Format:
 ```
-CP.1: [High-level problem statement]
-  ├── CN.1.1: [Outcome needed to address part of CP.1]
-  │     ├── FR.1.1.1: [Capability for CN.1.1]
-  │     └── FR.1.1.2: [Capability for CN.1.1]
-  └── CN.1.2: [Another outcome for CP.1]
-        └── FR.1.2.1: [Capability for CN.1.2]
+CP.01: [High-level problem statement]
+  ├── CN.01.1: [Outcome needed to address part of CP.01]
+  │     ├── FR.01.1.1: [Capability for CN.01.1]
+  │     └── FR.01.1.2: [Capability for CN.01.1]
+  └── CN.01.2: [Another outcome for CP.01]
+        └── FR.01.2.1: [Capability for CN.01.2]
 ```
 
 ### Operation 4: CONSISTENCY-CHECK (Full Audit)
@@ -147,9 +160,14 @@ Each FR SHOULD ideally map to one CN. If an FR affects multiple CNs, flag for re
 - No orphan CNs (needs without traced problems)
 
 ### Hierarchy Alignment
-When decomposing, sub-items SHOULD align across domains:
-- CP.1.1 SHOULD map to CN.1.1 (or subset)
-- CN.1.1 SHOULD map to FR.1.1.x
+When decomposing, sub-items SHOULD align across domains — and the ID is what aligns them:
+- a need addressing a facet of a problem repeats that problem's number: `CN.{cp}.{n}`
+- a requirement repeats both its problem's and its need's: `FR.{cp}.{cn}.{n}`
+- so `FR.01.2.3` can only sit under `CN.01.2`, which can only sit under `CP.01`
+
+Write partial shapes with `{}` placeholders, the way the notation table does:
+`FR.{cp}.{cn}.{n}` states which levels it stands for, whereas an ID cut short after two
+levels names a requirement that cannot exist.
 
 ---
 
@@ -157,7 +175,7 @@ When decomposing, sub-items SHOULD align across domains:
 
 ### Input
 ```
-CP.1: Sales managers must know customer purchase history within 5 minutes
+CP.01: Sales managers must know customer purchase history within 5 minutes
       otherwise losing sales opportunities during client calls.
 ```
 
@@ -165,45 +183,50 @@ CP.1: Sales managers must know customer purchase history within 5 minutes
 
 **Step 1 - ZAG:** What outcome (CN) addresses this problem?
 ```
-CN.1: The sales manager needs a CRM system to know the complete purchase 
+CN.01.1: The sales manager needs a CRM system to know the complete purchase 
       history of each customer at any time.
 ```
 
-**Step 2 - ZIG:** Does CN.1 fully address CP.1? 
-- CP.1 specifies "within 5 minutes" → CN.1 says "at any time" ✅
-- CP.1 specifies "during client calls" → Consider decomposition
+**Step 2 - ZIG:** Does CN.01.1 fully address CP.01? 
+- CP.01 specifies "within 5 minutes" → CN.01.1 says "at any time" ✅
+- CP.01 specifies "during client calls" → Consider decomposition
 
-**Step 3 - DECOMPOSE CN:**
+**Step 3 - DECOMPOSE CN:** the single outcome splits into two needs of the same problem,
+so both keep `CP.01` as their first segment and number on from there:
 ```
-CN.1.1: Sales manager needs CRM to display purchase history instantly.
-CN.1.2: Sales manager needs CRM accessible during phone calls (mobile/desktop).
+CN.01.1: Sales manager needs CRM to display purchase history instantly.
+CN.01.2: Sales manager needs CRM accessible during phone calls (mobile/desktop).
 ```
 
 **Step 4 - ZAG:** What FRs deliver these CNs?
 ```
-FR.1.1.1: The CRM shall display customer purchase history within 3 seconds.
-FR.1.1.2: The CRM shall allow search by customer name or phone number.
-FR.1.2.1: The CRM shall be accessible via mobile application.
-FR.1.2.2: The CRM shall provide one-click access from phone integration.
+FR.01.1.1: The CRM shall display customer purchase history within 3 seconds.
+FR.01.1.2: The CRM shall allow search by customer name or phone number.
+FR.01.2.1: The CRM shall be accessible via mobile application.
+FR.01.2.2: The CRM shall provide one-click access from phone integration.
 ```
 
 **Step 5 - ZIG:** Validate FRs trace to CNs
 | FR | CN | Valid |
 |----|-----|-------|
-| FR.1.1.1 | CN.1.1 | ✅ |
-| FR.1.1.2 | CN.1.1 | ✅ |
-| FR.1.2.1 | CN.1.2 | ✅ |
-| FR.1.2.2 | CN.1.2 | ✅ |
+| FR.01.1.1 | CN.01.1 | ✅ |
+| FR.01.1.2 | CN.01.1 | ✅ |
+| FR.01.2.1 | CN.01.2 | ✅ |
+| FR.01.2.2 | CN.01.2 | ✅ |
+
+This table is verifiable without reading a word of the statements: an `FR.{cp}.{cn}.{n}`
+is valid exactly when a `CN.{cp}.{cn}` exists. That check is only possible because the ID
+carries the parent.
 
 ### Final Hierarchy
 ```
-CP.1: Sales managers must know customer purchase history within 5 minutes
-  ├── CN.1.1: Display purchase history instantly
-  │     ├── FR.1.1.1: Display within 3 seconds
-  │     └── FR.1.1.2: Search by name/phone
-  └── CN.1.2: Accessible during phone calls
-        ├── FR.1.2.1: Mobile application
-        └── FR.1.2.2: Phone integration
+CP.01: Sales managers must know customer purchase history within 5 minutes
+  ├── CN.01.1: Display purchase history instantly
+  │     ├── FR.01.1.1: Display within 3 seconds
+  │     └── FR.01.1.2: Search by name/phone
+  └── CN.01.2: Accessible during phone calls
+        ├── FR.01.2.1: Mobile application
+        └── FR.01.2.2: Phone integration
 ```
 
 ---
@@ -217,11 +240,11 @@ Use **C** (Complete) and **P** (Partial) markers to indicate how well each eleme
 ```markdown
 ## CP → CN Coverage Matrix
 
-|      | CN.1 | CN.2 | CN.3 | CN.4 |
-|------|------|------|------|------|
-| CP.1 | C    |      |      |      |
-| CP.2 |      | C    | P    |      |
-| CP.3 |      |      |      | C    |
+|       | CN.01.1 | CN.02.1 | CN.02.2 | CN.03.1 |
+|-------|---------|---------|---------|---------|
+| CP.01 | C       |         |         |         |
+| CP.02 |         | C       | P       |         |
+| CP.03 |         |         |         | C       |
 
 **Legend:**
 - **C** = Complete — CN fully addresses the CP
@@ -229,9 +252,9 @@ Use **C** (Complete) and **P** (Partial) markers to indicate how well each eleme
 - (blank) = No relationship
 
 **Coverage Summary:**
-- CP.1: Fully covered by CN.1 ✅
-- CP.2: Covered by CN.2 (complete) + CN.3 (partial) ✅
-- CP.3: Fully covered by CN.4 ✅
+- CP.01: Fully covered by CN.01.1 ✅
+- CP.02: Covered by CN.02.1 (complete) + CN.02.2 (partial) ✅
+- CP.03: Fully covered by CN.03.1 ✅
 ```
 
 ### Gap Analysis
@@ -242,18 +265,18 @@ Use **C** (Complete) and **P** (Partial) markers to indicate how well each eleme
 ### Uncovered Customer Problems
 | CP | Statement | Suggested Action |
 |----|-----------|------------------|
-| CP.3 | [statement] | Generate CN using /problem-based-srs needs |
+| CP.03 | [statement] | Generate CN using /problem-based-srs needs |
 
 ### Orphan Items
 | Item | Type | Issue | Suggested Action |
 |------|------|-------|------------------|
-| FR.7 | FR | No CN traces | Remove or identify missing CN |
-| CN.5 | CN | No CP traces | Validate business need or remove |
+| FR.07.1.1 | FR | No CN traces — CN.07.1 does not exist | Remove or identify missing CN |
+| CN.05.1 | CN | No CP traces — CP.05 does not exist | Validate business need or remove |
 
 ### Redundancies
 | Items | Overlap | Suggested Action |
 |-------|---------|------------------|
-| FR.2, FR.8 | Both handle user search | Merge or differentiate scope |
+| FR.01.1.2, FR.02.1.1 | Both handle user search | Merge or differentiate scope |
 ```
 
 ---
@@ -277,7 +300,7 @@ Before completing zig zag analysis:
 - [ ] Every CN has at least one FR mapped
 - [ ] Every FR traces back to a CN
 - [ ] Every CN traces back to a CP
-- [ ] Hierarchical IDs align (CP.1 → CN.1.x → FR.1.x.y)
+- [ ] Hierarchical IDs align (`CP.{n}` → `CN.{cp}.{n}` → `FR.{cp}.{cn}.{n}`)
 - [ ] No orphan requirements identified
 - [ ] Gaps documented with action items
 

--- a/evals/tests/skills-install.test.mjs
+++ b/evals/tests/skills-install.test.mjs
@@ -42,6 +42,18 @@ const SKILL_SLUG = "problem-based-srs";
 const REPO_ONLY_PATHS = [".github/extensions/srs-navigator", ".spec/crm-system.json"];
 const PROJECT_URL = "https://github.com/RafaelGorski/Problem-Based-SRS";
 
+// A stand-in Identifier Notation table for the parser canaries at the bottom of this
+// file. It deliberately is not the real one: these tests prove the parser reads whatever
+// table it is handed, so the rules themselves can only ever live in SKILL.md.
+const NOTATION_TABLE = [
+  "| Customer Problem | `CP.{n}` | `CP.01` |",
+  "| Sub-problem | `CP.{n}.{m}` | `CP.01.1` |",
+  "| Sub-sub-problem | `CP.{n}.{m}.{k}` | `CP.01.2.1` |",
+  "| Customer Need | `CN.{cp}.{n}` | `CN.01.1` |",
+  "| Functional Requirement | `FR.{cp}.{cn}.{n}` | `FR.01.1.1` |",
+  "| Non-Functional Requirement | `NFR.{n}` | `NFR.01` |",
+].join("\n");
+
 /* ------------------------------------------------------------------ helpers */
 
 /** Every file in a tree, as forward-slash paths relative to it. */
@@ -99,13 +111,6 @@ export function notationArities(skillMd) {
   return arities;
 }
 
-/** Fenced code blocks of the given languages, as raw strings. */
-export function fencedBlocks(md, languages) {
-  const langs = languages.join("|");
-  const re = new RegExp("^```(?:" + langs + ")\\r?\\n([\\s\\S]*?)^```", "gm");
-  return [...md.matchAll(re)].map((m) => m[1]);
-}
-
 /** Every dotted artifact ID in a chunk of text, with its arity. */
 export function dottedIds(text) {
   return [...text.matchAll(/\b(NFR|CP|CN|FR)((?:\.\d+)+)\b/g)].map((m) => ({
@@ -113,6 +118,24 @@ export function dottedIds(text) {
     prefix: m[1],
     arity: m[2].split(".").length - 1,
   }));
+}
+
+/**
+ * IDs whose depth contradicts every arity SKILL.md declares for their prefix, reported
+ * with the 1-based line they sit on. A prefix the table says nothing about is left
+ * alone: this check enforces the table, it does not invent rules the table never made.
+ */
+export function arityOffenders(md, arities) {
+  const offenders = [];
+  md.split(/\r?\n/).forEach((line, i) => {
+    for (const { id, prefix, arity } of dottedIds(line)) {
+      const allowed = arities.get(prefix);
+      if (allowed && !allowed.has(arity)) {
+        offenders.push({ id, line: i + 1, allowed: [...allowed].sort() });
+      }
+    }
+  });
+  return offenders;
 }
 
 /** Actions the orchestrator routes to a reference file, from its dispatch table. */
@@ -241,28 +264,35 @@ describe("the installed skill is self-contained", () => {
   });
 });
 
-describe("machine-readable examples obey the notation table they ship with", () => {
-  it("every ID in a JSON example matches an arity SKILL.md declares", () => {
+// #74 scoped this check to fenced JSON, which is where that pass had found `NFR.1.0`.
+// Machine-readable blocks are not where a skill does its teaching, though: 150 IDs like
+// `CN.1` and `FR.3` sat in prose, tables and diagrams, invisible to it. They are dotted,
+// so the hyphen-ID guard passes them, and they are exactly what Rule 2 forbids — `FR.3`
+// names no parent need, `CN.1` names no parent problem. Examples are the strongest
+// instruction in a skill: an agent that reads a worked walkthrough of `CN.2 → FR.3` emits
+// `CN.2 → FR.3`, and then the canvas has no `{cp}.{cn}` to link with and `validate` can
+// only check traceability by reading prose. So the scope is the whole installed body.
+describe("every example obeys the notation table it ships with", () => {
+  it("every dotted ID in the skill matches an arity SKILL.md declares", () => {
     const arities = notationArities(read("SKILL.md"));
     assert.ok(arities.size >= 4, "SKILL.md must declare CP/CN/FR/NFR formats in its notation table");
 
     const wrong = [];
     for (const rel of staged.filter((f) => f.endsWith(".md"))) {
-      for (const block of fencedBlocks(read(rel), ["json", "jsonc"])) {
-        for (const { id, prefix, arity } of dottedIds(block)) {
-          const allowed = arities.get(prefix);
-          if (allowed && !allowed.has(arity)) {
-            wrong.push(`${rel}: ${id} (${arity} level(s); SKILL.md allows ${[...allowed].join(", ")})`);
-          }
-        }
+      for (const { id, line, allowed } of arityOffenders(read(rel), arities)) {
+        wrong.push(`${rel}:${line}: ${id} (SKILL.md allows ${allowed.join(", ")} level(s))`);
       }
     }
     assert.deepEqual(
       wrong,
       [],
-      "a machine-readable example that contradicts the orchestrator's own notation table " +
-        "teaches an agent to emit IDs the methodology forbids, and the hyphen-ID guard cannot " +
-        "see a wrong-arity dotted ID",
+      "an example that contradicts the orchestrator's own notation table teaches an agent to " +
+        "emit IDs the methodology forbids, and the hyphen-ID guard cannot see a wrong-arity " +
+        "dotted ID. Renumber the example from the parent it actually has — or, if the shape is " +
+        "legitimate methodology, declare it in SKILL.md's Identifier Notation table, which is " +
+        "the only place this test reads the rules from. A truncated ID with a placeholder tail " +
+        "(`FR.01.1.x`) is reported too, and correctly: write partial shapes the way the " +
+        "notation table does, with `{}` placeholders — `FR.{cp}.{cn}.{n}`",
     );
   });
 });
@@ -295,15 +325,10 @@ describe("negative canaries", () => {
   });
 
   it("notationArities() reads the table instead of assuming it", () => {
-    const table = [
-      "| Customer Problem | `CP.{n}` | `CP.01` |",
-      "| Sub-problem | `CP.{n}.{m}` | `CP.01.1` |",
-      "| Customer Need | `CN.{cp}.{n}` | `CN.01.1` |",
-      "| Non-Functional Requirement | `NFR.{n}` | `NFR.01` |",
-    ].join("\n");
-    const arities = notationArities(table);
-    assert.deepEqual([...arities.get("CP")].sort(), [1, 2]);
+    const arities = notationArities(NOTATION_TABLE);
+    assert.deepEqual([...arities.get("CP")].sort(), [1, 2, 3]);
     assert.deepEqual([...arities.get("CN")], [2]);
+    assert.deepEqual([...arities.get("FR")], [3]);
     assert.deepEqual([...arities.get("NFR")], [1]);
     assert.equal(notationArities("no table here").size, 0);
   });
@@ -316,10 +341,26 @@ describe("negative canaries", () => {
     assert.deepEqual(dottedIds("CP-001 is legacy"), []);
   });
 
-  it("fencedBlocks() only returns the requested languages", () => {
-    const md = "```jsonc\n{\"id\":\"CP.01\"}\n```\n\n```bash\necho CP.01.2.3\n```\n";
-    assert.deepEqual(fencedBlocks(md, ["json", "jsonc"]), ['{"id":"CP.01"}\n']);
-    assert.deepEqual(fencedBlocks(md, ["json"]), []);
+  it("arityOffenders() catches the prose shapes a JSON-only scope walked past", () => {
+    const arities = notationArities(NOTATION_TABLE);
+    // A case-study row and a coverage-matrix header — the two shapes that carried the
+    // 150 offenders this check was widened for.
+    assert.deepEqual(
+      arityOffenders("| CN.1 | The company needs a CRM to know its customers. | CP.1.1 |", arities)
+        .map((o) => o.id),
+      ["CN.1"],
+    );
+    assert.deepEqual(
+      arityOffenders("|      | FR.1 | FR.2 |\n| CN.1 | C    |      |", arities)
+        .map((o) => `${o.id}@${o.line}`),
+      ["FR.1@1", "FR.2@1", "CN.1@2"],
+    );
+    // Canonical IDs pass, including the sub-sub-problem — but only because the table
+    // declares it. Teach a shape the table omits and this check fails, by design.
+    assert.deepEqual(arityOffenders("FR.01.1.1 implements CN.01.1 under CP.01.2.1", arities), []);
+    assert.equal(arityOffenders("CP.01.2.1", notationArities("")).length, 0);
+    // A prefix the table never mentions is not this check's business.
+    assert.deepEqual(arityOffenders("REQ.1.2 and CP-001 are not it", arities), []);
   });
 
   it("dispatchTable() reads routes, not prose that mentions an action", () => {

--- a/skills/problem-based-srs/SKILL.md
+++ b/skills/problem-based-srs/SKILL.md
@@ -110,6 +110,7 @@ the ID itself — reading an ID tells you what it descends from:
 |----------|--------|---------|----------|
 | Customer Problem | `CP.{n}` | `CP.01` | the first customer problem |
 | Sub-problem | `CP.{n}.{m}` | `CP.01.1` | first facet of `CP.01` |
+| Sub-sub-problem (rare) | `CP.{n}.{m}.{k}` | `CP.01.2.1` | first facet of `CP.01.2` |
 | Customer Need | `CN.{cp}.{n}` | `CN.01.1` | first need addressing `CP.01` |
 | Functional Requirement | `FR.{cp}.{cn}.{n}` | `FR.01.1.1` | first FR implementing `CN.01.1` |
 | Non-Functional Requirement | `NFR.{n}` | `NFR.01` | the first quality requirement |

--- a/skills/problem-based-srs/reference/complexity.md
+++ b/skills/problem-based-srs/reference/complexity.md
@@ -73,10 +73,10 @@ For each mapping (CP→CN and CN→FR), check:
 Create a design matrix to visualize relationships:
 
 ```
-         CN.1  CN.2  CN.3
-CP.1     [X]   [ ]   [ ]    ← Ideal: one X per row
-CP.2     [ ]   [X]   [ ]
-CP.3     [ ]   [ ]   [X]
+         CN.01.1  CN.02.1  CN.03.1
+CP.01      [X]      [ ]      [ ]    ← Ideal: one X per row
+CP.02      [ ]      [X]      [ ]
+CP.03      [ ]      [ ]      [X]
 ```
 
 **Matrix Types:**
@@ -96,10 +96,10 @@ Use **C** (Complete) and **P** (Partial) markers to indicate how well each eleme
 ### CP → CN Completeness Matrix
 
 ```
-         CN.1  CN.2  CN.3
-CP.1     [C]   [ ]   [ ]    C = CN completely solves CP
-CP.2     [P]   [P]   [ ]    P = CN partially solves CP
-CP.3     [ ]   [ ]   [C]
+         CN.01.1  CN.02.1  CN.02.2  CN.03.1
+CP.01      [C]      [ ]      [ ]      [ ]    C = CN completely solves CP
+CP.02      [ ]      [P]      [P]      [ ]    P = CN partially solves CP
+CP.03      [ ]      [ ]      [ ]      [C]
 ```
 
 **Interpretation:**
@@ -109,11 +109,16 @@ CP.3     [ ]   [ ]   [C]
 ### CN → FR Completeness Matrix
 
 ```
-         FR.1  FR.2  FR.3  FR.4
-CN.1     [C]   [ ]   [ ]   [ ]
-CN.2     [P]   [P]   [ ]   [ ]
-CN.3     [ ]   [ ]   [C]   [P]
+           FR.01.1.1  FR.01.1.2  FR.02.1.1  FR.03.1.1
+CN.01.1      [C]        [P]        [ ]        [ ]
+CN.02.1      [ ]        [P]        [C]        [ ]
+CN.03.1      [ ]        [ ]        [ ]        [C]
 ```
+
+Canonical IDs make coupling visible before the statements are even read: an
+`FR.{cp}.{cn}.{n}` sits on the diagonal of the `CN.{cp}.{n}` its own ID names. Every mark
+off that diagonal — `FR.01.1.2` in the `CN.02.1` row above — is a shared requirement, and
+each one has to be justified against Axiom 1 rather than discovered later.
 
 ### Completeness Rules
 
@@ -144,7 +149,7 @@ For each CN, estimate:
 
 **Example:**
 ```
-CN.1: Manager needs to know account balances within 24 hours
+CN.01.1: Manager needs to know account balances within 24 hours
 
 Need Range: 0-24 hours (acceptable)
 System Range: 0-2 hours (what system delivers)
@@ -206,7 +211,7 @@ When running complexity analysis, produce:
 
 | CN | Need Range | System Range | Overlap | IC Level |
 |----|------------|--------------|---------|----------|
-| CN.1 | [range] | [range] | [%] | [Low/Med/High] |
+| CN.01.1 | [range] | [range] | [%] | [Low/Med/High] |
 
 ### 5. Recommendations
 
@@ -241,15 +246,15 @@ When running complexity analysis, produce:
 
 **CP → CN Matrix:**
 ```
-         CN.1  CN.2  CN.3  CN.4  CN.5  CN.6
-CP.1     [C]   [P]   [ ]   [ ]   [ ]   [ ]
-CP.2     [ ]   [ ]   [C]   [ ]   [ ]   [ ]
-CP.3     [ ]   [ ]   [ ]   [C]   [ ]   [ ]
-CP.4     [ ]   [ ]   [ ]   [ ]   [C]   [P]
-CP.5     [ ]   [ ]   [ ]   [ ]   [ ]   [C]
+         CN.01.1  CN.01.2  CN.02.1  CN.03.1  CN.04.1  CN.05.1
+CP.01      [C]      [P]      [ ]      [ ]      [ ]      [ ]
+CP.02      [ ]      [ ]      [C]      [ ]      [ ]      [ ]
+CP.03      [ ]      [ ]      [ ]      [C]      [ ]      [ ]
+CP.04      [ ]      [ ]      [ ]      [ ]      [C]      [P]
+CP.05      [ ]      [ ]      [ ]      [ ]      [ ]      [C]
 ```
 
-**Result:** Semi-coupled (triangular tendency). CP.1 and CP.4 have multiple CNs but they don't compete. Acceptable.
+**Result:** Semi-coupled (triangular tendency). CP.01 and CP.04 have multiple CNs but they don't compete. Acceptable.
 
 ---
 

--- a/skills/problem-based-srs/reference/crm-example.md
+++ b/skills/problem-based-srs/reference/crm-example.md
@@ -18,19 +18,19 @@ The company has difficulties maintaining an effective relationship with its cust
 
 | ID | Statement | Class |
 |----|-----------|-------|
-| CP.1 | The company must ensure the existence of a communication channel with all customers, otherwise it risks losing customers, affecting marketing, promotions, feedback, and future sales. | Obligation |
-| CP.1.1 | The company must ensure it can contact all of its customers. | Obligation |
-| CP.1.2 | The company must ensure each customer is contacted regularly. | Obligation |
-| CP.2 | The company must consider customer feedback statistics in planning, otherwise it creates customer dissatisfaction and loses market share. | Obligation |
-| CP.3 | Customers expect the company to respond to their feedback, otherwise they become frustrated and company reputation decreases. | Expectation |
-| CP.4 | The company must align sales strategies with customer behavior, otherwise it misses sales opportunities. | Obligation |
-| CP.5 | The company must project sales, otherwise it loses opportunities and makes inadequate provisions. | Obligation |
+| CP.01 | The company must ensure the existence of a communication channel with all customers, otherwise it risks losing customers, affecting marketing, promotions, feedback, and future sales. | Obligation |
+| CP.01.1 | The company must ensure it can contact all of its customers. | Obligation |
+| CP.01.2 | The company must ensure each customer is contacted regularly. | Obligation |
+| CP.02 | The company must consider customer feedback statistics in planning, otherwise it creates customer dissatisfaction and loses market share. | Obligation |
+| CP.03 | Customers expect the company to respond to their feedback, otherwise they become frustrated and company reputation decreases. | Expectation |
+| CP.04 | The company must align sales strategies with customer behavior, otherwise it misses sales opportunities. | Obligation |
+| CP.05 | The company must project sales, otherwise it loses opportunities and makes inadequate provisions. | Obligation |
 
 ### Decomposition Note
 
-CP.1 was decomposed into CP.1.1 and CP.1.2 to clarify two distinct facets:
-- **CP.1.1:** Ability to contact (having contact information)
-- **CP.1.2:** Regular contact (frequency of communication)
+CP.01 was decomposed into CP.01.1 and CP.01.2 to clarify two distinct facets:
+- **CP.01.1:** Ability to contact (having contact information)
+- **CP.01.2:** Regular contact (frequency of communication)
 
 ---
 
@@ -74,12 +74,16 @@ CRM software will:
 
 | ID | Statement | Outcome Class | Traces To |
 |----|-----------|---------------|-----------|
-| CN.1 | The company needs a CRM software to know who its customers are and have updated contact information. | Information | CP.1.1 |
-| CN.2 | The company needs a CRM software to be aware of when each customer was last contacted. | Information | CP.1.2 |
-| CN.3 | The company needs a CRM software to know customer feedback statistics monthly. | Information | CP.2 |
-| CN.4 | The company needs a CRM software to allow responding to customer feedback. | Construction | CP.3 |
-| CN.5 | The company needs a CRM software to know customer behavior patterns. | Information | CP.4 |
-| CN.6 | The company needs a CRM software to know projected sales forecasts quarterly. | Information | CP.5 |
+| CN.01.1 | The company needs a CRM software to know who its customers are and have updated contact information. | Information | CP.01.1 |
+| CN.01.2 | The company needs a CRM software to be aware of when each customer was last contacted. | Information | CP.01.2 |
+| CN.02.1 | The company needs a CRM software to know customer feedback statistics monthly. | Information | CP.02 |
+| CN.03.1 | The company needs a CRM software to allow responding to customer feedback. | Construction | CP.03 |
+| CN.04.1 | The company needs a CRM software to know customer behavior patterns. | Information | CP.04 |
+| CN.05.1 | The company needs a CRM software to know projected sales forecasts quarterly. | Information | CP.05 |
+
+> **Reading the IDs:** `CN.01.1` and `CN.01.2` are the first and second needs raised by
+> `CP.01` — one per sub-problem. The needs of `CP.02`…`CP.05` restart at `.1` under their
+> own problem, so the ID alone says which problem a need came from.
 
 ---
 
@@ -111,14 +115,18 @@ CRM software for companies with customer relationship difficulties. Unlike gener
 
 | ID | Statement | Traces To |
 |----|-----------|-----------|
-| FR.1 | The CRM shall store and display customer contact information including name, email, phone, and address. | CN.1 |
-| FR.2 | The CRM shall record the date of last contact for each customer. | CN.2 |
-| FR.3 | The CRM shall display customers not contacted within a configurable period. | CN.2 |
-| FR.4 | The CRM shall calculate and display feedback statistics by category monthly. | CN.3 |
-| FR.5 | The CRM shall allow users to compose and send responses to customer feedback. | CN.4 |
-| FR.6 | The CRM shall analyze and display customer purchase behavior patterns. | CN.5 |
-| FR.7 | The CRM shall generate quarterly sales forecasts based on historical data. | CN.6 |
-| FR.8 | The CRM shall send marketing campaigns to selected customer segments. | CN.1, CN.2 |
+| FR.01.1.1 | The CRM shall store and display customer contact information including name, email, phone, and address. | CN.01.1 |
+| FR.01.1.2 | The CRM shall send marketing campaigns to selected customer segments. | CN.01.1, CN.01.2 |
+| FR.01.2.1 | The CRM shall record the date of last contact for each customer. | CN.01.2 |
+| FR.01.2.2 | The CRM shall display customers not contacted within a configurable period. | CN.01.2 |
+| FR.02.1.1 | The CRM shall calculate and display feedback statistics by category monthly. | CN.02.1 |
+| FR.03.1.1 | The CRM shall allow users to compose and send responses to customer feedback. | CN.03.1 |
+| FR.04.1.1 | The CRM shall analyze and display customer purchase behavior patterns. | CN.04.1 |
+| FR.05.1.1 | The CRM shall generate quarterly sales forecasts based on historical data. | CN.05.1 |
+
+> **Reading the IDs:** `FR.01.2.2` is the second requirement implementing `CN.01.2`, which
+> addresses `CP.01`. A shared requirement keeps the ID of its primary need — `FR.01.1.2`
+> belongs to `CN.01.1` — and lists the other needs it serves in **Traces To**.
 
 ---
 
@@ -126,27 +134,27 @@ CRM software for companies with customer relationship difficulties. Unlike gener
 
 ### CP → CN Coverage
 
-|     | CN.1 | CN.2 | CN.3 | CN.4 | CN.5 | CN.6 |
-|-----|------|------|------|------|------|------|
-| CP.1.1 | C |   |   |   |   |   |
-| CP.1.2 |   | C |   |   |   |   |
-| CP.2 |   |   | C |   |   |   |
-| CP.3 |   |   |   | C |   |   |
-| CP.4 |   |   |   |   | C |   |
-| CP.5 |   |   |   |   |   | C |
+|         | CN.01.1 | CN.01.2 | CN.02.1 | CN.03.1 | CN.04.1 | CN.05.1 |
+|---------|---------|---------|---------|---------|---------|---------|
+| CP.01.1 | C       |         |         |         |         |         |
+| CP.01.2 |         | C       |         |         |         |         |
+| CP.02   |         |         | C       |         |         |         |
+| CP.03   |         |         |         | C       |         |         |
+| CP.04   |         |         |         |         | C       |         |
+| CP.05   |         |         |         |         |         | C       |
 
 **C** = Complete coverage ✅
 
 ### CN → FR Coverage
 
-|     | FR.1 | FR.2 | FR.3 | FR.4 | FR.5 | FR.6 | FR.7 | FR.8 |
-|-----|------|------|------|------|------|------|------|------|
-| CN.1 | C |   |   |   |   |   |   | P |
-| CN.2 |   | C | P |   |   |   |   | P |
-| CN.3 |   |   |   | C |   |   |   |   |
-| CN.4 |   |   |   |   | C |   |   |   |
-| CN.5 |   |   |   |   |   | C |   |   |
-| CN.6 |   |   |   |   |   |   | C |   |
+|         | FR.01.1.1 | FR.01.1.2 | FR.01.2.1 | FR.01.2.2 | FR.02.1.1 | FR.03.1.1 | FR.04.1.1 | FR.05.1.1 |
+|---------|-----------|-----------|-----------|-----------|-----------|-----------|-----------|-----------|
+| CN.01.1 | C         | P         |           |           |           |           |           |           |
+| CN.01.2 |           | P         | C         | P         |           |           |           |           |
+| CN.02.1 |           |           |           |           | C         |           |           |           |
+| CN.03.1 |           |           |           |           |           | C         |           |           |
+| CN.04.1 |           |           |           |           |           |           | C         |           |
+| CN.05.1 |           |           |           |           |           |           |           | C         |
 
 **C** = Complete, **P** = Partial ✅
 
@@ -168,10 +176,12 @@ CRM software for companies with customer relationship difficulties. Unlike gener
 
 ## Key Learnings
 
-1. **Decomposition:** CP.1 was split into sub-problems for clarity
+1. **Decomposition:** CP.01 was split into sub-problems for clarity
 2. **Outcome Classes:** Most CNs are Information-type (typical for CRM)
-3. **Multiple FRs per CN:** CN.2 needed two FRs to be fully addressed
-4. **Shared FRs:** FR.8 traces to multiple CNs (marketing uses contact data)
+3. **Multiple FRs per CN:** CN.01.2 needed two FRs to be fully addressed
+4. **Shared FRs:** FR.01.1.2 traces to multiple CNs (marketing uses contact data)
+5. **IDs carry the chain:** `FR.01.2.2` → `CN.01.2` → `CP.01` can be read off the ID alone,
+   with no lookup table
 
 ---
 

--- a/skills/problem-based-srs/reference/functional-requirements.md
+++ b/skills/problem-based-srs/reference/functional-requirements.md
@@ -123,7 +123,7 @@ The CRM system shall allow the Account Manager to update existing client records
 ```
 | CN | Functional Requirements |
 |----|------------------------|
-| CN.1 | FR.01.1.1 Registration, FR.01.1.2 Update |
+| CN.01.1 | FR.01.1.1 Registration, FR.01.1.2 Update |
 ```
 
 The wrong format above lacks "shall" statements, acceptance criteria, and proper traceability.

--- a/skills/problem-based-srs/reference/microer-example.md
+++ b/skills/problem-based-srs/reference/microer-example.md
@@ -22,22 +22,22 @@ A residential end user is concerned about rational energy use and has invested i
 
 | ID | Statement | Class |
 |----|-----------|-------|
-| CP.1 | The customer intends to reduce energy consumption to lower costs using a renewable microgeneration system based on solar and wind sources. | Obligation |
-| CP.1.1 | The customer must reduce unnecessary energy consumption to reduce costs. | Obligation |
-| CP.1.2 | The customer must change consumption patterns, otherwise unable to reduce consumption. | Obligation |
-| CP.1.3 | The customer must monitor consumption patterns, otherwise unable to optimize usage. | Obligation |
-| CP.1.4 | The customer must ensure generating unit efficiency, otherwise must consume from public grid. | Obligation |
-| CP.1.5 | The customer must ensure maintenance status of generating unit, otherwise malfunction occurs. | Obligation |
-| CP.2 | The customer intends to contribute to minimizing environmental impacts of public energy sources. | Hope |
-| CP.2.1 | The customer must be aware of the environmental impact of their consumption. | Expectation |
-| CP.2.2 | The customer intends to rationalize energy use. | Hope |
-| CP.3 | The customer intends to contribute to reducing consumption pressure on regional/national energy matrix. | Hope |
-| CP.4 | The customer intends to influence others toward energy and environmental causes. | Hope |
+| CP.01 | The customer intends to reduce energy consumption to lower costs using a renewable microgeneration system based on solar and wind sources. | Obligation |
+| CP.01.1 | The customer must reduce unnecessary energy consumption to reduce costs. | Obligation |
+| CP.01.2 | The customer must change consumption patterns, otherwise unable to reduce consumption. | Obligation |
+| CP.01.3 | The customer must monitor consumption patterns, otherwise unable to optimize usage. | Obligation |
+| CP.01.4 | The customer must ensure generating unit efficiency, otherwise must consume from public grid. | Obligation |
+| CP.01.5 | The customer must ensure maintenance status of generating unit, otherwise malfunction occurs. | Obligation |
+| CP.02 | The customer intends to contribute to minimizing environmental impacts of public energy sources. | Hope |
+| CP.02.1 | The customer must be aware of the environmental impact of their consumption. | Expectation |
+| CP.02.2 | The customer intends to rationalize energy use. | Hope |
+| CP.03 | The customer intends to contribute to reducing consumption pressure on regional/national energy matrix. | Hope |
+| CP.04 | The customer intends to influence others toward energy and environmental causes. | Hope |
 
 ### Decomposition Notes
 
-- **CP.1** decomposed into 5 sub-problems covering: waste reduction, behavior change, monitoring, efficiency, and maintenance
-- **CP.2** decomposed into awareness and rationalization aspects
+- **CP.01** decomposed into 5 sub-problems covering: waste reduction, behavior change, monitoring, efficiency, and maintenance
+- **CP.02** decomposed into awareness and rationalization aspects
 
 ---
 
@@ -88,14 +88,18 @@ MicroER software will:
 
 | ID | Statement | Outcome Class | Traces To |
 |----|-----------|---------------|-----------|
-| CN.1 | The user needs MicroER to know current energy consumption in real-time. | Information | CP.1.1 |
-| CN.2 | The user needs MicroER to control energy distribution based on consumption profiles. | Control | CP.1.2 |
-| CN.3 | The user needs MicroER to know consumption patterns over time. | Information | CP.1.3 |
-| CN.4 | The user needs MicroER to know generating unit efficiency status. | Information | CP.1.4 |
-| CN.5 | The user needs MicroER to be aware of maintenance alerts. | Information | CP.1.5 |
-| CN.6 | The user needs MicroER to know environmental impact metrics. | Information | CP.2.1 |
-| CN.7 | The user needs MicroER to control load prioritization during low generation. | Control | CP.2.2 |
-| CN.8 | The user needs MicroER to create consumption profiles. | Construction | CP.1.2 |
+| CN.01.1 | The user needs MicroER to know current energy consumption in real-time. | Information | CP.01.1 |
+| CN.01.2 | The user needs MicroER to control energy distribution based on consumption profiles. | Control | CP.01.2 |
+| CN.01.3 | The user needs MicroER to know consumption patterns over time. | Information | CP.01.3 |
+| CN.01.4 | The user needs MicroER to know generating unit efficiency status. | Information | CP.01.4 |
+| CN.01.5 | The user needs MicroER to be aware of maintenance alerts. | Information | CP.01.5 |
+| CN.01.6 | The user needs MicroER to create consumption profiles. | Construction | CP.01.2 |
+| CN.02.1 | The user needs MicroER to know environmental impact metrics. | Information | CP.02.1 |
+| CN.02.2 | The user needs MicroER to control load prioritization during low generation. | Control | CP.02.2 |
+
+> **Reading the IDs:** all six needs raised by `CP.01` are numbered under it, including
+> `CN.01.6` — a second, Construction-class need for sub-problem `CP.01.2`. The needs of
+> `CP.02` restart at `.1`, so an ID never has to be looked up to find its problem.
 
 ### Outcome Class Distribution
 
@@ -142,15 +146,15 @@ MicroER is energy management software for residential users with renewable micro
 
 | ID | Statement | Traces To |
 |----|-----------|-----------|
-| FR.1 | MicroER shall display real-time energy consumption in watts and kilowatt-hours. | CN.1 |
-| FR.2 | MicroER shall allow users to define consumption profiles with load priorities. | CN.8 |
-| FR.3 | MicroER shall automatically adjust energy distribution based on active profile. | CN.2 |
-| FR.4 | MicroER shall display hourly, daily, weekly, and monthly consumption graphs. | CN.3 |
-| FR.5 | MicroER shall calculate and display generation efficiency percentage. | CN.4 |
-| FR.6 | MicroER shall generate maintenance alerts when efficiency drops below threshold. | CN.5 |
-| FR.7 | MicroER shall calculate and display CO₂ offset compared to grid consumption. | CN.6 |
-| FR.8 | MicroER shall reduce non-priority loads when generation falls below demand. | CN.7 |
-| FR.9 | MicroER shall log all consumption and generation data for historical analysis. | CN.3 |
+| FR.01.1.1 | MicroER shall display real-time energy consumption in watts and kilowatt-hours. | CN.01.1 |
+| FR.01.2.1 | MicroER shall automatically adjust energy distribution based on active profile. | CN.01.2 |
+| FR.01.3.1 | MicroER shall display hourly, daily, weekly, and monthly consumption graphs. | CN.01.3 |
+| FR.01.3.2 | MicroER shall log all consumption and generation data for historical analysis. | CN.01.3 |
+| FR.01.4.1 | MicroER shall calculate and display generation efficiency percentage. | CN.01.4 |
+| FR.01.5.1 | MicroER shall generate maintenance alerts when efficiency drops below threshold. | CN.01.5 |
+| FR.01.6.1 | MicroER shall allow users to define consumption profiles with load priorities. | CN.01.6 |
+| FR.02.1.1 | MicroER shall calculate and display CO₂ offset compared to grid consumption. | CN.02.1 |
+| FR.02.2.1 | MicroER shall reduce non-priority loads when generation falls below demand. | CN.02.2 |
 
 ---
 
@@ -158,32 +162,36 @@ MicroER is energy management software for residential users with renewable micro
 
 ### CP → CN Coverage (Partial View)
 
-|      | CN.1 | CN.2 | CN.3 | CN.4 | CN.5 | CN.6 | CN.7 | CN.8 |
-|------|------|------|------|------|------|------|------|------|
-| CP.1.1 | C |   |   |   |   |   |   |   |
-| CP.1.2 |   | C |   |   |   |   |   | P |
-| CP.1.3 |   |   | C |   |   |   |   |   |
-| CP.1.4 |   |   |   | C |   |   |   |   |
-| CP.1.5 |   |   |   |   | C |   |   |   |
-| CP.2.1 |   |   |   |   |   | C |   |   |
-| CP.2.2 |   |   |   |   |   |   | C |   |
+|         | CN.01.1 | CN.01.2 | CN.01.3 | CN.01.4 | CN.01.5 | CN.01.6 | CN.02.1 | CN.02.2 |
+|---------|---------|---------|---------|---------|---------|---------|---------|---------|
+| CP.01.1 | C       |         |         |         |         |         |         |         |
+| CP.01.2 |         | C       |         |         |         | P       |         |         |
+| CP.01.3 |         |         | C       |         |         |         |         |         |
+| CP.01.4 |         |         |         | C       |         |         |         |         |
+| CP.01.5 |         |         |         |         | C       |         |         |         |
+| CP.02.1 |         |         |         |         |         |         | C       |         |
+| CP.02.2 |         |         |         |         |         |         |         | C       |
 
 **C** = Complete, **P** = Partial ✅
 
 ### CN → FR Coverage
 
-|     | FR.1 | FR.2 | FR.3 | FR.4 | FR.5 | FR.6 | FR.7 | FR.8 | FR.9 |
-|-----|------|------|------|------|------|------|------|------|------|
-| CN.1 | C |   |   |   |   |   |   |   |   |
-| CN.2 |   |   | C |   |   |   |   |   |   |
-| CN.3 |   |   |   | C |   |   |   |   | P |
-| CN.4 |   |   |   |   | C |   |   |   |   |
-| CN.5 |   |   |   |   |   | C |   |   |   |
-| CN.6 |   |   |   |   |   |   | C |   |   |
-| CN.7 |   |   |   |   |   |   |   | C |   |
-| CN.8 |   | C |   |   |   |   |   |   |   |
+|         | FR.01.1.1 | FR.01.2.1 | FR.01.3.1 | FR.01.3.2 | FR.01.4.1 | FR.01.5.1 | FR.01.6.1 | FR.02.1.1 | FR.02.2.1 |
+|---------|-----------|-----------|-----------|-----------|-----------|-----------|-----------|-----------|-----------|
+| CN.01.1 | C         |           |           |           |           |           |           |           |           |
+| CN.01.2 |           | C         |           |           |           |           |           |           |           |
+| CN.01.3 |           |           | C         | P         |           |           |           |           |           |
+| CN.01.4 |           |           |           |           | C         |           |           |           |           |
+| CN.01.5 |           |           |           |           |           | C         |           |           |           |
+| CN.01.6 |           |           |           |           |           |           | C         |           |           |
+| CN.02.1 |           |           |           |           |           |           |           | C         |           |
+| CN.02.2 |           |           |           |           |           |           |           |           | C         |
 
 **C** = Complete, **P** = Partial ✅
+
+The matrix is diagonal because the IDs are: an `FR.{cp}.{cn}.{n}` can only carry a **C** in
+the row of the `CN.{cp}.{n}` its own ID names. Anything off the diagonal is a shared
+requirement, and has to be justified as one.
 
 ---
 
@@ -204,10 +212,12 @@ MicroER is energy management software for residential users with renewable micro
 ## Key Learnings
 
 1. **Technical Domain:** Embedded systems require more Control-type CNs
-2. **Deep Decomposition:** CP.1 has 5 sub-problems reflecting system complexity
+2. **Deep Decomposition:** CP.01 has 5 sub-problems reflecting system complexity
 3. **Hardware Integration:** Software Glance must acknowledge hardware boundaries
 4. **Multiple Outcome Classes:** Mix of Information (6), Control (2), and Construction (1)
-5. **Hope-class Problems:** CP.3 and CP.4 are aspirational; may not generate direct FRs
+5. **Hope-class Problems:** CP.03 and CP.04 are aspirational; may not generate direct FRs
+6. **Numbering follows parentage, not order of discovery:** the profile-creation need was
+   found last but belongs to `CP.01`, so it is `CN.01.6` — not the eighth need overall
 
 ---
 

--- a/skills/problem-based-srs/reference/validate.md
+++ b/skills/problem-based-srs/reference/validate.md
@@ -14,32 +14,45 @@ This skill is used **during and after** Steps 1, 3, and 5 to validate and refine
 
 > **Diagram preference:** When visualizing traceability mappings, prefer Mermaid UML diagrams (e.g., `flowchart` for hierarchy trees, `graph` for dependency maps) over ASCII art where rendering supports it.
 
+```mermaid
+flowchart LR
+    subgraph WHY["Customer Problems — WHY"]
+        direction TB
+        CP01["CP.01"]
+        CP011["CP.01.1"]
+        CP012["CP.01.2"]
+        CP01 --> CP011
+        CP01 --> CP012
+    end
+
+    subgraph WHAT["Customer Needs — WHAT"]
+        direction TB
+        CN011["CN.01.1"]
+        CN012["CN.01.2"]
+    end
+
+    subgraph HOW["Functional Requirements — HOW"]
+        direction TB
+        FR0111["FR.01.1.1"]
+        FR0112["FR.01.1.2"]
+        FR0121["FR.01.2.1"]
+    end
+
+    CP011 -- ZAG --> CN011
+    CP012 -- ZAG --> CN012
+    CN011 -- ZAG --> FR0111
+    CN011 -- ZAG --> FR0112
+    CN012 -- ZAG --> FR0121
+
+    CN011 -. ZIG .-> CP011
+    FR0111 -. ZIG .-> CN011
 ```
-┌─────────────────────────────────────────────────────────────────────────┐
-│                           ZIG ZAG DECOMPOSITION                         │
-│                                                                         │
-│   Customer        Customer         Functional                           │
-│   Problems        Needs            Requirements                         │
-│   Domain          Domain           Domain                               │
-│                                                                         │
-│   ┌─────┐        ┌─────┐          ┌─────┐                               │
-│   │ CP  │───────▶│ CN  │─────────▶│ FR  │                               │
-│   └──┬──┘        └──┬──┘          └──┬──┘                               │
-│      │    ◀─ZIG     │    ◀─ZIG      │                                   │
-│   ┌──▼──┐  ZAG─▶ ┌──▼──┐  ZAG─▶  ┌──▼──┐                               │
-│   │CP.1 │───────▶│CN.1 │─────────▶│FR.1 │                               │
-│   │CP.2 │───────▶│CN.2 │─────────▶│FR.2 │                               │
-│   └──┬──┘        └──┬──┘          └──┬──┘                               │
-│      │              │                │                                   │
-│   ┌──▼──┐        ┌──▼──┐          ┌──▼──┐                               │
-│   │CP.1.1│──────▶│CN.1.1│────────▶│FR.1.1│                              │
-│   │CP.1.2│──────▶│CN.1.2│────────▶│FR.1.2│                              │
-│   └─────┘        └─────┘          └─────┘                               │
-│                                                                         │
-│   "WHY"          "WHAT"           "HOW"                                 │
-│   (Problem)      (Outcome)        (Capability)                          │
-└─────────────────────────────────────────────────────────────────────────┘
-```
+
+**Reading the diagram:** the top of each domain is decomposition level 1 and the nodes
+below it are level 2 — the levels are the rows, not the ID scheme. Solid arrows ZAG
+forward (problem → outcome → capability); dashed arrows ZIG back to validate that each
+item still answers its source. Every ID names its own parent, so `FR.01.1.2` is traceable
+to `CN.01.1` and on to `CP.01` without consulting the diagram at all.
 
 ---
 
@@ -89,8 +102,8 @@ Output: Mapping table showing relationships
 Format:
 | Source | Target(s) | Relationship | Gap? |
 |--------|-----------|--------------|------|
-| CP.1   | CN.1, CN.2 | CP.1 addressed by CN.1 (primary), CN.2 (secondary) | No |
-| CP.2   | —          | No CN addresses CP.2 | YES |
+| CP.01  | CN.01.1, CN.01.2 | CP.01 addressed by CN.01.1 (primary), CN.01.2 (secondary) | No |
+| CP.02  | —          | No CN addresses CP.02 | YES |
 
 ### Operation 2: ZIG-VALIDATE (Backward Traceability)
 Verify each item traces back to its source.
@@ -101,27 +114,27 @@ Output: Validation report
 Format:
 | Item | Traces To | Valid? | Issue |
 |------|-----------|--------|-------|
-| FR.1 | CN.1      | ✅     | —     |
-| FR.7 | —         | ❌     | Orphan FR - no CN source |
+| FR.01.1.1 | CN.01.1 | ✅     | —     |
+| FR.07.1.1 | —         | ❌     | Orphan FR — its ID claims CN.07.1, which does not exist |
 
 ### Operation 3: DECOMPOSE (Hierarchical Breakdown)
 Decompose a high-level item into sub-items, zigzagging between domains.
 
 Process:
-1. Start with high-level CP (e.g., CP.1)
-2. ZAG → Identify CN(s) that address CP.1
+1. Start with high-level CP (e.g., CP.01)
+2. ZAG → Identify CN(s) that address CP.01
 3. ZIG → Review if CN decomposition suggests CP refinement
 4. ZAG → For each CN, identify FR(s)
 5. ZIG → Review if FR decomposition suggests CN refinement
 
 Format:
 ```
-CP.1: [High-level problem statement]
-  ├── CN.1.1: [Outcome needed to address part of CP.1]
-  │     ├── FR.1.1.1: [Capability for CN.1.1]
-  │     └── FR.1.1.2: [Capability for CN.1.1]
-  └── CN.1.2: [Another outcome for CP.1]
-        └── FR.1.2.1: [Capability for CN.1.2]
+CP.01: [High-level problem statement]
+  ├── CN.01.1: [Outcome needed to address part of CP.01]
+  │     ├── FR.01.1.1: [Capability for CN.01.1]
+  │     └── FR.01.1.2: [Capability for CN.01.1]
+  └── CN.01.2: [Another outcome for CP.01]
+        └── FR.01.2.1: [Capability for CN.01.2]
 ```
 
 ### Operation 4: CONSISTENCY-CHECK (Full Audit)
@@ -147,9 +160,14 @@ Each FR SHOULD ideally map to one CN. If an FR affects multiple CNs, flag for re
 - No orphan CNs (needs without traced problems)
 
 ### Hierarchy Alignment
-When decomposing, sub-items SHOULD align across domains:
-- CP.1.1 SHOULD map to CN.1.1 (or subset)
-- CN.1.1 SHOULD map to FR.1.1.x
+When decomposing, sub-items SHOULD align across domains — and the ID is what aligns them:
+- a need addressing a facet of a problem repeats that problem's number: `CN.{cp}.{n}`
+- a requirement repeats both its problem's and its need's: `FR.{cp}.{cn}.{n}`
+- so `FR.01.2.3` can only sit under `CN.01.2`, which can only sit under `CP.01`
+
+Write partial shapes with `{}` placeholders, the way the notation table does:
+`FR.{cp}.{cn}.{n}` states which levels it stands for, whereas an ID cut short after two
+levels names a requirement that cannot exist.
 
 ---
 
@@ -157,7 +175,7 @@ When decomposing, sub-items SHOULD align across domains:
 
 ### Input
 ```
-CP.1: Sales managers must know customer purchase history within 5 minutes
+CP.01: Sales managers must know customer purchase history within 5 minutes
       otherwise losing sales opportunities during client calls.
 ```
 
@@ -165,45 +183,50 @@ CP.1: Sales managers must know customer purchase history within 5 minutes
 
 **Step 1 - ZAG:** What outcome (CN) addresses this problem?
 ```
-CN.1: The sales manager needs a CRM system to know the complete purchase 
+CN.01.1: The sales manager needs a CRM system to know the complete purchase 
       history of each customer at any time.
 ```
 
-**Step 2 - ZIG:** Does CN.1 fully address CP.1? 
-- CP.1 specifies "within 5 minutes" → CN.1 says "at any time" ✅
-- CP.1 specifies "during client calls" → Consider decomposition
+**Step 2 - ZIG:** Does CN.01.1 fully address CP.01? 
+- CP.01 specifies "within 5 minutes" → CN.01.1 says "at any time" ✅
+- CP.01 specifies "during client calls" → Consider decomposition
 
-**Step 3 - DECOMPOSE CN:**
+**Step 3 - DECOMPOSE CN:** the single outcome splits into two needs of the same problem,
+so both keep `CP.01` as their first segment and number on from there:
 ```
-CN.1.1: Sales manager needs CRM to display purchase history instantly.
-CN.1.2: Sales manager needs CRM accessible during phone calls (mobile/desktop).
+CN.01.1: Sales manager needs CRM to display purchase history instantly.
+CN.01.2: Sales manager needs CRM accessible during phone calls (mobile/desktop).
 ```
 
 **Step 4 - ZAG:** What FRs deliver these CNs?
 ```
-FR.1.1.1: The CRM shall display customer purchase history within 3 seconds.
-FR.1.1.2: The CRM shall allow search by customer name or phone number.
-FR.1.2.1: The CRM shall be accessible via mobile application.
-FR.1.2.2: The CRM shall provide one-click access from phone integration.
+FR.01.1.1: The CRM shall display customer purchase history within 3 seconds.
+FR.01.1.2: The CRM shall allow search by customer name or phone number.
+FR.01.2.1: The CRM shall be accessible via mobile application.
+FR.01.2.2: The CRM shall provide one-click access from phone integration.
 ```
 
 **Step 5 - ZIG:** Validate FRs trace to CNs
 | FR | CN | Valid |
 |----|-----|-------|
-| FR.1.1.1 | CN.1.1 | ✅ |
-| FR.1.1.2 | CN.1.1 | ✅ |
-| FR.1.2.1 | CN.1.2 | ✅ |
-| FR.1.2.2 | CN.1.2 | ✅ |
+| FR.01.1.1 | CN.01.1 | ✅ |
+| FR.01.1.2 | CN.01.1 | ✅ |
+| FR.01.2.1 | CN.01.2 | ✅ |
+| FR.01.2.2 | CN.01.2 | ✅ |
+
+This table is verifiable without reading a word of the statements: an `FR.{cp}.{cn}.{n}`
+is valid exactly when a `CN.{cp}.{cn}` exists. That check is only possible because the ID
+carries the parent.
 
 ### Final Hierarchy
 ```
-CP.1: Sales managers must know customer purchase history within 5 minutes
-  ├── CN.1.1: Display purchase history instantly
-  │     ├── FR.1.1.1: Display within 3 seconds
-  │     └── FR.1.1.2: Search by name/phone
-  └── CN.1.2: Accessible during phone calls
-        ├── FR.1.2.1: Mobile application
-        └── FR.1.2.2: Phone integration
+CP.01: Sales managers must know customer purchase history within 5 minutes
+  ├── CN.01.1: Display purchase history instantly
+  │     ├── FR.01.1.1: Display within 3 seconds
+  │     └── FR.01.1.2: Search by name/phone
+  └── CN.01.2: Accessible during phone calls
+        ├── FR.01.2.1: Mobile application
+        └── FR.01.2.2: Phone integration
 ```
 
 ---
@@ -217,11 +240,11 @@ Use **C** (Complete) and **P** (Partial) markers to indicate how well each eleme
 ```markdown
 ## CP → CN Coverage Matrix
 
-|      | CN.1 | CN.2 | CN.3 | CN.4 |
-|------|------|------|------|------|
-| CP.1 | C    |      |      |      |
-| CP.2 |      | C    | P    |      |
-| CP.3 |      |      |      | C    |
+|       | CN.01.1 | CN.02.1 | CN.02.2 | CN.03.1 |
+|-------|---------|---------|---------|---------|
+| CP.01 | C       |         |         |         |
+| CP.02 |         | C       | P       |         |
+| CP.03 |         |         |         | C       |
 
 **Legend:**
 - **C** = Complete — CN fully addresses the CP
@@ -229,9 +252,9 @@ Use **C** (Complete) and **P** (Partial) markers to indicate how well each eleme
 - (blank) = No relationship
 
 **Coverage Summary:**
-- CP.1: Fully covered by CN.1 ✅
-- CP.2: Covered by CN.2 (complete) + CN.3 (partial) ✅
-- CP.3: Fully covered by CN.4 ✅
+- CP.01: Fully covered by CN.01.1 ✅
+- CP.02: Covered by CN.02.1 (complete) + CN.02.2 (partial) ✅
+- CP.03: Fully covered by CN.03.1 ✅
 ```
 
 ### Gap Analysis
@@ -242,18 +265,18 @@ Use **C** (Complete) and **P** (Partial) markers to indicate how well each eleme
 ### Uncovered Customer Problems
 | CP | Statement | Suggested Action |
 |----|-----------|------------------|
-| CP.3 | [statement] | Generate CN using /problem-based-srs needs |
+| CP.03 | [statement] | Generate CN using /problem-based-srs needs |
 
 ### Orphan Items
 | Item | Type | Issue | Suggested Action |
 |------|------|-------|------------------|
-| FR.7 | FR | No CN traces | Remove or identify missing CN |
-| CN.5 | CN | No CP traces | Validate business need or remove |
+| FR.07.1.1 | FR | No CN traces — CN.07.1 does not exist | Remove or identify missing CN |
+| CN.05.1 | CN | No CP traces — CP.05 does not exist | Validate business need or remove |
 
 ### Redundancies
 | Items | Overlap | Suggested Action |
 |-------|---------|------------------|
-| FR.2, FR.8 | Both handle user search | Merge or differentiate scope |
+| FR.01.1.2, FR.02.1.1 | Both handle user search | Merge or differentiate scope |
 ```
 
 ---
@@ -277,7 +300,7 @@ Before completing zig zag analysis:
 - [ ] Every CN has at least one FR mapped
 - [ ] Every FR traces back to a CN
 - [ ] Every CN traces back to a CP
-- [ ] Hierarchical IDs align (CP.1 → CN.1.x → FR.1.x.y)
+- [ ] Hierarchical IDs align (`CP.{n}` → `CN.{cp}.{n}` → `FR.{cp}.{cn}.{n}`)
 - [ ] No orphan requirements identified
 - [ ] Gaps documented with action items
 


### PR DESCRIPTION
Closes #75.

## The problem

The skill's own teaching material taught `CN.1` and `FR.3` — IDs that name no parent, and so carry none of the traceability the dotted notation exists to encode. 150 of them, across the CRM and MicroER walkthroughs, the ZigZag validation guide and the complexity matrices.

They sat in prose, tables and diagrams, which is where a skill actually does its teaching. An agent that reads a worked `CN.2 → FR.3` walkthrough emits `CN.2 → FR.3`. Downstream, the canvas has no `{cp}.{cn}` to link with and `validate` can only check traceability by reading prose. Meanwhile `.spec/crm-system.json` — the *same* CRM case study, rendered by the canvas — was already fully canonical, so the two halves of the repo disagreed about the same example.

#74 caught `NFR.1.0` by scanning fenced JSON blocks. Machine-readable blocks are not where a skill teaches, so that scope walked past every one of these. Being dotted, they also slip past the hyphen-ID guard.

## The change

**Guard first (TDD).** `evals/tests/skills-install.test.mjs` now checks the whole installed body, not just fenced JSON, and reports offenders with `file:line`. It still reads the permitted arities out of SKILL.md's Identifier Notation table at runtime — the rules stay in exactly one place, and adding a legitimate new shape means declaring it there, not editing the test.

**Then the content.** Every example is renumbered from the parent it actually has:

| Old | New | Why |
|-----|-----|-----|
| `CN.2` | `CN.01.2` | second need raised by `CP.01` |
| `FR.3` | `FR.01.2.2` | second requirement implementing `CN.01.2` |
| `FR.8` | `FR.01.1.2` | shared FR keeps its **primary** need's ID; the others stay in *Traces To* |

Each walkthrough gained a short **Reading the IDs** note so the example teaches the scheme rather than just obeying it.

Two things the renumbering surfaced:

- **`CP.{n}.{m}.{k}` is now declared in the notation table.** `reference/problems.md` already taught sub-sub-problems (`CP.01.2.1`), but the table never said they were legal. Declaring it keeps the table the single source of truth; deleting the guidance would have thrown away real methodology.
- **The ASCII ZigZag diagram was actively misleading** — its `CN.1.1` / `FR.1.1` labels used ID arity to mean *decomposition depth*, teaching the exact conflation this issue is about. Replaced with a Mermaid flowchart (verified against the Mermaid 11 parser) where levels are rows and IDs stay canonical, plus a paragraph naming the distinction.

Partial shapes are now written the way the notation table writes them — `FR.{cp}.{cn}.{n}` — because a truncated `FR.01.1.x` is indistinguishable from a malformed ID and is correctly reported as one.

## Verification

- `node --test evals/tests/*.test.mjs` → **272 pass**
- canvas `npm test` → **231 pass** (includes byte-for-byte bundled-skill parity)
- `python scripts/build-plugin.py validate` → OK
- `node scripts/sync-skills.mjs` → 9 bundled skills refreshed
- Mermaid diagram parsed with the real Mermaid 11 engine

**Negative tests** (each mutation applied to a real tracked file, then restored):

| Mutation | Result |
|---|---|
| one prose `CN.1` back in the CRM walkthrough | ❌ `reference/crm-example.md:77: CN.1 (SKILL.md allows 2 level(s))` |
| delete the `CP.{n}.{m}.{k}` row from SKILL.md | ❌ `reference/problems.md:296: CP.01.2.1 (SKILL.md allows 1, 2 level(s))` — proves it reads the table |
| truncated `FR.01.2` in the validate guidance | ❌ `reference/validate.md:166: FR.01.2 (SKILL.md allows 3 level(s))` |

No behaviour change to the methodology itself: the steps, prompts and guardrails are untouched. Only the identifiers in the examples, and the guard that keeps them honest.