### PR TITLE
test: Detect distribution drift instead of assuming it

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -451,6 +451,7 @@ single build script. Releases publish a validated, packaged plugin artifact to t
 | **CI workflow** | `.github/workflows/ci.yml` | On every push/PR to `main`: validates the plugin and uploads the packaged zip as a build artifact. |
 | **Release workflow** | `.github/workflows/create-release.yml` | Builds, validates, packages, and publishes a GitHub Release with the zip attached. |
 | **Canvas release workflow** | `.github/workflows/release-canvas.yml` | Independent pipeline for the SRS Navigator canvas app: runs `npm test`, refreshes bundled skills, bumps the extension version (`scripts/bump-version.mjs`), packages archives (`scripts/package-extension.mjs`), and publishes a `vX.Y.Z` GitHub Release. |
+| **Distribution monitor** | `.github/workflows/distribution-drift.yml` → `scripts/check-distribution.mjs` | Weekly (and on demand): compares the surfaces this repository does **not** own — the skills.sh listing and GitHub Releases — against what the repository actually ships. Deliberately outside the PR gate. |
 
 > **Two release pipelines, two tag schemes.** The **plugin** release uses `vX.Y` tags
 > (driven by `plugin.json` + `build-plugin.py`). The **canvas app** release uses `vX.Y.Z`
@@ -536,6 +537,46 @@ The workflow validates the plugin, packages `problem-based-srs-vX.Y.zip`, and cr
 Open the **Releases** section and confirm the `vX.Y` release exists, has the expected
 title and notes, and includes the **`problem-based-srs-vX.Y.zip`** asset. It must not
 be a draft or pre-release.
+
+Then run the distribution monitor, which is the only thing that checks the *published*
+side rather than the repository side:
+
+```bash
+node scripts/check-distribution.mjs          # report, always exits 0
+node scripts/check-distribution.mjs --strict # exit 1 on drift (what the workflow runs)
+```
+
+### Distribution surfaces (third-party state)
+
+Two surfaces carry this project and neither lives in the repository, so neither can be
+fixed by a pull request — only observed. `scripts/check-distribution.mjs` observes them;
+`.github/workflows/distribution-drift.yml` runs it weekly and on demand. A red run there
+is a notification, not a broken build: it is out of the PR gate on purpose.
+
+| Finding | Severity | What it means | What to do |
+|---------|----------|---------------|-----------|
+| `registry-listing-drift` | error | The [skills.sh listing](https://www.skills.sh/rafaelgorski/problem-based-srs) advertises skills the repository no longer ships. It is a cached index, so consolidations (like #50, which took nine skills to one) do not propagate. | Re-submit the repository at [skills.sh](https://www.skills.sh) so the listing is re-crawled, then re-run the checker. |
+| `dangling-release-links` | error | A `releases/tag/vX.Y.Z` link in `README.md`/`CHANGELOG.md` names a release that was never published — normally a manifest bump whose tag never got pushed. | Cut the missing release (above), or correct the link. |
+| `plugin-release-missing` / `canvas-release-missing` | error | The version a surface advertises has no release behind it. | Cut it on the matching train — `vX.Y` for the plugin, `vX.Y.Z` for the canvas. |
+| `surface-unreachable` | warning | A registry or the releases API could not be reached at all. | A fetch failure, **not** proof of drift. Re-run; if it persists, check the surface by hand. |
+| `registry-listing-unreadable` | warning | The listing responded but carried no JSON-LD `CollectionPage`. | Its markup probably changed. Check the page by hand and update `parseRegistryListing` — until then a clean run proves nothing. |
+| `registry-listing-partial` | warning | The page's own count disagrees with the entries it returned, so the comparison was skipped rather than run on a truncated payload. | Re-run; if it persists, read the page and confirm what it actually advertises. |
+
+**Exit codes.** Only `error` findings fail the run (`--strict` → 1). Warnings print, are
+emitted as `::warning::` annotations, and exit 0 — a monitor that goes red on someone
+else's 503 is a monitor that gets muted, and a muted monitor is the state #69 was already
+in. If warnings persist across runs, treat that as the signal instead of the exit code.
+
+**Version badges must link the `/releases` index, not a per-tag URL.** The documented
+process bumps `plugin.json` *before* the tag exists, so a per-tag badge 404s for the whole
+window in between — it did, across two consecutive versions. Guarded by
+`evals/tests/distribution-drift.test.mjs`.
+
+**Decision — no second registry, for now (2026-07-31).** The one listing we publish
+drifted by eight of nine entries and stayed that way for three passes, because nothing was
+looking. A second surface without a detector doubles that blind spot. Now that the monitor
+exists the question is answerable on maintenance cost instead of on fear of it; revisit
+when there is inbound signal to justify it.
 
 ### Version Numbering
 

--- a/.github/workflows/distribution-drift.yml
+++ b/.github/workflows/distribution-drift.yml
@@ -1,0 +1,38 @@
+# The project is distributed through surfaces it does not own: the skills.sh listing and
+# GitHub Releases. Both drifted silently — the listing still advertises the nine pre-#50
+# skills, and the manifest reached 2.6.0 while the newest release stayed v2.4.1 — because
+# nothing looked. This is the thing that looks.
+#
+# It is deliberately not part of CI. Third-party state is not a property of a pull
+# request, so gating PRs on someone else's cache would block unrelated work. A red run
+# here is the notification; it clears when the listing is refreshed or the release is cut.
+name: Distribution drift
+
+on:
+  schedule:
+    # Mondays, 09:00 UTC — a weekly nudge, not a pager.
+    - cron: "0 9 * * 1"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  check:
+    name: Compare published surfaces against the repository
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+
+      # No `npm ci`: the checker imports only node: builtins and evals/lib/skills.mjs,
+      # which evals/tests/distribution-drift.test.mjs asserts.
+      - name: Check distribution surfaces
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: node scripts/check-distribution.mjs --strict

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **The README's first badge is no longer a 404.** It linked
+  `releases/tag/v2.6.0`, a tag that was never pushed: the documented release process bumps
+  `.claude-plugin/plugin.json` *before* the tag exists, and the release had not been cut for
+  two consecutive versions, so the first clickable thing on the repository page led nowhere.
+  It now points at the `/releases` index, which `docs/index.html` already did, and a guard
+  keeps version badges off per-tag URLs.
+- **The changelog's oldest release link is no longer a 404.** `[1.0]` pointed at
+  `releases/tag/v1.0` for the project's entire life; the tag has always been `v1.0.0`. The
+  drift checker only found it because it compares tags **exactly** — GitHub serves
+  `/releases/tag/<tag>` by tag name, so `/releases/tag/v2.4.0` is a 404 even though release
+  2.4.0 exists as `v2.4`, and any matching that normalizes the two would have called this
+  link healthy.
 - **The installed skill no longer points at files only the maintainer has.**
   `reference/functional-requirements.md` headed its **Quality Rules** section — the rules
   that decide whether a requirement is well-formed — with a link to
@@ -29,6 +41,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   walked straight through.
 
 ### Added
+
+- **Distribution drift is detected instead of rediscovered by hand**
+  (`scripts/check-distribution.mjs`, `evals/tests/distribution-drift.test.mjs`,
+  `.github/workflows/distribution-drift.yml`). Two surfaces carry this project and neither
+  lives in the repository — the skills.sh listing and GitHub Releases — so #69 filed both as
+  untestable and every status comment since has re-quoted a hand-run check from #72. They
+  had drifted: the listing still advertises the **nine pre-#50 skills**, of which eight no
+  longer exist (its own counters put 70 of 101 installs on those names), and the manifest
+  reached 2.6.0 while the newest release stayed **v2.4.1**. `distribution-surfaces.test.mjs`
+  asserts those links *exist*; it never asked whether what they point at still agrees with
+  the repository — presence, not function, the same gap #73 had to disprove for the canvas
+  archive. The checker reads the listing's JSON-LD `CollectionPage`, derives the real skill
+  set from each `SKILL.md`'s frontmatter rather than restating it, and compares both release
+  trains (`vX.Y` plugin, `vX.Y.Z` canvas) against what is published, normalizing `v2.4` to
+  `2.4.0` the way `build-plugin.py` does — but only *within* the plugin train, so a plugin
+  `v1.2` can never be mistaken for a canvas 1.2.0 release that was never cut. Findings carry
+  a severity: only real disagreement fails the run, while an unreachable surface is a
+  warning with a `::warning::` annotation, because a monitor that goes red on someone else's
+  503 is a monitor that gets muted. The comparison is pure and unit-tested offline
+  against a verbatim capture of the live listing; only the weekly workflow touches the
+  network, and it stays out of the PR gate because third-party state is not a property of a
+  pull request.
 
 - **The skills install is executed, not inferred from a file count**
   (`evals/tests/skills-install.test.mjs`, 14 assertions). #69 checked its "follow the README
@@ -513,4 +547,4 @@ This release includes contributions from the following PRs:
 
 [1.2]: https://github.com/RafaelGorski/Problem-Based-SRS/releases/tag/v1.2
 [1.1]: https://github.com/RafaelGorski/Problem-Based-SRS/releases/tag/v1.1
-[1.0]: https://github.com/RafaelGorski/Problem-Based-SRS/releases/tag/v1.0
+[1.0]: https://github.com/RafaelGorski/Problem-Based-SRS/releases/tag/v1.0.0

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Problem-Based SRS
 
-[![Version 2.6.0](https://img.shields.io/badge/version-2.6.0-green.svg)](https://github.com/RafaelGorski/Problem-Based-SRS/releases/tag/v2.6.0)
+[![Version 2.6.0](https://img.shields.io/badge/version-2.6.0-green.svg)](https://github.com/RafaelGorski/Problem-Based-SRS/releases)
 [![Skills Health](https://img.shields.io/badge/skills%20health-dashboard-brightgreen.svg)](https://rafaelgorski.github.io/Problem-Based-SRS/skills-health.html)
 [![AgentSkills](https://img.shields.io/badge/AgentSkills-Open%20Standard-blue)](https://agentskills.io)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)

--- a/evals/fixtures/skills-sh-listing-2026-07-31.html
+++ b/evals/fixtures/skills-sh-listing-2026-07-31.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<!--
+  Captured 2026-07-31 from https://www.skills.sh/rafaelgorski/problem-based-srs
+  Trimmed to the machine-readable payload the drift checker reads: all three
+  JSON-LD blocks, so the parser has to pick the right one, plus the visible
+  per-skill install counts. Verbatim capture - this is evidence, not a mock.
+-->
+<html><head>
+<script type="application/ld+json">{"@context":"https://schema.org","@type":"BreadcrumbList","itemListElement":[{"@type":"ListItem","position":1,"name":"Skills","item":"https://www.skills.sh"},{"@type":"ListItem","position":2,"name":"rafaelgorski","item":"https://www.skills.sh/rafaelgorski"},{"@type":"ListItem","position":3,"name":"problem-based-srs","item":"https://www.skills.sh/rafaelgorski/problem-based-srs"}]}</script>
+<script type="application/ld+json">{"@context":"https://schema.org","@type":"CollectionPage","name":"rafaelgorski/problem-based-srs — Agent skills","description":"9 agent skills from the rafaelgorski/problem-based-srs repository.","url":"https://www.skills.sh/rafaelgorski/problem-based-srs","hasPart":[{"@type":"SoftwareApplication","name":"problem-based-srs","url":"https://www.skills.sh/rafaelgorski/problem-based-srs/problem-based-srs"},{"@type":"SoftwareApplication","name":"functional-requirements","url":"https://www.skills.sh/rafaelgorski/problem-based-srs/functional-requirements"},{"@type":"SoftwareApplication","name":"business-context","url":"https://www.skills.sh/rafaelgorski/problem-based-srs/business-context"},{"@type":"SoftwareApplication","name":"customer-problems","url":"https://www.skills.sh/rafaelgorski/problem-based-srs/customer-problems"},{"@type":"SoftwareApplication","name":"software-vision","url":"https://www.skills.sh/rafaelgorski/problem-based-srs/software-vision"},{"@type":"SoftwareApplication","name":"zigzag-validator","url":"https://www.skills.sh/rafaelgorski/problem-based-srs/zigzag-validator"},{"@type":"SoftwareApplication","name":"complexity-analysis","url":"https://www.skills.sh/rafaelgorski/problem-based-srs/complexity-analysis"},{"@type":"SoftwareApplication","name":"customer-needs","url":"https://www.skills.sh/rafaelgorski/problem-based-srs/customer-needs"},{"@type":"SoftwareApplication","name":"software-glance","url":"https://www.skills.sh/rafaelgorski/problem-based-srs/software-glance"}]}</script>
+<script type="application/ld+json">{"@context":"https://schema.org","@type":"WebSite","name":"Skills","alternateName":"The Agent Skills Directory","url":"https://www.skills.sh","description":"Discover and install skills for AI agents.","potentialAction":{"@type":"SearchAction","target":{"@type":"EntryPoint","urlTemplate":"https://www.skills.sh/search?q={search_term_string}"},"query-input":"required name=search_term_string"}}</script>
+</head><body><main>
+<h1>rafaelgorski/problem-based-srs</h1>
+<span>9 skills</span><span>101 total installs</span>
+<table><tbody>
+<tr><td>problem-based-srs</td><td>31</td></tr>
+<tr><td>functional-requirements</td><td>10</td></tr>
+<tr><td>business-context</td><td>9</td></tr>
+<tr><td>customer-problems</td><td>9</td></tr>
+<tr><td>software-vision</td><td>9</td></tr>
+<tr><td>zigzag-validator</td><td>9</td></tr>
+<tr><td>complexity-analysis</td><td>8</td></tr>
+<tr><td>customer-needs</td><td>8</td></tr>
+<tr><td>software-glance</td><td>8</td></tr>
+</tbody></table>
+</main></body></html>

--- a/evals/tests/distribution-drift.test.mjs
+++ b/evals/tests/distribution-drift.test.mjs
@@ -1,0 +1,668 @@
+// Three passes on #69 (#72, #73, #74) each took a box labelled "cannot be asserted in
+// CI" and found the half that could. This is the last of them, and the pattern that kept
+// it open is the same one #73 had to disprove for the canvas archive: presence is not
+// function.
+//
+// `distribution-surfaces.test.mjs` asserts the skills.sh link and the release links
+// *exist*. It never asks whether what they point at agrees with this repository. So both
+// of these were green in CI for months while being false:
+//
+//   * README.md's first badge linked .../releases/tag/v2.6.0 — a tag that was never
+//     pushed. The manifest was bumped twice without the release being cut, so the first
+//     clickable thing on the repository page was a 404.
+//   * The skills.sh listing still advertises the nine pre-#50 skills. The repository has
+//     had one since that consolidation, so eight of the nine names resolve to nothing —
+//     and the page's own counters put 70 of 101 installs on those eight names.
+//
+// What is guarded here is the *comparison*, not the third-party state: nobody can make a
+// PR refresh someone else's cache, but a checker can stop the drift from being invisible.
+// The network lives in .github/workflows/distribution-drift.yml. This suite is offline: it
+// feeds the checker a verbatim capture of the real listing and the repository's own files.
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import {
+  parseRegistryListing,
+  repoSkillNames,
+  advertisedRegistryUrl,
+  listingDrift,
+  advertisedTagLinks,
+  danglingTagLinks,
+  normalizeVersion,
+  compareVersions,
+  releaseDrift,
+  summarize,
+  renderReport,
+  renderAnnotations,
+  fetchPublishedTags,
+  main,
+  REGISTRY_URL,
+  REPO,
+} from "../../scripts/check-distribution.mjs";
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(here, "../..");
+const read = (rel) => fs.readFileSync(path.join(repoRoot, rel), "utf8");
+
+const LISTING_FIXTURE = read("evals/fixtures/skills-sh-listing-2026-07-31.html");
+const README = read("README.md");
+const CHANGELOG = read("CHANGELOG.md");
+const CHECKER = read("scripts/check-distribution.mjs");
+
+/** The tags that actually existed when this suite was written (git ls-remote --tags). */
+const PUBLISHED_TAGS = [
+  "v1.0.0",
+  "v1.1",
+  "v1.1.0",
+  "v1.2",
+  "v1.3",
+  "v1.4",
+  "v2.0",
+  "v2.1",
+  "v2.2",
+  "v2.3",
+  "v2.4",
+  "v2.4.1",
+];
+
+describe("the registry listing declares a machine-readable skill set", () => {
+  it("reads the CollectionPage block, not the other JSON-LD on the page", () => {
+    const listing = parseRegistryListing(LISTING_FIXTURE);
+    assert.ok(
+      LISTING_FIXTURE.includes('"@type":"BreadcrumbList"') &&
+        LISTING_FIXTURE.includes('"@type":"WebSite"'),
+      "the fixture must keep the decoy blocks, or this assertion proves nothing",
+    );
+    assert.ok(
+      !listing.skills.includes("Skills"),
+      "'Skills' is a breadcrumb label — picking the wrong block would surface it as a skill",
+    );
+    assert.equal(listing.url, REGISTRY_URL);
+  });
+
+  it("returns the skill names the page advertises, in page order", () => {
+    const { skills } = parseRegistryListing(LISTING_FIXTURE);
+    assert.deepEqual(skills, [
+      "problem-based-srs",
+      "functional-requirements",
+      "business-context",
+      "customer-problems",
+      "software-vision",
+      "zigzag-validator",
+      "complexity-analysis",
+      "customer-needs",
+      "software-glance",
+    ]);
+  });
+
+  it("reads the count the page states about itself", () => {
+    const listing = parseRegistryListing(LISTING_FIXTURE);
+    assert.equal(listing.declaredCount, 9);
+    assert.equal(
+      listing.declaredCount,
+      listing.skills.length,
+      "the page's prose count and its structured list must agree, or the parser picked " +
+        "up a partial payload",
+    );
+  });
+});
+
+describe("the repository's real skill set is derived, not restated", () => {
+  it("comes from the frontmatter of every skills/*/SKILL.md", () => {
+    const names = repoSkillNames(repoRoot);
+    assert.deepEqual(
+      names,
+      ["problem-based-srs"],
+      "since #50 the methodology is one skill; if that ever changes, this comparison's " +
+        "input must move with the repository rather than needing a test edit",
+    );
+  });
+
+  it("agrees with the directory each skill lives in", () => {
+    const dirs = fs
+      .readdirSync(path.join(repoRoot, "skills"), { withFileTypes: true })
+      .filter((e) => e.isDirectory())
+      .map((e) => e.name)
+      .sort();
+    assert.deepEqual(
+      repoSkillNames(repoRoot),
+      dirs,
+      "AgentSkills requires name === directory; a mismatch would make the registry " +
+        "comparison compare the wrong thing",
+    );
+  });
+});
+
+describe("the registry it watches is the one the project advertises", () => {
+  it("takes the listing URL from the README rather than a second copy of it", () => {
+    const url = advertisedRegistryUrl([{ file: "README.md", text: README }]);
+    assert.match(
+      url,
+      /^https:\/\/(www\.)?skills\.sh\/rafaelgorski\/problem-based-srs$/,
+      "the monitor must fetch the page readers are actually sent to — hard-coding the " +
+        "address would let the README point somewhere the check never looks",
+    );
+    assert.ok(
+      README.includes(url),
+      `${url} must appear verbatim in README.md, or it was not derived from it`,
+    );
+  });
+
+  it("falls back to the canonical URL when a document names no listing", () => {
+    assert.equal(advertisedRegistryUrl([{ file: "x.md", text: "no links here" }]), REGISTRY_URL);
+    assert.equal(advertisedRegistryUrl([]), REGISTRY_URL);
+  });
+
+  it("does not swallow the punctuation around a markdown link", () => {
+    assert.equal(
+      advertisedRegistryUrl([
+        { file: "x.md", text: "see [listing](https://skills.sh/a/b) for more." },
+      ]),
+      "https://skills.sh/a/b",
+    );
+    assert.equal(
+      advertisedRegistryUrl([{ file: "x.html", text: '<a href="https://skills.sh/a/b">x</a>' }]),
+      "https://skills.sh/a/b",
+    );
+  });
+});
+
+describe("listing drift — the comparison nothing was making", () => {
+  it("reports the eight skills the listing still advertises and the repo deleted", () => {
+    const drift = listingDrift({
+      listed: parseRegistryListing(LISTING_FIXTURE).skills,
+      actual: repoSkillNames(repoRoot),
+    });
+    assert.equal(drift.inSync, false);
+    assert.deepEqual(drift.phantom, [
+      "business-context",
+      "complexity-analysis",
+      "customer-needs",
+      "customer-problems",
+      "functional-requirements",
+      "software-glance",
+      "software-vision",
+      "zigzag-validator",
+    ]);
+    assert.deepEqual(
+      drift.missing,
+      [],
+      "the one skill the repository does have is listed — the drift is all in one direction",
+    );
+  });
+
+  it("reports a skill the repository ships that the listing never picked up", () => {
+    const drift = listingDrift({
+      listed: ["problem-based-srs"],
+      actual: ["problem-based-srs", "something-new"],
+    });
+    assert.deepEqual(drift.missing, ["something-new"]);
+    assert.deepEqual(drift.phantom, []);
+    assert.equal(drift.inSync, false);
+  });
+
+  it("is silent when the two agree", () => {
+    const drift = listingDrift({ listed: ["a", "b"], actual: ["b", "a"] });
+    assert.equal(drift.inSync, true, "order is not drift");
+    assert.deepEqual(drift.phantom, []);
+    assert.deepEqual(drift.missing, []);
+  });
+});
+
+describe("release links the repository publishes", () => {
+  const sources = () => [
+    { file: "README.md", text: README },
+    { file: "CHANGELOG.md", text: CHANGELOG },
+  ];
+
+  it("finds every per-tag release URL, with the file and line that carries it", () => {
+    const links = advertisedTagLinks(sources());
+    assert.ok(links.length >= 13, `expected the changelog's tag links, found ${links.length}`);
+    const v241 = links.find((l) => l.tag === "v2.4.1");
+    assert.ok(v241, "the changelog links every released version");
+    assert.equal(v241.file, "CHANGELOG.md");
+    assert.ok(v241.line > 0, "a finding without a line number is not actionable");
+  });
+
+  it("keeps the README version badge off a per-tag URL", () => {
+    const badge = README.split("\n").find((l) => /!\[Version /.test(l));
+    assert.ok(badge, "README.md must carry a version badge");
+    const links = advertisedTagLinks([{ file: "README.md", text: badge }]);
+    assert.deepEqual(
+      links,
+      [],
+      "the badge's version comes from .claude-plugin/plugin.json, which this project's " +
+        "documented process bumps *before* the tag is pushed. Linking a per-tag URL " +
+        "therefore 404s for the whole window between bump and release — it did, for two " +
+        "consecutive versions. docs/index.html already links the /releases index; the " +
+        "README badge must too.",
+    );
+    assert.match(
+      badge,
+      /https:\/\/github\.com\/RafaelGorski\/Problem-Based-SRS\/releases\)/,
+      "the badge must still be clickable — pointing at the releases index, not nowhere",
+    );
+  });
+
+  it("flags the links that name a release nobody ever published", () => {
+    const dangling = danglingTagLinks(advertisedTagLinks(sources()), PUBLISHED_TAGS);
+    const tags = [...new Set(dangling.map((l) => l.tag))].sort();
+    for (const expected of ["v2.5.0", "v2.6.0"]) {
+      assert.ok(
+        tags.includes(expected),
+        `${expected} must be reported: CHANGELOG.md dates a section for it and links its ` +
+          `tag, but neither tag exists — the manifest was bumped twice and the release ` +
+          `workflow never ran. Found: ${tags.join(", ")}`,
+      );
+    }
+    assert.ok(
+      !tags.includes("v2.4.1"),
+      "containment, not equality: every future release adds another changelog link, and " +
+        "this suite must not go red because correct work happened",
+    );
+  });
+
+  it("every link to an already-shipped release resolves", () => {
+    // The pending-release links (v2.5.0, v2.6.0) are a maintainer action — a tag push, not
+    // an edit. A link to a version *older* than the newest published release has no such
+    // excuse: it is a typo, and it is permanently broken. `[1.0]` pointed at v1.0 for the
+    // project's entire life; the tag has always been v1.0.0, and
+    //   /releases/tag/v1.0   → 404
+    //   /releases/tag/v1.0.0 → 200
+    // (verified 2026-07-31). Normalized matching had hidden it.
+    const newest = "2.4.1";
+    const stale = danglingTagLinks(advertisedTagLinks(sources()), PUBLISHED_TAGS).filter(
+      (l) => compareVersions(normalizeVersion(l.tag), newest) <= 0,
+    );
+    assert.deepEqual(
+      stale.map((l) => `${l.file}:${l.line} ${l.tag}`),
+      [],
+      "a link naming a version at or below the newest published release must resolve — " +
+        "no unpushed tag can explain it",
+    );
+  });
+
+  it("is silent when every advertised tag has a release behind it", () => {
+    const links = advertisedTagLinks([
+      {
+        file: "CHANGELOG.md",
+        text: "[2.4]: https://github.com/RafaelGorski/Problem-Based-SRS/releases/tag/v2.4",
+      },
+    ]);
+    assert.equal(links.length, 1, "the link must be this repository's, or nothing is proved");
+    assert.deepEqual(danglingTagLinks(links, ["v2.4"]), []);
+  });
+
+  it("compares tags exactly, because that is how GitHub serves them", () => {
+    const links = advertisedTagLinks([
+      {
+        file: "x.md",
+        text: "https://github.com/RafaelGorski/Problem-Based-SRS/releases/tag/v2.4.0",
+      },
+    ]);
+    assert.equal(
+      danglingTagLinks(links, ["v2.4"]).length,
+      1,
+      "/releases/tag/v2.4.0 returns 404 even though release 2.4.0 is published as v2.4 — " +
+        "normalizing here would call a genuinely broken link healthy",
+    );
+    assert.deepEqual(danglingTagLinks(links, ["v2.4.0"]), []);
+  });
+
+  it("leaves other repositories' release links alone", () => {
+    const links = advertisedTagLinks([
+      { file: "README.md", text: "https://github.com/github/spec-kit/releases/tag/v9.9.9" },
+    ]);
+    assert.equal(links.length, 1, "the link is still extracted…");
+    assert.deepEqual(
+      danglingTagLinks(links, PUBLISHED_TAGS),
+      [],
+      "…but another project's releases are not ours to publish; reporting them would be " +
+        "a false finding the moment the README links a tagged release elsewhere",
+    );
+  });
+});
+
+describe("release drift between the two release trains", () => {
+  it("reports a manifest version that was never released", () => {
+    const drift = releaseDrift({
+      manifestVersion: "2.6.0",
+      canvasVersion: "1.1.0",
+      tags: PUBLISHED_TAGS,
+    });
+    assert.equal(drift.plugin.advertised, "2.6.0");
+    assert.equal(drift.plugin.published, false);
+    assert.equal(drift.plugin.matchedTag, null);
+    assert.equal(
+      drift.newest,
+      "v2.4.1",
+      "the report has to name what a visitor actually finds on the releases page",
+    );
+  });
+
+  it("does not report the canvas train, which is published", () => {
+    const drift = releaseDrift({
+      manifestVersion: "2.6.0",
+      canvasVersion: "1.1.0",
+      tags: PUBLISHED_TAGS,
+    });
+    assert.equal(drift.canvas.published, true);
+    assert.equal(drift.canvas.matchedTag, "v1.1.0");
+  });
+
+  it("accepts the plugin train's two-part tags for a three-part manifest", () => {
+    assert.equal(normalizeVersion("v2.4"), "2.4.0");
+    assert.equal(normalizeVersion("2.4.0"), "2.4.0");
+    const drift = releaseDrift({
+      manifestVersion: "2.4.0",
+      canvasVersion: "1.1.0",
+      tags: PUBLISHED_TAGS,
+    });
+    assert.equal(
+      drift.plugin.matchedTag,
+      "v2.4",
+      "build-plugin.py stores X.Y as X.Y.0 and tags vX.Y — treating those as different " +
+        "releases would make this checker cry wolf on every plugin release ever cut",
+    );
+  });
+
+  it("does not let a plugin tag satisfy the canvas train", () => {
+    // VERSION is 1.1.0, so the next canvas minor is 1.2.0 — and v1.2 already exists as a
+    // *plugin* release. Matching by normalized version would silence exactly the case this
+    // checker exists for: bumped, tagged nowhere.
+    const drift = releaseDrift({
+      manifestVersion: "2.6.0",
+      canvasVersion: "1.2.0",
+      tags: PUBLISHED_TAGS,
+    });
+    assert.ok(PUBLISHED_TAGS.includes("v1.2"), "the collision must actually be present");
+    assert.equal(drift.canvas.published, false);
+    assert.equal(drift.canvas.matchedTag, null);
+  });
+});
+
+describe("the summary is what a human is handed", () => {
+  const drifted = () =>
+    summarize({
+      listing: parseRegistryListing(LISTING_FIXTURE),
+      repoSkills: repoSkillNames(repoRoot),
+      tagLinks: advertisedTagLinks([{ file: "CHANGELOG.md", text: CHANGELOG }]),
+      publishedTags: PUBLISHED_TAGS,
+      manifestVersion: "2.6.0",
+      canvasVersion: "1.1.0",
+    });
+
+  it("is not ok while any surface disagrees with the repository", () => {
+    const summary = drifted();
+    assert.equal(summary.ok, false);
+    assert.deepEqual(
+      summary.findings.map((f) => f.id).sort(),
+      ["dangling-release-links", "plugin-release-missing", "registry-listing-drift"],
+      "the canvas train is published, so it must not be reported",
+    );
+  });
+
+  it("is ok when every surface agrees", () => {
+    const summary = summarize({
+      listing: { skills: ["problem-based-srs"], declaredCount: 1, url: REGISTRY_URL },
+      repoSkills: ["problem-based-srs"],
+      tagLinks: [],
+      publishedTags: ["v2.6.0", "v1.1.0"],
+      manifestVersion: "2.6.0",
+      canvasVersion: "1.1.0",
+    });
+    assert.equal(summary.ok, true);
+    assert.deepEqual(summary.findings, []);
+  });
+
+  it("renders a report that names the offenders, not just a count", () => {
+    const md = renderReport(drifted());
+    assert.match(md, /zigzag-validator/, "a report that omits the names is not actionable");
+    assert.match(md, /v2\.6\.0/);
+    assert.match(md, /CHANGELOG\.md:\d+/, "findings must carry file:line");
+  });
+
+  it("emits a workflow annotation per finding, so warnings are not invisible", () => {
+    const lines = renderAnnotations(drifted());
+    assert.equal(lines.length, drifted().findings.length);
+    assert.ok(
+      lines.every((l) => l.startsWith("::error::") || l.startsWith("::warning::")),
+      "a warning-only run exits 0, so the Actions UI is the only place it can be seen",
+    );
+    assert.deepEqual(renderAnnotations({ findings: [] }), []);
+  });
+
+  it("separates 'something disagrees' from 'something could not be read'", () => {
+    const unreachable = summarize({
+      listing: { skills: [], declaredCount: null, url: REGISTRY_URL },
+      repoSkills: ["problem-based-srs"],
+      tagLinks: [],
+      publishedTags: [],
+      manifestVersion: null,
+      canvasVersion: null,
+      errors: [{ surface: "registry", message: "getaddrinfo ENOTFOUND" }],
+    });
+    assert.equal(unreachable.ok, false, "the run still has something to say");
+    assert.equal(
+      unreachable.drifted,
+      false,
+      "a 503 from a registry is not evidence that its listing is wrong; failing on it " +
+        "trains the maintainer to ignore this report",
+    );
+    assert.ok(unreachable.findings.every((f) => f.severity === "warning"));
+    assert.equal(
+      unreachable.findings.filter((f) => f.id === "registry-listing-unreadable").length,
+      0,
+      "the fetch error already explains the empty listing — two findings for one cause " +
+        "reads as two problems",
+    );
+    assert.equal(drifted().drifted, true, "real disagreement must still be an error");
+  });
+
+  it("refuses to compare a listing the page says is incomplete", () => {
+    const summary = summarize({
+      listing: { skills: ["problem-based-srs"], declaredCount: 9, url: REGISTRY_URL },
+      repoSkills: ["problem-based-srs"],
+      tagLinks: [],
+      publishedTags: ["v2.6.0", "v1.1.0"],
+      manifestVersion: "2.6.0",
+      canvasVersion: "1.1.0",
+    });
+    assert.deepEqual(
+      summary.findings.map((f) => f.id),
+      ["registry-listing-partial"],
+      "a truncated payload that happens to match the repo would otherwise print 'every " +
+        "surface agrees' while the live page still advertises the dead names",
+    );
+    assert.equal(summary.drifted, false, "a partial read is a warning, not a verdict");
+  });
+});
+
+describe("the exit code the workflow depends on", () => {
+  const stubFetch = ({ listingHtml, releases }) =>
+    async (url) => {
+      if (String(url).includes("api.github.com")) {
+        if (releases instanceof Error) throw releases;
+        return { ok: true, status: 200, json: async () => releases };
+      }
+      if (listingHtml instanceof Error) throw listingHtml;
+      return { ok: true, status: 200, text: async () => listingHtml };
+    };
+
+  it("is 1 under --strict when a surface really disagrees", async () => {
+    const code = await main(["--strict"], {
+      fetchImpl: stubFetch({
+        listingHtml: LISTING_FIXTURE,
+        releases: PUBLISHED_TAGS.map((t) => ({ tag_name: t, draft: false })),
+      }),
+      env: {},
+      root: repoRoot,
+    });
+    assert.equal(code, 1);
+  });
+
+  it("is 0 under --strict when both surfaces are merely unreachable", async () => {
+    const code = await main(["--strict"], {
+      fetchImpl: stubFetch({
+        listingHtml: new Error("ENOTFOUND"),
+        releases: new Error("502"),
+      }),
+      env: {},
+      root: repoRoot,
+    });
+    assert.equal(
+      code,
+      0,
+      "a network hiccup must not turn the weekly run red — the warning is still printed " +
+        "and annotated, but nothing is being claimed about drift",
+    );
+  });
+
+  it("is 0 without --strict even when everything has drifted", async () => {
+    const code = await main([], {
+      fetchImpl: stubFetch({
+        listingHtml: LISTING_FIXTURE,
+        releases: PUBLISHED_TAGS.map((t) => ({ tag_name: t, draft: false })),
+      }),
+      env: {},
+      root: repoRoot,
+    });
+    assert.equal(code, 0, "the plain report is for humans; only the workflow opts into failing");
+  });
+
+  it("ignores draft releases, which nobody can download", async () => {
+    const tags = await fetchPublishedTags({
+      fetchImpl: async () => ({
+        ok: true,
+        status: 200,
+        json: async () => [
+          { tag_name: "v2.6.0", draft: true },
+          { tag_name: "v2.4.1", draft: false },
+          { tag_name: null, draft: false },
+        ],
+      }),
+    });
+    assert.deepEqual(
+      tags,
+      ["v2.4.1"],
+      "a draft is visible to the maintainer and to nobody else; counting it would report " +
+        "a release as published while every link to it 404s for readers",
+    );
+  });
+});
+
+describe("the checker actually runs somewhere", () => {
+  const WORKFLOW = ".github/workflows/distribution-drift.yml";
+
+  it("has a scheduled workflow, since nothing else in CI may touch the network", () => {
+    assert.ok(
+      fs.existsSync(path.join(repoRoot, WORKFLOW)),
+      `${WORKFLOW} must exist — a checker nothing invokes is a checker that never runs`,
+    );
+    const wf = read(WORKFLOW);
+    assert.match(wf, /schedule:/, "the point is to notice drift that appears while nobody looks");
+    assert.match(wf, /workflow_dispatch:/, "and to be runnable on demand when refreshing");
+    assert.match(wf, /scripts\/check-distribution\.mjs/, "it must invoke the checker");
+  });
+
+  it("stays out of the PR gate", () => {
+    const wf = read(WORKFLOW);
+    const trigger = wf.slice(0, wf.indexOf("jobs:"));
+    assert.ok(
+      !/pull_request/.test(trigger),
+      "third-party state is not a property of a pull request; gating PRs on someone " +
+        "else's cache would block unrelated work",
+    );
+  });
+
+  it("needs no dependencies to run", () => {
+    const bare = [...CHECKER.matchAll(/^\s*import[\s\S]*?from\s+["']([^"']+)["']/gm)].map(
+      (m) => m[1],
+    );
+    assert.ok(bare.length > 0, "the import scan must actually find imports");
+    for (const spec of bare) {
+      assert.ok(
+        spec.startsWith("node:") || spec.startsWith("."),
+        `${spec} is a third-party import — the workflow runs this with no npm install`,
+      );
+    }
+  });
+});
+
+describe("negative canaries", () => {
+  it("parseRegistryListing returns nothing rather than guessing when the block is gone", () => {
+    const stripped = LISTING_FIXTURE.replace(/"@type":"CollectionPage"/, '"@type":"WebPage"');
+    const listing = parseRegistryListing(stripped);
+    assert.deepEqual(listing.skills, []);
+    assert.equal(listing.declaredCount, null);
+  });
+
+  it("parseRegistryListing survives a malformed JSON-LD block", () => {
+    const broken = '<script type="application/ld+json">{not json}</script>' + LISTING_FIXTURE;
+    assert.equal(parseRegistryListing(broken).skills.length, 9, "one bad block must not");
+    assert.deepEqual(parseRegistryListing("<html></html>").skills, []);
+  });
+
+  it("advertisedTagLinks ignores release URLs that are not per-tag", () => {
+    const text = [
+      "index: https://github.com/RafaelGorski/Problem-Based-SRS/releases",
+      "asset: https://github.com/RafaelGorski/Problem-Based-SRS/releases/download/v1.1.0/x.zip",
+      "filter: https://github.com/RafaelGorski/Problem-Based-SRS/releases?q=srs-navigator",
+      "real:   https://github.com/RafaelGorski/Problem-Based-SRS/releases/tag/v2.4",
+    ].join("\n");
+    assert.deepEqual(
+      advertisedTagLinks([{ file: "x.md", text }]).map((l) => l.tag),
+      ["v2.4"],
+      "the releases index and asset links resolve whether or not a given tag exists; " +
+        "flagging them would drown the real finding",
+    );
+  });
+
+  it("a README badge that goes back to a per-tag link fails this suite's assertion", () => {
+    const regressed = README.replace(
+      /(!\[Version [^\]]*\]\([^)]*\)\]\(https:\/\/github\.com\/RafaelGorski\/Problem-Based-SRS\/releases)\)/,
+      "$1/tag/v9.9.9)",
+    );
+    const badge = regressed.split("\n").find((l) => /!\[Version /.test(l));
+    assert.deepEqual(
+      advertisedTagLinks([{ file: "README.md", text: badge }]).map((l) => l.tag),
+      ["v9.9.9"],
+      "the check must actually notice the regression it exists to prevent",
+    );
+  });
+
+  it("danglingTagLinks does not paper over a 404 by normalizing the tag", () => {
+    // Verified against the live repository on 2026-07-31:
+    //   /releases/tag/v2.4    → 200
+    //   /releases/tag/v2.4.0  → 404
+    // GitHub resolves this path by exact tag name. An earlier draft normalized both sides,
+    // which called the second link healthy while a reader following it got a 404 — the
+    // precise failure this whole checker exists to catch.
+    const links = advertisedTagLinks([
+      { file: "x.md", text: `https://github.com/${REPO}/releases/tag/v2.4.0` },
+    ]);
+    assert.equal(danglingTagLinks(links, ["v2.4"]).length, 1);
+    assert.deepEqual(danglingTagLinks(links, ["v2.4.0"]), []);
+  });
+
+  it("summarize does not report drift it was not given evidence for", () => {
+    const summary = summarize({
+      listing: { skills: [], declaredCount: null, url: null },
+      repoSkills: ["problem-based-srs"],
+      tagLinks: [],
+      publishedTags: ["v2.6.0", "v1.1.0"],
+      manifestVersion: "2.6.0",
+      canvasVersion: "1.1.0",
+    });
+    assert.equal(
+      summary.findings.some((f) => f.id === "registry-listing-drift"),
+      false,
+      "an unreachable listing is a fetch problem, not proof that the listing is wrong — " +
+        "reporting it as drift would teach the maintainer to ignore the report",
+    );
+    assert.equal(summary.findings.some((f) => f.id === "registry-listing-unreadable"), true);
+  });
+});

--- a/scripts/check-distribution.mjs
+++ b/scripts/check-distribution.mjs
@@ -1,0 +1,506 @@
+#!/usr/bin/env node
+/**
+ * Distribution drift checker.
+ *
+ * This project is distributed through surfaces it does not own: a registry listing on
+ * skills.sh, and GitHub Releases for the plugin zip and the canvas archive. Nothing in
+ * the repository could see either, so both drifted silently:
+ *
+ *   * the listing still advertises the nine pre-#50 skills, of which eight no longer
+ *     exist — its own counters put 70 of 101 installs on names that resolve to nothing;
+ *   * .claude-plugin/plugin.json reached 2.6.0 while the newest release stayed v2.4.1,
+ *     so README.md's version badge linked a tag that returns 404.
+ *
+ * `evals/tests/distribution-surfaces.test.mjs` asserts those links *exist*. This module
+ * asks the question that one cannot: does what they point at still agree with this
+ * repository? The comparison is pure and unit-tested offline; only the CLI at the bottom
+ * touches the network, and only .github/workflows/distribution-drift.yml runs it.
+ *
+ * Usage:
+ *   node scripts/check-distribution.mjs [--json] [--strict]
+ *
+ *   --json    print the summary as JSON instead of markdown
+ *   --strict  exit non-zero when any surface has drifted (what the workflow uses)
+ */
+
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { parseFrontmatter } from "../evals/lib/skills.mjs";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+export const REPO_ROOT = path.resolve(__dirname, "..");
+
+export const REPO = "RafaelGorski/Problem-Based-SRS";
+export const REGISTRY_URL = "https://www.skills.sh/rafaelgorski/problem-based-srs";
+
+/** Files that publish release links to readers. */
+export const LINK_SOURCES = ["README.md", "CHANGELOG.md", "docs/index.html", "docs/docs.html"];
+
+// ---------------------------------------------------------------------------
+// Registry listing
+// ---------------------------------------------------------------------------
+
+/** Every JSON-LD payload on a page, skipping blocks that do not parse. */
+function jsonLdBlocks(html) {
+  const out = [];
+  for (const m of String(html ?? "").matchAll(
+    /<script[^>]*type=["']application\/ld\+json["'][^>]*>([\s\S]*?)<\/script>/gi,
+  )) {
+    try {
+      out.push(JSON.parse(m[1]));
+    } catch {
+      // A malformed block is the page's problem, not a reason to report drift.
+    }
+  }
+  return out;
+}
+
+/**
+ * Read the skill set a registry page advertises.
+ *
+ * Uses the page's JSON-LD `CollectionPage` rather than its markup: it is a declared
+ * contract, so it survives a redesign, and picking the wrong block is detectable (the
+ * page also carries a BreadcrumbList and a WebSite block).
+ *
+ * @param {string} html
+ * @returns {{skills:string[], description:string|null, declaredCount:number|null, url:string|null}}
+ */
+export function parseRegistryListing(html) {
+  const page = jsonLdBlocks(html).find((b) => b && b["@type"] === "CollectionPage");
+  if (!page) return { skills: [], description: null, declaredCount: null, url: null };
+
+  const parts = Array.isArray(page.hasPart) ? page.hasPart : [];
+  const description = typeof page.description === "string" ? page.description : null;
+  const stated = description?.match(/^(\d+)\s+agent skills/i);
+
+  return {
+    skills: parts.map((p) => p?.name).filter((n) => typeof n === "string"),
+    description,
+    declaredCount: stated ? Number(stated[1]) : null,
+    url: typeof page.url === "string" ? page.url : null,
+  };
+}
+
+/**
+ * The skills this repository actually ships, read from each SKILL.md's frontmatter.
+ * Derived rather than restated so the comparison moves with the repository.
+ * @param {string} [root]
+ * @returns {string[]}
+ */
+export function repoSkillNames(root = REPO_ROOT) {
+  const dir = path.join(root, "skills");
+  if (!fs.existsSync(dir)) return [];
+  const names = [];
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    if (!entry.isDirectory()) continue;
+    const skillMd = path.join(dir, entry.name, "SKILL.md");
+    if (!fs.existsSync(skillMd)) continue;
+    const { frontmatter } = parseFrontmatter(fs.readFileSync(skillMd, "utf8"));
+    names.push(frontmatter.name || entry.name);
+  }
+  return names.sort();
+}
+
+/**
+ * The registry listing URL the project actually advertises, read from its own docs so the
+ * monitor watches the page readers are sent to rather than a second copy of the address.
+ * @param {Array<{file:string, text:string}>} sources
+ * @param {string} [fallback]
+ */
+export function advertisedRegistryUrl(sources = [], fallback = REGISTRY_URL) {
+  for (const { text } of sources) {
+    const m = String(text ?? "").match(/https?:\/\/(?:www\.)?skills\.sh\/[^\s)"'<]+/);
+    if (m) return m[0].replace(/[.,]+$/, "");
+  }
+  return fallback;
+}
+
+/**
+ * Compare an advertised skill set against the real one.
+ * @param {{listed:string[], actual:string[]}} input
+ * @returns {{phantom:string[], missing:string[], inSync:boolean}}
+ */
+export function listingDrift({ listed = [], actual = [] } = {}) {
+  const has = (set, name) => set.includes(name);
+  const phantom = [...new Set(listed.filter((n) => !has(actual, n)))].sort();
+  const missing = [...new Set(actual.filter((n) => !has(listed, n)))].sort();
+  return { phantom, missing, inSync: phantom.length === 0 && missing.length === 0 };
+}
+
+// ---------------------------------------------------------------------------
+// Release links and release trains
+// ---------------------------------------------------------------------------
+
+const TAG_LINK = /https?:\/\/github\.com\/([\w.-]+\/[\w.-]+)\/releases\/tag\/([^\s)"'\]]+)/g;
+
+/**
+ * Every per-tag release URL a set of documents publishes, with file and line.
+ *
+ * Deliberately does not match the `/releases` index, `/releases?q=…` filters, or
+ * `/releases/download/…` asset URLs: those resolve whether or not a given tag exists, so
+ * flagging them would bury the finding that matters.
+ *
+ * @param {Array<{file:string, text:string}>} sources
+ * @returns {Array<{file:string, line:number, repo:string, tag:string, url:string}>}
+ */
+export function advertisedTagLinks(sources = []) {
+  const out = [];
+  for (const { file, text } of sources) {
+    const lines = String(text ?? "").split(/\r?\n/);
+    lines.forEach((line, i) => {
+      for (const m of line.matchAll(TAG_LINK)) {
+        out.push({ file, line: i + 1, repo: m[1], tag: m[2], url: m[0] });
+      }
+    });
+  }
+  return out;
+}
+
+/**
+ * Normalize a version or tag to X.Y.Z so the plugin train's two-part tags (`v2.4`, stored
+ * in the manifest as `2.4.0` by build-plugin.py) compare equal to the manifest.
+ * @param {string} value
+ * @returns {string|null} null when the value is not a dotted numeric version
+ */
+export function normalizeVersion(value) {
+  const raw = String(value ?? "").trim().replace(/^v/i, "");
+  if (!/^\d+(\.\d+)*$/.test(raw)) return null;
+  const parts = raw.split(".").map(Number);
+  while (parts.length < 3) parts.push(0);
+  return parts.slice(0, 3).join(".");
+}
+
+function exactTag(version, tags) {
+  return tags.find((t) => t === `v${version}` || t === version) ?? null;
+}
+
+/**
+ * The plugin train tags `vX.Y` for a manifest that stores `X.Y.0`, so an exact miss there
+ * still has to try the normalized form. The canvas train does not: `bump-version.mjs`
+ * always tags `v${VERSION}` in full.
+ */
+function pluginTag(version, tags) {
+  const exact = exactTag(version, tags);
+  if (exact) return exact;
+  const want = normalizeVersion(version);
+  if (!want) return null;
+  return tags.find((t) => normalizeVersion(t) === want) ?? null;
+}
+
+/**
+ * Release links whose tag has no published release behind it.
+ *
+ * Tags are compared **exactly**: GitHub serves /releases/tag/<tag> by tag name, so
+ * `/releases/tag/v2.4.0` is a 404 even though release 2.4.0 exists as `v2.4`. Normalizing
+ * here would call a genuinely broken link healthy. Links to other repositories are not
+ * this repository's releases to publish, so they are out of scope.
+ *
+ * @param {ReturnType<typeof advertisedTagLinks>} links
+ * @param {string[]} publishedTags
+ * @param {{repo?:string}} [options]
+ */
+export function danglingTagLinks(links = [], publishedTags = [], { repo = REPO } = {}) {
+  return links.filter(
+    (l) =>
+      String(l.repo).toLowerCase() === String(repo).toLowerCase() &&
+      !publishedTags.includes(l.tag),
+  );
+}
+
+/**
+ * Compare each release train's advertised version against what is published.
+ *
+ * The two trains share a tag namespace but not a version file: the plugin's number lives
+ * in .claude-plugin/plugin.json and is tagged vX.Y, the canvas app's lives in VERSION and
+ * is tagged vX.Y.Z. Matching them by normalized version alone would let the plugin's `v1.2`
+ * satisfy a canvas VERSION of 1.2.0 — a release of the *other* product silencing exactly
+ * the "bumped but never cut" case this checker exists for.
+ *
+ * @param {{manifestVersion:string, canvasVersion:string, tags:string[]}} input
+ */
+export function releaseDrift({ manifestVersion, canvasVersion, tags = [] } = {}) {
+  const train = (advertised, match) => {
+    const matchedTag = advertised ? match(advertised, tags) : null;
+    return { advertised: advertised ?? null, matchedTag, published: matchedTag !== null };
+  };
+
+  let newest = null;
+  for (const tag of tags) {
+    const v = normalizeVersion(tag);
+    if (!v) continue;
+    if (newest === null || compareVersions(v, normalizeVersion(newest)) > 0) newest = tag;
+  }
+
+  return {
+    plugin: train(manifestVersion, pluginTag),
+    canvas: train(canvasVersion, exactTag),
+    newest,
+  };
+}
+
+/** Numeric dotted-version comparison. Returns >0 when a is newer than b. */
+export function compareVersions(a, b) {
+  const pa = String(a ?? "").split(".").map(Number);
+  const pb = String(b ?? "").split(".").map(Number);
+  for (let i = 0; i < Math.max(pa.length, pb.length); i++) {
+    const d = (pa[i] || 0) - (pb[i] || 0);
+    if (d !== 0) return d;
+  }
+  return 0;
+}
+
+// ---------------------------------------------------------------------------
+// Summary
+// ---------------------------------------------------------------------------
+
+/**
+ * Turn the raw observations into findings a maintainer can act on.
+ *
+ * A surface that could not be read is a **warning**, never drift: a 503 from a registry is
+ * not evidence that its listing is wrong. Only `error` findings mean something actually
+ * disagrees with the repository, and only those drive the exit code — a report that cries
+ * wolf on a network hiccup is a report that gets ignored.
+ *
+ * @param {{errors?: Array<{surface:string, message:string}>}} input
+ */
+export function summarize({
+  listing = { skills: [], declaredCount: null, url: null },
+  repoSkills = [],
+  tagLinks = [],
+  publishedTags = [],
+  manifestVersion = null,
+  canvasVersion = null,
+  errors = [],
+} = {}) {
+  const findings = [];
+  const failed = new Set(errors.map((e) => e.surface));
+
+  for (const { surface, message } of errors) {
+    findings.push({
+      id: "surface-unreachable",
+      severity: "warning",
+      title: `The ${surface} surface could not be read`,
+      detail: [message, "This run has no evidence about that surface either way."],
+    });
+  }
+
+  if (listing.skills.length === 0) {
+    // Already explained by a fetch error above; a second finding for one cause reads as
+    // two problems.
+    if (!failed.has("registry")) {
+      findings.push({
+        id: "registry-listing-unreadable",
+        severity: "warning",
+        title: "The registry listing published no machine-readable skill set",
+        detail: [
+          `${listing.url ?? REGISTRY_URL} carried no JSON-LD CollectionPage.`,
+          "Its markup may have changed — check by hand before trusting a clean run.",
+        ],
+      });
+    }
+  } else if (listing.declaredCount !== null && listing.declaredCount !== listing.skills.length) {
+    findings.push({
+      id: "registry-listing-partial",
+      severity: "warning",
+      title: "The registry listing returned a partial skill set",
+      detail: [
+        `${listing.url ?? REGISTRY_URL} says it has ${listing.declaredCount} skills but ` +
+          `published ${listing.skills.length}.`,
+        "Comparing a truncated payload could report agreement that is not there, so the",
+        "comparison was skipped.",
+      ],
+    });
+  } else {
+    const drift = listingDrift({ listed: listing.skills, actual: repoSkills });
+    if (!drift.inSync) {
+      const detail = [`Listing: ${listing.url ?? REGISTRY_URL}`];
+      if (drift.phantom.length) {
+        detail.push(
+          `Advertised but not in this repository (${drift.phantom.length}): ` +
+            drift.phantom.join(", "),
+        );
+      }
+      if (drift.missing.length) {
+        detail.push(
+          `Shipped here but not listed (${drift.missing.length}): ` + drift.missing.join(", "),
+        );
+      }
+      detail.push(
+        "Refreshing the listing is third-party state; re-submit it at https://www.skills.sh.",
+      );
+      findings.push({
+        id: "registry-listing-drift",
+        severity: "error",
+        title: "The registry listing disagrees with the repository",
+        detail,
+      });
+    }
+  }
+
+  const dangling = danglingTagLinks(tagLinks, publishedTags);
+  if (dangling.length) {
+    findings.push({
+      id: "dangling-release-links",
+      severity: "error",
+      title: "Published links point at releases that do not exist",
+      detail: dangling.map((l) => `${l.file}:${l.line}  ${l.tag}  ${l.url}`),
+    });
+  }
+
+  const releases = releaseDrift({ manifestVersion, canvasVersion, tags: publishedTags });
+  if (manifestVersion && !releases.plugin.published) {
+    findings.push({
+      id: "plugin-release-missing",
+      severity: "error",
+      title: `The plugin advertises ${manifestVersion} but no such release is published`,
+      detail: [
+        `.claude-plugin/plugin.json: ${manifestVersion}`,
+        `newest published release: ${releases.newest ?? "none"}`,
+        "Cut it with `git tag vX.Y && git push origin vX.Y` (create-release.yml).",
+      ],
+    });
+  }
+  if (canvasVersion && !releases.canvas.published) {
+    findings.push({
+      id: "canvas-release-missing",
+      severity: "error",
+      title: `The canvas app advertises ${canvasVersion} but no such release is published`,
+      detail: [
+        `VERSION: ${canvasVersion}`,
+        `newest published release: ${releases.newest ?? "none"}`,
+        "release-canvas.yml owns this train and bumps VERSION itself.",
+      ],
+    });
+  }
+
+  return {
+    ok: findings.length === 0,
+    // Only real disagreement fails a run; warnings are surfaced, not paged on.
+    drifted: findings.some((f) => f.severity === "error"),
+    findings,
+    releases,
+  };
+}
+
+/** Render a summary as markdown, for a job summary or a terminal. */
+export function renderReport(summary) {
+  const lines = ["# Distribution drift", ""];
+  if (summary.ok) {
+    lines.push("Every distribution surface agrees with the repository.");
+    return lines.join("\n") + "\n";
+  }
+  lines.push(`${summary.findings.length} finding(s).`, "");
+  for (const f of summary.findings) {
+    lines.push(`## ${f.severity === "error" ? "❌" : "⚠️"} ${f.title}`, "");
+    for (const line of f.detail) lines.push(`- ${line}`);
+    lines.push("");
+  }
+  return lines.join("\n");
+}
+
+/**
+ * Workflow-command lines so a warning-only run is visible in the Actions UI without
+ * failing the job — otherwise "the listing became unparseable" would be a green run whose
+ * only trace is a summary nobody opens.
+ */
+export function renderAnnotations(summary) {
+  return summary.findings.map((f) => `::${f.severity}::${f.title} — ${f.detail[0] ?? ""}`);
+}
+
+// ---------------------------------------------------------------------------
+// CLI (the only part that touches the network)
+// ---------------------------------------------------------------------------
+
+export async function fetchRegistryListing({ url = REGISTRY_URL, fetchImpl } = {}) {
+  const doFetch = fetchImpl ?? globalThis.fetch;
+  const res = await doFetch(url, { headers: { accept: "text/html" }, redirect: "follow" });
+  if (!res.ok) throw new Error(`${url} responded ${res.status}`);
+  return await res.text();
+}
+
+export async function fetchPublishedTags({ repo = REPO, fetchImpl, token } = {}) {
+  const doFetch = fetchImpl ?? globalThis.fetch;
+  const headers = { accept: "application/vnd.github+json" };
+  if (token) headers.authorization = `Bearer ${token}`;
+  const url = `https://api.github.com/repos/${repo}/releases?per_page=100`;
+  const res = await doFetch(url, { headers });
+  if (!res.ok) throw new Error(`${url} responded ${res.status}`);
+  const body = await res.json();
+  return (Array.isArray(body) ? body : [])
+    .filter((r) => !r.draft)
+    .map((r) => r.tag_name)
+    .filter(Boolean);
+}
+
+export function readLocalState(root = REPO_ROOT) {
+  const manifest = JSON.parse(fs.readFileSync(path.join(root, ".claude-plugin/plugin.json"), "utf8"));
+  const versionFile = path.join(root, "VERSION");
+  const sources = LINK_SOURCES.filter((rel) => fs.existsSync(path.join(root, rel))).map((rel) => ({
+    file: rel,
+    text: fs.readFileSync(path.join(root, rel), "utf8"),
+  }));
+  return {
+    manifestVersion: manifest.version,
+    canvasVersion: fs.existsSync(versionFile)
+      ? fs.readFileSync(versionFile, "utf8").trim()
+      : null,
+    repoSkills: repoSkillNames(root),
+    tagLinks: advertisedTagLinks(sources),
+    registryUrl: advertisedRegistryUrl(sources),
+  };
+}
+
+export async function main(argv = [], { fetchImpl, env = process.env, root = REPO_ROOT } = {}) {
+  const asJson = argv.includes("--json");
+  const strict = argv.includes("--strict");
+  const { registryUrl, ...local } = readLocalState(root);
+  const errors = [];
+
+  let listing = { skills: [], description: null, declaredCount: null, url: registryUrl };
+  try {
+    listing = parseRegistryListing(await fetchRegistryListing({ url: registryUrl, fetchImpl }));
+  } catch (err) {
+    errors.push({ surface: "registry", message: `${registryUrl}: ${err.message}` });
+  }
+
+  let publishedTags = [];
+  try {
+    publishedTags = await fetchPublishedTags({
+      fetchImpl,
+      token: env.GITHUB_TOKEN || env.GH_TOKEN,
+    });
+  } catch (err) {
+    errors.push({ surface: "releases", message: `GitHub releases API: ${err.message}` });
+    // Without the release list every tag link would look dangling. Drop those inputs
+    // rather than emit findings the run has no evidence for.
+    local.tagLinks = [];
+    local.manifestVersion = null;
+    local.canvasVersion = null;
+  }
+
+  const summary = summarize({ listing, ...local, publishedTags, errors });
+  const output = asJson ? JSON.stringify(summary, null, 2) : renderReport(summary);
+  console.log(output);
+
+  if (env.GITHUB_ACTIONS) {
+    for (const line of renderAnnotations(summary)) console.log(line);
+  }
+  if (env.GITHUB_STEP_SUMMARY) {
+    fs.appendFileSync(env.GITHUB_STEP_SUMMARY, renderReport(summary));
+  }
+  return strict && summary.drifted ? 1 : 0;
+}
+
+const invokedDirectly =
+  process.argv[1] && path.resolve(process.argv[1]) === path.resolve(fileURLToPath(import.meta.url));
+
+if (invokedDirectly) {
+  main(process.argv.slice(2))
+    .then((code) => process.exit(code))
+    .catch((err) => {
+      console.error(err);
+      process.exit(2);
+    });
+}


### PR DESCRIPTION
Closes the last unclaimed half of #69.

## The problem

#69's two remaining boxes were filed as untestable because the surfaces they describe are third-party: the [skills.sh listing](https://www.skills.sh/rafaelgorski/problem-based-srs) and GitHub Releases. Three passes (#72, #73, #74) left them open, and every status comment since has re-quoted a hand-run check from #72.

They were not untestable. They were **unobserved** — and both had drifted while CI stayed green:

| Surface | State when this branch started |
|---|---|
| `README.md`'s first badge | linked `releases/tag/v2.6.0` — **404**. The documented process bumps `plugin.json` *before* the tag exists, and the release had not been cut for two consecutive versions, so the first clickable thing on the repository page led nowhere. |
| The skills.sh listing | still advertises the **nine pre-#50 skills**. One exists; the page's own counters put **70 of 101 installs** on the eight that do not. |
| `.claude-plugin/plugin.json` | says 2.6.0; newest published release is **v2.4.1**. |

`evals/tests/distribution-surfaces.test.mjs` asserts those links *exist*. It never asked whether what they point at agrees with this repository — presence, not function, the same gap #73 had to disprove for the canvas archive.

## What this adds

**`scripts/check-distribution.mjs`** makes the comparison. It reads the listing's JSON-LD `CollectionPage`, derives the real skill set from each `SKILL.md`'s frontmatter rather than restating it, and checks both release trains against what is actually published. Every comparison is a pure exported function.

**`.github/workflows/distribution-drift.yml`** is the only thing that touches the network — weekly and on demand, deliberately **outside the PR gate**, because third-party state is not a property of a pull request.

**`evals/tests/distribution-drift.test.mjs`** (41 assertions) is offline and deterministic: it feeds the checker a verbatim capture of the live listing plus the repository's own files.

## Two design decisions worth reviewing

**Tags are compared exactly.** GitHub serves `/releases/tag/<tag>` by tag name:

```
/releases/tag/v2.4    → 200
/releases/tag/v2.4.0  → 404      # release 2.4.0 exists — as tag v2.4
/releases/tag/v1.0    → 404
/releases/tag/v1.0.0  → 200
```

Normalizing both sides would call a genuinely broken link healthy. It found a **third** dead link that way: `[1.0]` in `CHANGELOG.md` has pointed at `v1.0` since the project began, and the tag has always been `v1.0.0`. Fixed here. Normalizing is confined to the plugin train's own version→release matching, where `build-plugin.py` really does store `X.Y` as `X.Y.0` — so a plugin `v1.2` can never be mistaken for a canvas `1.2.0` release that was never cut.

**Findings carry a severity.** Only real disagreement fails the run (`--strict` → 1). A surface that could not be read is a warning with a `::warning::` annotation and exit 0 — a monitor that goes red on someone else's 503 is a monitor that gets muted, and a muted monitor is the state #69 was already in.

## Verification

```
node --test evals/tests/*.test.mjs        313 pass  (was 302)
npm test  (srs-navigator)                 231 pass
python scripts/build-plugin.py validate   OK
node scripts/check-distribution.mjs       3 findings, --strict exits 1
```

Every new assertion was negative-tested by mutating a **real tracked file** — 9 mutations, all caught, control green before and after:

```
OK  stale link: [1.0] back to the tag that 404s
OK  canvas train matched by normalized version (plugin tag would satisfy it)
OK  dangling check normalizes instead of comparing exactly
OK  off-repo release links reported as ours
OK  --strict fails on warnings too
OK  partial payload compared anyway
OK  duplicate finding for one fetch failure
OK  annotations lose their severity prefix
OK  draft releases counted as published
```

## Still maintainer actions

Refreshing the skills.sh listing (re-submit at skills.sh) and cutting the missing `v2.6.0` release are outside a pull request's reach. What changes here is that neither can go unnoticed again — the runbook for both is in `.github/copilot-instructions.md`.