### PR TITLE
fix: brownfield onboarding no longer contradicts the Discovery Interview

### DIFF
--- a/.github/extensions/srs-navigator/README.md
+++ b/.github/extensions/srs-navigator/README.md
@@ -153,16 +153,23 @@ SRS Navigator and no specification is loaded, the start screen offers three ways
 
 | Action | What it does |
 |--------|--------------|
-| **Learn & Create Spec** | Scans your project and generates a specification |
+| **Learn & Create Spec** | Harvests evidence from your project, confirms it with you, and generates a specification |
 | **Load Specification** | Opens an existing `.spec` JSON file from your project |
 | **Explore Demo** | Loads the CRM sample specification to explore features |
 
-**Learn & Create Spec** is the primary onboarding path. It reads your existing code,
-README, and documentation, runs the full Problem-Based SRS methodology (`problem_based_srs`)
+**Learn & Create Spec** is the primary onboarding path. It reads your existing code, README,
+and documentation to gather evidence — schema volumes, recurring ticket themes, TODOs,
+operational metrics — then runs the full Problem-Based SRS methodology (`problem_based_srs`)
 to work backward from the system to the customer problems it solves, writes the resulting
 artifacts to your `.spec/` folder, and loads them as an interactive graph. You then refine
 the draft with the agent using the action bar (`+CN`, `+FR`, `decompose`, and so on). It is
 the same path the `learn` agent action triggers programmatically.
+
+The scan is *preparation*, not a substitute for you. The methodology's `problems` step carries
+a mandatory Discovery Interview, and reading a repository never satisfies its Skip Conditions —
+so the agent asserts what the evidence suggests and waits for you to confirm or correct it
+before writing Customer Problems. See **Mode 3: Brownfield Discovery** in
+`skills/problem-based-srs/reference/problems.md`.
 
 ## Architecture & Agent Integration
 

--- a/.github/extensions/srs-navigator/extension.mjs
+++ b/.github/extensions/srs-navigator/extension.mjs
@@ -18,6 +18,7 @@ import { DEMO_SPEC } from "./lib/demo-spec.mjs";
 import { compileAndSave } from "./lib/spec-compiler.mjs";
 import { decomposeNode } from "./lib/decompose.mjs";
 import { isTrustedLoopbackRequest } from "./lib/http-guard.mjs";
+import { LEARN_PROMPT, LOAD_PROMPT, buildActionPrompt, srsActionCommand } from "./lib/prompts.mjs";
 
 // Content fingerprint of a graph, used to detect *any* change to the loaded
 // specification (not just node/link count changes) so the canvas can reload
@@ -114,13 +115,10 @@ function fileForAction(action) {
     return (match || ACTIONS.find((a) => a.action === "full")).file;
 }
 
-// Map a methodology action (e.g. "needs") to its slash-command form. The whole
-// methodology is a single command; the action is passed as an argument, so
-// "full" (the default) is just `/problem-based-srs`.
-function srsActionCommand(action) {
-    const a = String(action || "full").trim() || "full";
-    return a === "full" ? "/problem-based-srs" : `/problem-based-srs ${a}`;
-}
+// Map a methodology action (e.g. "needs") to its slash-command form: see
+// `srsActionCommand` in lib/prompts.mjs. The whole methodology is a single
+// command; the action is passed as an argument, so "full" (the default) is just
+// `/problem-based-srs`.
 
 // Build the single unified methodology tool. It replaces the former one-tool-per
 // -step registry: callers select a step with the `action` argument.
@@ -310,71 +308,11 @@ async function reloadInstanceFromSource(inst, workspacePath) {
     return true;
 }
 
-// --- Agent prompts shared by the landing overlay and the graph action bar ---
-const LEARN_PROMPT = [
-    "## Problem-Based SRS: Learn & Create Specification",
-    "",
-    "The user wants to create a Problem-Based SRS specification for their project.",
-    "Use the `problem_based_srs` tool to run the full methodology.",
-    "Scan the workspace for existing code, README, and documentation to provide context.",
-    "",
-    "**IMPORTANT:** After generating all the .spec/ markdown artifacts (customer problems, needs, requirements),",
-    "you MUST also generate a consolidated JSON specification file at `.spec/<project-name>.json` with this shape:",
-    '{ "name", "version", "problems":[{id,title,description}], "needs":[{id,title,description,problemIds}],',
-    '  "functionalRequirements":[{id,title,description,needIds}], "nonFunctionalRequirements":[{id,title,description,needIds}] }',
-    "",
-    "**CRITICAL - Display the graph:** After creating the JSON file, use the `load_specification` canvas action",
-    "with the ABSOLUTE file path to the JSON file. Do NOT skip this step — the graph will not auto-refresh without it.",
-].join("\n");
-
-const LOAD_PROMPT = [
-    "## Problem-Based SRS: Load Specification",
-    "",
-    "The user wants to load an existing specification file.",
-    "Look for .spec/*.json files in the workspace, or ask the user which file to load.",
-    "Then use the `load_specification` canvas action to display it.",
-].join("\n");
-
-// Map a methodology action (e.g. "needs") to its Problem-Based SRS slash-command
-// form (e.g. "/problem-based-srs needs"). Taskbar actions must run the existing
-// methodology, never improvised free-text instructions. (Defined near the ACTIONS
-// registry as `srsActionCommand`.)
-
-function buildActionPrompt(action) {
-    // "Implement" is not a methodology step — it asks the agent to turn a
-    // fully-specified requirement into real code, so it gets its own prompt
-    // instead of a methodology slash-command.
-    if (action.action === "implement") {
-        const kind = action.nodeType === "nfr" ? "Non-Functional Requirement" : "Functional Requirement";
-        return [
-            `## Problem-Based SRS — implement ${action.nodeId} in code`,
-            "",
-            `Turn the following ${kind} into production-ready code in this repository.`,
-            "",
-            `**Target requirement:** ${action.nodeId} (${action.nodeType}) — "${action.nodeLabel}"`,
-            `**Request:** ${action.context}`,
-            "",
-            "Steps:",
-            "1. Read the specification in the `.spec/` folder to understand this requirement in full, including its parent Customer Needs and Customer Problems.",
-            "2. Locate the relevant part of the codebase (or create it) and write real, working code that satisfies the requirement.",
-            `3. Preserve traceability: reference ${action.nodeId} in code comments or the commit message so the implementation maps back to the spec.`,
-            "4. Follow the repository's existing conventions, and add or update tests where the project already has them.",
-            "",
-            "This is an implementation task, not a requirements-authoring task — do not rewrite the specification files. When done, briefly summarize what you built and where.",
-        ].join("\n");
-    }
-    const command = srsActionCommand(action.srsAction);
-    return [
-        `## Problem-Based SRS — run ${command}`,
-        "",
-        `Run the Problem-Based SRS **${command}** action (the \`problem_based_srs\` tool with \`action: "${action.srsAction}"\`) and follow its methodology exactly. Do not improvise a generic answer — the methodology defines the process you must use.`,
-        "",
-        `**Target node:** ${action.nodeId} (${action.nodeType}) — "${action.nodeLabel}"`,
-        `**Request:** ${action.context}`,
-        "",
-        `Apply the ${command} action to the target node, using the request above as its input and preserving traceability to ${action.nodeId}. After the methodology updates the specification, use the \`load_specification\` canvas action to refresh the graph.`,
-    ].join("\n");
-}
+// --- Agent prompts ---
+//
+// LEARN_PROMPT, LOAD_PROMPT, srsActionCommand and buildActionPrompt live in
+// lib/prompts.mjs so a unit test can assert the values that actually ship;
+// this module imports the copilot-sdk and cannot be loaded by node --test.
 
 const sendJson = (res, obj, status = 200) => {
     res.statusCode = status;

--- a/.github/extensions/srs-navigator/lib/prompts.mjs
+++ b/.github/extensions/srs-navigator/lib/prompts.mjs
@@ -1,0 +1,155 @@
+// Every prompt the canvas sends to the agent, plus the predicates that decide
+// whether a prompt is allowed to say what it says.
+//
+// These used to be `const`s inside extension.mjs, which imports
+// `@github/copilot-sdk/extension` and therefore cannot be loaded by a unit test.
+// That blind spot is not theoretical: the "Learn & Create Spec" button — the
+// primary onboarding path — shipped a prompt telling the agent to derive a
+// specification by scanning the workspace, which is precisely what the
+// methodology's mandatory Discovery Interview forbids, and no suite could see it.
+// Prompts live here so the guard asserts the value that actually ships.
+
+// A prompt tells the agent to run the methodology when it invokes the single
+// `problem_based_srs` tool / `/problem-based-srs` command. Those steps each carry
+// a mandatory Discovery Interview.
+export const RUNS_METHODOLOGY = /problem_based_srs|\/problem-based-srs/;
+
+// A prompt reads repository material when it tells the agent to go look at the
+// code, the README, or the docs for context.
+export const READS_WORKSPACE =
+    /\b(scan|scans|scanning|read|reads|reading|analy[sz]e\w*|inspect\w*|crawl\w*)\b[^.\n]{0,90}\b(workspace|repositor\w+|codebase|source code|README|documentation|docs)\b/i;
+
+// The obligation such a prompt must carry: name the interview, and say the scan
+// does not stand in for it.
+export const NAMES_INTERVIEW = /Discovery Interview/;
+export const DISCLAIMS_WAIVER =
+    /\b(does not|doesn't|never|not a)\b[^.\n]{0,90}\b(waive|waiver|replace|substitute|satisfy|skip)\b/i;
+
+/** True when the prompt asks the agent to run a methodology step. */
+export function runsMethodology(text) {
+    return RUNS_METHODOLOGY.test(String(text ?? ""));
+}
+
+/** True when the prompt asks the agent to read repository material for context. */
+export function readsWorkspace(text) {
+    return READS_WORKSPACE.test(String(text ?? ""));
+}
+
+/**
+ * True when the prompt both names the mandatory Discovery Interview and states
+ * that reading the repository does not waive it.
+ */
+export function carriesInterviewObligation(text) {
+    const s = String(text ?? "");
+    return NAMES_INTERVIEW.test(s) && DISCLAIMS_WAIVER.test(s);
+}
+
+/**
+ * The rule: if you tell the agent to run the methodology over material it
+ * scraped out of the repository, you must also tell it the scrape does not
+ * waive the Discovery Interview. Returns the ids of prompts that break it.
+ *
+ * @param {Array<{id:string, text:string}>} prompts
+ * @returns {string[]}
+ */
+export function promptsMissingInterviewObligation(prompts) {
+    return (prompts ?? [])
+        .filter((p) => runsMethodology(p.text) && readsWorkspace(p.text))
+        .filter((p) => !carriesInterviewObligation(p.text))
+        .map((p) => p.id);
+}
+
+// --- The prompts themselves -------------------------------------------------
+
+// "Learn & Create Spec" — the primary landing action, and the documented answer
+// to "I inherited a system with no spec". The workspace scan here is raw
+// material for the interview, never a replacement for it: reference/problems.md
+// states that a README or source code alone does NOT satisfy its Skip
+// Conditions, so a prompt that told the agent to derive Customer Problems from a
+// scan would be instructing it to break the methodology it just invoked.
+export const LEARN_PROMPT = [
+    "## Problem-Based SRS: Learn & Create Specification",
+    "",
+    "The user wants to create a Problem-Based SRS specification for their project.",
+    "Use the `problem_based_srs` tool to run the full methodology.",
+    "Scan the workspace for existing code, README, and documentation to gather evidence —",
+    "schema and data volumes, recurring ticket themes, TODOs and workarounds, operational metrics.",
+    "",
+    "**The scan prepares the mandatory Discovery Interview; it does not waive it.** Repository",
+    "material is evidence, not answers: it never satisfies the Skip Conditions in the methodology's",
+    "`problems` step. Bring what you found back to the user as assert-then-confirm (\"the data shows",
+    "X, so the consequence looks like Y — confirm or correct me\") and wait for the reply before",
+    "writing Customer Problems. Do not infer a specification from the codebase on your own.",
+    "",
+    "**IMPORTANT:** After generating all the .spec/ markdown artifacts (customer problems, needs, requirements),",
+    "you MUST also generate a consolidated JSON specification file at `.spec/<project-name>.json` with this shape:",
+    '{ "name", "version", "problems":[{id,title,description}], "needs":[{id,title,description,problemIds}],',
+    '  "functionalRequirements":[{id,title,description,needIds}], "nonFunctionalRequirements":[{id,title,description,needIds}] }',
+    "",
+    "**CRITICAL - Display the graph:** After creating the JSON file, use the `load_specification` canvas action",
+    "with the ABSOLUTE file path to the JSON file. Do NOT skip this step — the graph will not auto-refresh without it.",
+].join("\n");
+
+export const LOAD_PROMPT = [
+    "## Problem-Based SRS: Load Specification",
+    "",
+    "The user wants to load an existing specification file.",
+    "Look for .spec/*.json files in the workspace, or ask the user which file to load.",
+    "Then use the `load_specification` canvas action to display it.",
+].join("\n");
+
+/**
+ * Map a methodology action (e.g. "needs") to its slash-command form. The whole
+ * methodology is a single command; the action is passed as an argument, so
+ * "full" (the default) is just `/problem-based-srs`.
+ */
+export function srsActionCommand(action) {
+    const a = String(action || "full").trim() || "full";
+    return a === "full" ? "/problem-based-srs" : `/problem-based-srs ${a}`;
+}
+
+/** Build the prompt sent by an action-bar button. */
+export function buildActionPrompt(action) {
+    // "Implement" is not a methodology step — it asks the agent to turn a
+    // fully-specified requirement into real code, so it gets its own prompt
+    // instead of a methodology slash-command.
+    if (action.action === "implement") {
+        const kind = action.nodeType === "nfr" ? "Non-Functional Requirement" : "Functional Requirement";
+        return [
+            `## Problem-Based SRS — implement ${action.nodeId} in code`,
+            "",
+            `Turn the following ${kind} into production-ready code in this repository.`,
+            "",
+            `**Target requirement:** ${action.nodeId} (${action.nodeType}) — "${action.nodeLabel}"`,
+            `**Request:** ${action.context}`,
+            "",
+            "Steps:",
+            "1. Read the specification in the `.spec/` folder to understand this requirement in full, including its parent Customer Needs and Customer Problems.",
+            "2. Locate the relevant part of the codebase (or create it) and write real, working code that satisfies the requirement.",
+            `3. Preserve traceability: reference ${action.nodeId} in code comments or the commit message so the implementation maps back to the spec.`,
+            "4. Follow the repository's existing conventions, and add or update tests where the project already has them.",
+            "",
+            "This is an implementation task, not a requirements-authoring task — do not rewrite the specification files. When done, briefly summarize what you built and where.",
+        ].join("\n");
+    }
+    const command = srsActionCommand(action.srsAction);
+    return [
+        `## Problem-Based SRS — run ${command}`,
+        "",
+        `Run the Problem-Based SRS **${command}** action (the \`problem_based_srs\` tool with \`action: "${action.srsAction}"\`) and follow its methodology exactly. Do not improvise a generic answer — the methodology defines the process you must use.`,
+        "",
+        `**Target node:** ${action.nodeId} (${action.nodeType}) — "${action.nodeLabel}"`,
+        `**Request:** ${action.context}`,
+        "",
+        `Apply the ${command} action to the target node, using the request above as its input and preserving traceability to ${action.nodeId}. After the methodology updates the specification, use the \`load_specification\` canvas action to refresh the graph.`,
+    ].join("\n");
+}
+
+/**
+ * Every static prompt the canvas can send, so a guard iterates the set instead
+ * of naming one constant and missing the next one somebody adds.
+ */
+export const AGENT_PROMPTS = [
+    { id: "learn", text: LEARN_PROMPT },
+    { id: "load", text: LOAD_PROMPT },
+];

--- a/.github/extensions/srs-navigator/lib/renderer.mjs
+++ b/.github/extensions/srs-navigator/lib/renderer.mjs
@@ -1889,7 +1889,7 @@ export function renderGraphHtml(graphData, options = {}) {
             </span>
             <span class="landing-action-text">
               <span class="label">Learn &amp; Create Spec</span>
-              <span class="desc">Scan your project and generate a specification</span>
+              <span class="desc">Scan your project, confirm what hurts, generate a spec</span>
             </span>
           </button>
           <button class="landing-action-btn" id="modal-btn-load" aria-label="Load an existing specification file">

--- a/.github/extensions/srs-navigator/package.json
+++ b/.github/extensions/srs-navigator/package.json
@@ -9,7 +9,7 @@
     "test": "tests"
   },
   "scripts": {
-    "test": "node --test tests/parser.test.mjs tests/validation.test.mjs tests/renderer.test.mjs tests/action-bar.test.mjs tests/integration.test.mjs tests/decompose.test.mjs tests/skill-sync.test.mjs tests/interview-guard.test.mjs tests/http-guard.test.mjs tests/text-refs.test.mjs tests/notation.test.mjs tests/serve-canvas.test.mjs tests/serve-site.test.mjs tests/test-wiring.test.mjs",
+    "test": "node --test tests/parser.test.mjs tests/validation.test.mjs tests/renderer.test.mjs tests/action-bar.test.mjs tests/integration.test.mjs tests/decompose.test.mjs tests/skill-sync.test.mjs tests/interview-guard.test.mjs tests/brownfield-guard.test.mjs tests/http-guard.test.mjs tests/text-refs.test.mjs tests/notation.test.mjs tests/serve-canvas.test.mjs tests/serve-site.test.mjs tests/test-wiring.test.mjs",
     "test:skill-behavior": "node --test tests/skill-behavior/*.test.mjs",
     "test:e2e": "playwright test",
     "record-demo": "node scripts/record-demo.mjs",

--- a/.github/extensions/srs-navigator/skills/problem-based-srs.md
+++ b/.github/extensions/srs-navigator/skills/problem-based-srs.md
@@ -229,6 +229,9 @@ The business context captures: project identity, business principles (Mandatory/
 - **Assert-then-confirm:** When context makes one option obvious, state it and ask to confirm or override. Don't present a menu when the answer is already clear.
 - **Skip only when** a *confirmed* prior artifact plus the user's own prompt unambiguously answer all needed inputs. A README or source code that you inferred context from does NOT count. State what you're using as basis.
 - Questions must reference the specific context at hand — never ask generic questions
+- **Starting from an existing system?** Scanning the repository is legitimate *preparation* — it
+  gives you evidence to assert and confirm — but it is not a shortcut past the interview. See
+  **Mode 3: Brownfield Discovery** in [`reference/problems.md`](reference/problems.md).
 
 ### Starting Fresh
 When user provides business context or problem description:

--- a/.github/extensions/srs-navigator/skills/problems.md
+++ b/.github/extensions/srs-navigator/skills/problems.md
@@ -27,13 +27,17 @@ Identify, document, and validate Customer Problems from business context. Custom
 
 ---
 
-## Two Modes of Operation
+## Modes of Operation
 
 ### Mode 1: CP Generation
 Use when starting from **business context** to discover and document problems.
 
 ### Mode 2: CP Review & Normalization  
 Use when you have **draft CP statements** that need quality review and formatting.
+
+### Mode 3: Brownfield Discovery
+Use when the software **already exists** and nobody wrote down why. The starting point is a
+running system rather than a brief.
 
 ---
 
@@ -122,8 +126,78 @@ For each draft problem:
 
 ---
 
-## CP Structured Notation
+## Mode 3: Brownfield Discovery (existing system → CPs)
 
+Most systems that need a specification already run in production. The code, the schema, the
+ticket queue and the dashboards are dense evidence about what hurts — but evidence is not a
+specification, and reading it is not the same as knowing why the system must change.
+
+### The governing rule
+
+**Repository evidence is input to the Discovery Interview and never a basis to skip it.**
+
+The Skip Conditions above are unchanged and still apply literally: a README, source code,
+commit history, or issue tracker does **NOT** satisfy them. Harvesting evidence makes the
+interview *shorter and sharper* — you arrive with numbers instead of open questions — but the
+person who owns the system is still the only one who can say which consequences matter and
+what they cost. Producing CPs from a code scan alone is the exact failure this step exists to
+prevent, whether or not a human is present to stop you.
+
+### Step 1 — Harvest the evidence
+
+Read the system for **consequences**, not for architecture. Useful sources:
+
+| Source | What to extract |
+|--------|-----------------|
+| Database schema and data | Volumes that reveal pain — duplicate rows, orphaned records, unused columns |
+| Support tickets / issue tracker | Recurring themes, and what users say they could not do |
+| Analytics and operational metrics | Abandonment, latency, retry, error and rework rates |
+| Code comments, TODOs, workarounds | Where the team keeps patching the same wound |
+| Runbooks and manual processes | Work humans do because the system does not |
+
+Record each finding with its source, so every CP you later write is traceable to observed
+evidence rather than to a guess.
+
+### Step 2 — Bring the evidence to the interview
+
+Use the **assert-then-confirm** cadence from the Discovery Interview: state what the evidence
+suggests and ask the owner to confirm or override. This is a genuine interview turn — you MUST
+wait for the answer.
+
+> "The contacts table holds 41,800 rows for roughly 26,000 real customers, and 22% of support
+> tickets mention a colleague's missing notes. My reading is that reps cannot reconstruct a
+> customer's history, and the cost is repeated work and lost renewals. Is that the consequence
+> that matters, or is something else more urgent?"
+
+### Step 3 — Translate causes into problems
+
+A technical finding is a **cause**. A Customer Problem is the **business consequence** that
+cause produces, stated with a Subject and a Penalty. Technical debt is real, and it belongs in
+the Business Context as a constraint — it is not a Customer Problem.
+
+### Anti-Patterns to Avoid (Brownfield)
+
+| ❌ Wrong (the finding restated) | ✅ Correct (its consequence) |
+|--------------------------------|------------------------------|
+| ❌ "The CRM is a PHP monolith with jQuery front-ends and no tests" | ✅ "Sales managers must wait two weeks for any pipeline change, losing deals that turn on a same-week response" |
+| ❌ "The team must rewrite the legacy system and migrate to microservices" | ✅ "Support agents cannot reconstruct a customer's history, so 22% of conversations repeat work already done" |
+| ❌ "We should build a new CRM system to replace the old one" | ✅ "Account managers lose renewals because no one is alerted when a contract is 30 days from expiry" |
+| ❌ "Buy Salesforce instead" | ✅ "Compliance officers cannot produce a record of who changed a customer's data, breaching the audit obligation" |
+
+Each ❌ names a technology, a rewrite, or a purchase — none of them says who suffers or what it
+costs. Each ✅ names a subject and a penalty, and stays true whichever technology is chosen.
+
+### Mode 3 Checklist
+
+- [ ] Evidence harvested with its source recorded
+- [ ] Findings asserted back to the system's owner and confirmed or overridden
+- [ ] Every CP traces to observed evidence, not to inference from code alone
+- [ ] No CP names a technology, a rewrite, or a product to buy
+- [ ] Technical debt recorded as a constraint, not promoted to a Customer Problem
+
+---
+
+## CP Structured Notation
 Each Customer Problem MUST follow this syntax:
 
 ```

--- a/.github/extensions/srs-navigator/tests/action-bar.test.mjs
+++ b/.github/extensions/srs-navigator/tests/action-bar.test.mjs
@@ -11,6 +11,7 @@ import { readFileSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 import { dirname, join } from "node:path";
 import { renderGraphHtml } from "../lib/renderer.mjs";
+import { buildActionPrompt } from "../lib/prompts.mjs";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 
@@ -381,23 +382,33 @@ describe("Action Bar: Queue consume-once semantics", () => {
 // --- List View Implement Action (server prompt) ---
 
 describe("List View: implement action prompt", () => {
-  const extSource = readFileSync(join(__dirname, "..", "extension.mjs"), "utf8");
+  // Asserted against the built prompt rather than extension.mjs source text:
+  // the prompts moved to lib/prompts.mjs precisely so a test can see the value
+  // that ships instead of the substring that happens to be in the file.
+  const built = buildActionPrompt({
+    action: "implement",
+    srsAction: "functional-requirements",
+    nodeId: "FR.01.1.1",
+    nodeType: "fr",
+    nodeLabel: "Client registration",
+    context: "make it real",
+  });
 
   it("buildActionPrompt branches on the implement action", () => {
-    assert.ok(extSource.includes('action.action === "implement"'),
+    assert.ok(built.includes("implement FR.01.1.1 in code"),
       "server must special-case the implement action");
+    assert.ok(!built.includes("/problem-based-srs functional-requirements"),
+      "the implement branch must not route through a methodology slash-command");
   });
 
   it("implement prompt is an implementation task, not a skill slash-command", () => {
-    // The implement branch must not route through skillCommand (skill is null).
-    assert.ok(extSource.includes("implement ${action.nodeId} in code"));
-    assert.ok(extSource.includes("production-ready code"));
-    assert.ok(extSource.includes("do not rewrite the specification files"));
+    assert.ok(built.includes("production-ready code"));
+    assert.ok(built.includes("do not rewrite the specification files"));
   });
 
   it("implement prompt preserves traceability to the requirement", () => {
-    assert.ok(extSource.includes("Preserve traceability"));
-    assert.ok(extSource.includes("${action.nodeId}"));
+    assert.ok(built.includes("Preserve traceability"));
+    assert.ok(built.includes("FR.01.1.1"));
   });
 });
 

--- a/.github/extensions/srs-navigator/tests/brownfield-guard.test.mjs
+++ b/.github/extensions/srs-navigator/tests/brownfield-guard.test.mjs
@@ -1,0 +1,189 @@
+// Cross-surface drift guard: a canvas prompt must not tell the agent to do what
+// the methodology it invokes forbids.
+//
+// Every existing guard checks one surface at a time. `interview-guard.test.mjs`
+// asserts the skill markdown; `action-bar.test.mjs` asserts the canvas UI. Nothing
+// compared the two, and that gap shipped a contradiction on the primary onboarding
+// path: "Learn & Create Spec" sent a prompt saying
+//
+//     Use the `problem_based_srs` tool to run the full methodology.
+//     Scan the workspace for existing code, README, and documentation to provide context.
+//
+// while reference/problems.md — the first step that prompt runs — states that
+// "autonomously inferring context from repo files is precisely what the interview
+// exists to prevent". Whichever instruction the agent obeyed, the user lost: either
+// the button silently didn't do what docs/docs.html promised, or Customer Problems
+// were invented from source code with no human contact.
+//
+// The rule is written to generalize: any prompt that runs the methodology over
+// material scraped from the repository must carry the interview obligation, so the
+// next prompt written the same wrong way fails on arrival.
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, resolve } from "node:path";
+import {
+  AGENT_PROMPTS,
+  LEARN_PROMPT,
+  buildActionPrompt,
+  carriesInterviewObligation,
+  promptsMissingInterviewObligation,
+  readsWorkspace,
+  runsMethodology,
+} from "../lib/prompts.mjs";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const repoRoot = resolve(__dirname, "../../../..");
+const referenceDir = resolve(repoRoot, "skills/problem-based-srs/reference");
+const bundledDir = resolve(__dirname, "../skills");
+const read = (p) => readFileSync(p, "utf8");
+
+// The action-bar prompts are built per click, so they are exercised for real
+// rather than assumed: one methodology action and the implement action, which
+// takes the non-methodology branch.
+const builtPrompts = [
+  {
+    id: "action:needs",
+    text: buildActionPrompt({
+      action: "addCN",
+      srsAction: "needs",
+      nodeId: "CP.01",
+      nodeType: "problem",
+      nodeLabel: "Duplicate customer records",
+      context: "derive the needs",
+    }),
+  },
+  {
+    id: "action:implement",
+    text: buildActionPrompt({
+      action: "implement",
+      srsAction: "functional-requirements",
+      nodeId: "FR.01.1.1",
+      nodeType: "fr",
+      nodeLabel: "Client registration",
+      context: "write the code",
+    }),
+  },
+];
+
+const allPrompts = [...AGENT_PROMPTS, ...builtPrompts];
+
+describe("canvas prompts honour the mandatory Discovery Interview", () => {
+  it("no prompt runs the methodology over a repo scan without the obligation", () => {
+    assert.deepEqual(
+      promptsMissingInterviewObligation(allPrompts),
+      [],
+      "these prompts tell the agent to run the methodology on material scraped from the " +
+        "repository, but never say the scan does not waive the Discovery Interview",
+    );
+  });
+
+  it("the Learn & Create Spec prompt is the one that must carry it", () => {
+    // Guards the guard: if LEARN_PROMPT ever stops scanning or stops running the
+    // methodology, the check above would pass vacuously.
+    assert.ok(runsMethodology(LEARN_PROMPT), "the learn prompt must invoke the methodology");
+    assert.ok(readsWorkspace(LEARN_PROMPT), "the learn prompt must read the workspace");
+    assert.ok(
+      carriesInterviewObligation(LEARN_PROMPT),
+      "the learn prompt must name the Discovery Interview and disclaim that the scan waives it",
+    );
+  });
+
+  it("the obligation the prompt states is the one the skill states", () => {
+    const problems = read(resolve(referenceDir, "problems.md"));
+    assert.match(
+      problems,
+      /README, source code, or other repository documentation alone does/i,
+      "problems.md must still hold the guardrail the prompt defers to",
+    );
+    assert.match(
+      LEARN_PROMPT,
+      /Skip Conditions/,
+      "the prompt must point at the skill's Skip Conditions rather than inventing its own rule",
+    );
+  });
+
+  it("prompts that do not run the methodology are left alone", () => {
+    // The implement action reads the repo on purpose — it writes code, not
+    // requirements — and Load Specification looks for a file. Neither authors a
+    // specification, so neither owes an interview.
+    const implement = builtPrompts.find((p) => p.id === "action:implement");
+    assert.ok(!runsMethodology(implement.text), "implement must not route through the methodology");
+    assert.deepEqual(promptsMissingInterviewObligation([implement]), []);
+  });
+});
+
+describe("the brownfield path exists in the skill the prompt runs", () => {
+  const canonical = read(resolve(referenceDir, "problems.md"));
+
+  it("problems.md documents deriving CPs from a system that already exists", () => {
+    assert.match(
+      canonical,
+      /^#{2,3}\s+.*brownfield/im,
+      "problems.md must carry a brownfield mode — the canvas's primary onboarding path runs it",
+    );
+  });
+
+  it("it states repository evidence is interview input, never a skip basis", () => {
+    assert.match(
+      canonical,
+      /evidence[^.\n]{0,120}\b(does not|never)\b[^.\n]{0,80}\b(waive|replace|substitute|satisfy|skip)\b/i,
+      "the brownfield mode must say the harvested evidence does not waive the interview",
+    );
+  });
+
+  it("the bundled canvas copy carries the same brownfield mode", () => {
+    // The canvas ships flat copies for standalone installs. A brownfield mode
+    // that exists only canonically would be missing for exactly the users who
+    // installed the navigator on its own.
+    assert.equal(
+      read(resolve(bundledDir, "problems.md")),
+      canonical,
+      "problems.md is out of sync — run: npm run sync-skills",
+    );
+  });
+});
+
+describe("negative canaries", () => {
+  const OFFENDER = [
+    "Use the `problem_based_srs` tool to run the full methodology.",
+    "Scan the workspace for existing code, README, and documentation to provide context.",
+  ].join("\n");
+
+  it("flags the exact prompt this guard was written for", () => {
+    assert.deepEqual(promptsMissingInterviewObligation([{ id: "regression", text: OFFENDER }]), [
+      "regression",
+    ]);
+  });
+
+  it("name-dropping the interview is not enough — the waiver must be disclaimed", () => {
+    const halfway = `${OFFENDER}\nFollow the Discovery Interview guidance.`;
+    assert.ok(runsMethodology(halfway) && readsWorkspace(halfway));
+    assert.deepEqual(promptsMissingInterviewObligation([{ id: "halfway", text: halfway }]), [
+      "halfway",
+    ]);
+  });
+
+  it("disclaiming a waiver without naming the interview is not enough either", () => {
+    const vague = `${OFFENDER}\nThis does not replace anything.`;
+    assert.deepEqual(promptsMissingInterviewObligation([{ id: "vague", text: vague }]), ["vague"]);
+  });
+
+  it("a scan with no methodology run is out of scope", () => {
+    const scanOnly = "Scan the workspace for a README and summarize it.";
+    assert.ok(readsWorkspace(scanOnly) && !runsMethodology(scanOnly));
+    assert.deepEqual(promptsMissingInterviewObligation([{ id: "scan-only", text: scanOnly }]), []);
+  });
+
+  it("a methodology run with no scan is out of scope", () => {
+    const runOnly = "Run the `problem_based_srs` tool with action \"needs\".";
+    assert.ok(runsMethodology(runOnly) && !readsWorkspace(runOnly));
+    assert.deepEqual(promptsMissingInterviewObligation([{ id: "run-only", text: runOnly }]), []);
+  });
+
+  it("the prompt registry is not empty", () => {
+    assert.ok(AGENT_PROMPTS.length > 0, "an empty registry would make every check vacuous");
+    assert.ok(AGENT_PROMPTS.some((p) => p.id === "learn"));
+  });
+});

--- a/docs/docs.html
+++ b/docs/docs.html
@@ -157,7 +157,7 @@
                     <article class="tut reveal" id="from-codebase">
                         <span class="tut-kicker">Tutorial &middot; brownfield</span>
                         <h3>Learn from your codebase</h3>
-                        <p>Inherited a system with no spec? Open the Navigator on an existing project and choose <strong>Learn &amp; Create Spec</strong>. It scans your code, README, and docs, runs the methodology, and drafts problems, needs, and requirements for you to refine.</p>
+                        <p>Inherited a system with no spec? Open the Navigator on an existing project and choose <strong>Learn &amp; Create Spec</strong>. It harvests evidence from your code, README, and docs, brings it back as a short round of questions to confirm what actually hurts, then drafts problems, needs, and requirements for you to refine.</p>
                         <a class="tut-more" href="#nav-launch">See how the Navigator drafts it <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M5 12h14M13 6l6 6-6 6"/></svg></a>
                     </article>
                 </div>
@@ -286,7 +286,7 @@ git tag vX.Y &amp;&amp; git push origin vX.Y</code></pre>
                                 <div class="learn-actions">
                                     <div class="learn-action is-primary">
                                         <span class="la-icon" aria-hidden="true"><svg viewBox="0 0 256 256" fill="currentColor"><path d="M232,128a8,8,0,0,1-8,8H136v88a8,8,0,0,1-16,0V136H32a8,8,0,0,1,0-16h88V32a8,8,0,0,1,16,0v88h88A8,8,0,0,1,232,128Z"/></svg></span>
-                                        <span class="la-text"><span class="la-label">Learn &amp; Create Spec</span><span class="la-desc">Scan your project and generate a specification</span></span>
+                                        <span class="la-text"><span class="la-label">Learn &amp; Create Spec</span><span class="la-desc">Scan your project, confirm what hurts, generate a spec</span></span>
                                     </div>
                                     <div class="learn-action">
                                         <span class="la-icon" aria-hidden="true"><svg viewBox="0 0 256 256" fill="currentColor"><path d="M213.66,82.34l-56-56A8,8,0,0,0,152,24H56A16,16,0,0,0,40,40V216a16,16,0,0,0,16,16H200a16,16,0,0,0,16-16V88A8,8,0,0,0,213.66,82.34ZM160,51.31,188.69,80H160ZM200,216H56V40h88V88a8,8,0,0,0,8,8h48V216Z"/></svg></span>

--- a/docs/skills-health.html
+++ b/docs/skills-health.html
@@ -47,15 +47,15 @@
 <body>
 <main class="health">
   <h1>Skills Health</h1>
-  <p class="sub">Problem-Based SRS v2.6.0 · SRS Navigator v1.1.0 · generated 2026-07-31 11:04 UTC · <a href="index.html">back to the site</a></p>
+  <p class="sub">Problem-Based SRS v2.6.0 · SRS Navigator v1.1.0 · generated 2026-07-31 17:40 UTC · <a href="index.html">back to the site</a></p>
 
   <div class="cards">
     <div class="card verdict-passed"><span class="k">Verdict</span><span class="v">Passed</span></div>
-    <div class="card"><span class="k">Tests</span><span class="v">488</span></div>
-    <div class="card"><span class="k">Passing</span><span class="v">488</span></div>
+    <div class="card"><span class="k">Tests</span><span class="v">566</span></div>
+    <div class="card"><span class="k">Passing</span><span class="v">566</span></div>
     <div class="card"><span class="k">Failing</span><span class="v">0</span></div>
     <div class="card"><span class="k">Suites run</span><span class="v">4/6</span></div>
-    <div class="card"><span class="k">Duration</span><span class="v">72.4s</span></div>
+    <div class="card"><span class="k">Duration</span><span class="v">87.8s</span></div>
   </div>
 
   <h2>Suites</h2>
@@ -74,19 +74,19 @@
         <tr class="state-passed">
           <td class="name">Canvas extension<code>npm test</code></td>
           <td><span class="pill pill-passed">Passed</span></td>
-          <td class="num">231</td>
-          <td class="num">231</td>
+          <td class="num">244</td>
+          <td class="num">244</td>
           <td class="num ">0</td>
-          <td class="num">1.8s</td>
+          <td class="num">1.5s</td>
           <td class="note"></td>
         </tr>
         <tr class="state-passed">
           <td class="name">Skill evals<code>pwsh evals/scripts/run-tests.ps1</code></td>
           <td><span class="pill pill-passed">Passed</span></td>
-          <td class="num">215</td>
-          <td class="num">215</td>
+          <td class="num">280</td>
+          <td class="num">280</td>
           <td class="num ">0</td>
-          <td class="num">1.1s</td>
+          <td class="num">2s</td>
           <td class="note"></td>
         </tr>
         <tr class="state-passed">
@@ -95,7 +95,7 @@
           <td class="num">41</td>
           <td class="num">41</td>
           <td class="num ">0</td>
-          <td class="num">69.1s</td>
+          <td class="num">83.9s</td>
           <td class="note"></td>
         </tr>
         <tr class="state-skipped">
@@ -125,8 +125,8 @@
     <tbody>
         <tr class="state-ok">
           <td class="name"><code>skills/problem-based-srs/SKILL.md</code></td>
-          <td class="num">479</td>
-          <td class="bar-cell"><span class="bar"><i style="width:79.8%"></i></span></td>
+          <td class="num">482</td>
+          <td class="bar-cell"><span class="bar"><i style="width:80.3%"></i></span></td>
           <td><span class="pill pill-ok">OK</span></td>
         </tr>
         <tr class="state-ok">
@@ -155,8 +155,8 @@
         </tr>
         <tr class="state-ok">
           <td class="name"><code>skills/problem-based-srs/reference/live.md</code></td>
-          <td class="num">74</td>
-          <td class="bar-cell"><span class="bar"><i style="width:12.3%"></i></span></td>
+          <td class="num">81</td>
+          <td class="bar-cell"><span class="bar"><i style="width:13.5%"></i></span></td>
           <td><span class="pill pill-ok">OK</span></td>
         </tr>
         <tr class="state-ok">
@@ -173,8 +173,8 @@
         </tr>
         <tr class="state-ok">
           <td class="name"><code>skills/problem-based-srs/reference/problems.md</code></td>
-          <td class="num">375</td>
-          <td class="bar-cell"><span class="bar"><i style="width:62.5%"></i></span></td>
+          <td class="num">449</td>
+          <td class="bar-cell"><span class="bar"><i style="width:74.8%"></i></span></td>
           <td><span class="pill pill-ok">OK</span></td>
         </tr>
         <tr class="state-ok">

--- a/docs/skills-health.json
+++ b/docs/skills-health.json
@@ -1,6 +1,6 @@
 {
   "schema": "skills-health/1",
-  "generatedAt": "2026-07-31T11:04:06.7890950Z",
+  "generatedAt": "2026-07-31T17:40:57.9277572Z",
   "repo": "RafaelGorski/Problem-Based-SRS",
   "version": "2.6.0",
   "canvasVersion": "1.1.0",
@@ -10,11 +10,11 @@
     "suitesRun": 4,
     "suitesFailed": 0,
     "suitesSkipped": 2,
-    "tests": 488,
-    "pass": 488,
+    "tests": 566,
+    "pass": 566,
     "fail": 0,
     "skipped": 0,
-    "durationSeconds": 72.4
+    "durationSeconds": 87.8
   },
   "suites": [
     {
@@ -32,22 +32,22 @@
       "name": "Canvas extension",
       "state": "passed",
       "command": "npm test",
-      "tests": 231,
-      "pass": 231,
+      "tests": 244,
+      "pass": 244,
       "fail": 0,
       "skipped": 0,
-      "seconds": 1.8,
+      "seconds": 1.5,
       "reason": ""
     },
     {
       "name": "Skill evals",
       "state": "passed",
       "command": "pwsh evals/scripts/run-tests.ps1",
-      "tests": 215,
-      "pass": 215,
+      "tests": 280,
+      "pass": 280,
       "fail": 0,
       "skipped": 0,
-      "seconds": 1.1,
+      "seconds": 2,
       "reason": ""
     },
     {
@@ -58,7 +58,7 @@
       "pass": 41,
       "fail": 0,
       "skipped": 0,
-      "seconds": 69.1,
+      "seconds": 83.9,
       "reason": ""
     },
     {
@@ -91,9 +91,9 @@
     "files": [
       {
         "file": "skills/problem-based-srs/SKILL.md",
-        "lines": 479,
+        "lines": 482,
         "state": "ok",
-        "pctOfCap": 79.8
+        "pctOfCap": 80.3
       },
       {
         "file": "skills/problem-based-srs/reference/business-context.md",
@@ -121,9 +121,9 @@
       },
       {
         "file": "skills/problem-based-srs/reference/live.md",
-        "lines": 74,
+        "lines": 81,
         "state": "ok",
-        "pctOfCap": 12.3
+        "pctOfCap": 13.5
       },
       {
         "file": "skills/problem-based-srs/reference/microer-example.md",
@@ -139,9 +139,9 @@
       },
       {
         "file": "skills/problem-based-srs/reference/problems.md",
-        "lines": 375,
+        "lines": 449,
         "state": "ok",
-        "pctOfCap": 62.5
+        "pctOfCap": 74.8
       },
       {
         "file": "skills/problem-based-srs/reference/software-glance.md",

--- a/evals/tests/brownfield-coverage.test.mjs
+++ b/evals/tests/brownfield-coverage.test.mjs
@@ -1,0 +1,177 @@
+// "Don't grade what you don't teach."
+//
+// evals/cases/brownfield.case.mjs scores the reverse path (an inherited system ->
+// Customer Problems) against `skill: "problems"`, and penalizes brownfield-specific
+// failures: proposing a rewrite, blaming the tech stack, phrasing a problem as a
+// build instruction. Those penalties existed while reference/problems.md documented
+// only two modes — from business context, and reviewing draft CPs — neither of which
+// mentions an existing system, let alone the traps. The skill was being scored on
+// guidance it did not contain, so a model could only pass by luck.
+//
+// This guard ties the two corpora together WITHOUT restating either. It reads the
+// penalties out of the case file and requires the skill to carry a worked ❌ example
+// that each penalty actually catches. Add a fourth trap to the rubric tomorrow and
+// this fails until the skill teaches it.
+
+import { describe, it, before } from "node:test";
+import assert from "node:assert/strict";
+import path from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+import { loadAction, defaultSkillsRoot, extractSections } from "../lib/skills.mjs";
+
+const HERE = path.dirname(fileURLToPath(import.meta.url));
+const CASE_FILE = path.resolve(HERE, "..", "cases", "brownfield.case.mjs");
+
+/**
+ * A rubric check is an "absence" check when it passes on empty text: nothing
+ * forbidden is present. Pattern/predicate checks fail on empty text because the
+ * thing they require is missing. Derived from behavior so the classification
+ * cannot drift from a naming convention.
+ */
+export function absenceChecks(rubric) {
+  return (rubric ?? []).filter((c) => {
+    try {
+      const r = c.run("");
+      return (typeof r === "boolean" ? r : r?.pass) === true;
+    } catch {
+      return false;
+    }
+  });
+}
+
+/**
+ * Pull the ❌ / ✅ worked examples out of the sections of a skill whose heading
+ * matches `sectionPattern`. Sub-sections are included: the traps live under a
+ * nested "Anti-Patterns" heading inside the brownfield mode.
+ *
+ * Examples appear either as list/prose lines or as cells of a two-column
+ * wrong/right table, which is how this skill already writes anti-patterns, so
+ * table rows are split on `|` and each cell considered on its own.
+ */
+export function workedExamples(skillBody, sectionPattern) {
+  const sections = extractSections(skillBody);
+  const starts = sections
+    .map((s, i) => (sectionPattern.test(s.title) ? i : -1))
+    .filter((i) => i !== -1);
+  if (starts.length === 0) return { bad: [], good: [], found: false };
+
+  // A skill may name the mode twice — once in a summary list, once where it is
+  // actually specified. Take every match and its descendants so the examples are
+  // found wherever the author put them.
+  const scoped = [];
+  for (const start of starts) {
+    const level = sections[start].level;
+    scoped.push(sections[start]);
+    for (let i = start + 1; i < sections.length && sections[i].level > level; i++) {
+      scoped.push(sections[i]);
+    }
+  }
+
+  const fragments = scoped
+    .flatMap((s) => s.body.split(/\r?\n/))
+    .flatMap((line) => (line.includes("|") ? line.split("|") : [line]))
+    .map((f) => f.trim())
+    .filter(Boolean);
+
+  const collect = (marker) => fragments.filter((f) => f.startsWith(marker));
+  return { bad: collect("❌"), good: collect("✅"), found: true };
+}
+
+let brownfield;
+let skill;
+let examples;
+
+before(async () => {
+  brownfield = (await import(pathToFileURL(CASE_FILE).href)).default;
+  skill = await loadAction(brownfield.skill, { skillsRoot: defaultSkillsRoot() });
+  examples = workedExamples(skill.body, /brownfield/i);
+});
+
+describe("brownfield eval coverage", () => {
+  it("the case grades an action file that documents the brownfield path", () => {
+    assert.ok(
+      examples.found,
+      `cases/brownfield.case.mjs grades "${brownfield.skill}", but ${path.basename(skill.file)} ` +
+        "has no brownfield section — the reverse path (existing system -> CPs) is scored but never taught",
+    );
+  });
+
+  it("the brownfield section carries worked ❌ and ✅ examples", () => {
+    assert.ok(examples.bad.length > 0, "the brownfield section must show at least one ❌ example");
+    assert.ok(examples.good.length > 0, "the brownfield section must show at least one ✅ example");
+  });
+
+  it("every penalty in the rubric is illustrated by a ❌ example in the skill", () => {
+    const penalties = absenceChecks(brownfield.rubric);
+    assert.ok(penalties.length > 0, "the brownfield rubric must carry absence checks");
+
+    const untaught = penalties.filter(
+      (c) => !examples.bad.some((line) => c.run(line).pass === false),
+    );
+    assert.deepEqual(
+      untaught.map((c) => `${c.id} — ${c.description}`),
+      [],
+      "the brownfield rubric penalizes these, but no ❌ example in the skill demonstrates them",
+    );
+  });
+
+  it("the skill's ✅ examples would survive its own rubric", () => {
+    const penalties = absenceChecks(brownfield.rubric);
+    const offending = [];
+    for (const line of examples.good) {
+      for (const c of penalties) {
+        if (c.run(line).pass === false) offending.push(`${c.id}: ${line}`);
+      }
+    }
+    assert.deepEqual(
+      offending,
+      [],
+      "a ✅ example that the eval would penalize teaches the wrong lesson",
+    );
+  });
+});
+
+describe("negative canaries", () => {
+  it("absenceChecks separates penalties from requirements", () => {
+    const ids = absenceChecks(brownfield.rubric).map((c) => c.id).sort();
+    const all = brownfield.rubric.map((c) => c.id);
+    assert.ok(ids.length > 0 && ids.length < all.length, "the split must be a real partition");
+    for (const id of ids) {
+      assert.equal(brownfield.rubric.find((c) => c.id === id).run("").pass, true);
+    }
+  });
+
+  it("a skill with no brownfield section is reported, not silently passed", () => {
+    const blind = workedExamples("## Mode 1: CP Generation\n\ntext\n", /brownfield/i);
+    assert.equal(blind.found, false);
+    assert.deepEqual(blind.bad, []);
+  });
+
+  it("a brownfield section with no ❌ examples fails the coverage check", () => {
+    const toothless = workedExamples(
+      "## Mode 3: Brownfield\n\nJust prose, no worked examples.\n",
+      /brownfield/i,
+    );
+    assert.equal(toothless.found, true);
+    const penalties = absenceChecks(brownfield.rubric);
+    const untaught = penalties.filter(
+      (c) => !toothless.bad.some((line) => c.run(line).pass === false),
+    );
+    assert.equal(untaught.length, penalties.length, "prose alone must not satisfy the guard");
+  });
+
+  it("workedExamples pulls examples from nested sub-sections and table cells", () => {
+    const body = [
+      "## Mode 3: Brownfield",
+      "intro",
+      "### Anti-patterns",
+      "| ❌ bad line | ✅ good line |",
+      "|---|---|",
+      "## Something else",
+      "❌ out of scope",
+    ].join("\n");
+    const got = workedExamples(body, /brownfield/i);
+    assert.deepEqual(got.bad, ["❌ bad line"]);
+    assert.deepEqual(got.good, ["✅ good line"]);
+  });
+});

--- a/skills/problem-based-srs/SKILL.md
+++ b/skills/problem-based-srs/SKILL.md
@@ -229,6 +229,9 @@ The business context captures: project identity, business principles (Mandatory/
 - **Assert-then-confirm:** When context makes one option obvious, state it and ask to confirm or override. Don't present a menu when the answer is already clear.
 - **Skip only when** a *confirmed* prior artifact plus the user's own prompt unambiguously answer all needed inputs. A README or source code that you inferred context from does NOT count. State what you're using as basis.
 - Questions must reference the specific context at hand — never ask generic questions
+- **Starting from an existing system?** Scanning the repository is legitimate *preparation* — it
+  gives you evidence to assert and confirm — but it is not a shortcut past the interview. See
+  **Mode 3: Brownfield Discovery** in [`reference/problems.md`](reference/problems.md).
 
 ### Starting Fresh
 When user provides business context or problem description:

--- a/skills/problem-based-srs/reference/problems.md
+++ b/skills/problem-based-srs/reference/problems.md
@@ -27,13 +27,17 @@ Identify, document, and validate Customer Problems from business context. Custom
 
 ---
 
-## Two Modes of Operation
+## Modes of Operation
 
 ### Mode 1: CP Generation
 Use when starting from **business context** to discover and document problems.
 
 ### Mode 2: CP Review & Normalization  
 Use when you have **draft CP statements** that need quality review and formatting.
+
+### Mode 3: Brownfield Discovery
+Use when the software **already exists** and nobody wrote down why. The starting point is a
+running system rather than a brief.
 
 ---
 
@@ -122,8 +126,78 @@ For each draft problem:
 
 ---
 
-## CP Structured Notation
+## Mode 3: Brownfield Discovery (existing system → CPs)
 
+Most systems that need a specification already run in production. The code, the schema, the
+ticket queue and the dashboards are dense evidence about what hurts — but evidence is not a
+specification, and reading it is not the same as knowing why the system must change.
+
+### The governing rule
+
+**Repository evidence is input to the Discovery Interview and never a basis to skip it.**
+
+The Skip Conditions above are unchanged and still apply literally: a README, source code,
+commit history, or issue tracker does **NOT** satisfy them. Harvesting evidence makes the
+interview *shorter and sharper* — you arrive with numbers instead of open questions — but the
+person who owns the system is still the only one who can say which consequences matter and
+what they cost. Producing CPs from a code scan alone is the exact failure this step exists to
+prevent, whether or not a human is present to stop you.
+
+### Step 1 — Harvest the evidence
+
+Read the system for **consequences**, not for architecture. Useful sources:
+
+| Source | What to extract |
+|--------|-----------------|
+| Database schema and data | Volumes that reveal pain — duplicate rows, orphaned records, unused columns |
+| Support tickets / issue tracker | Recurring themes, and what users say they could not do |
+| Analytics and operational metrics | Abandonment, latency, retry, error and rework rates |
+| Code comments, TODOs, workarounds | Where the team keeps patching the same wound |
+| Runbooks and manual processes | Work humans do because the system does not |
+
+Record each finding with its source, so every CP you later write is traceable to observed
+evidence rather than to a guess.
+
+### Step 2 — Bring the evidence to the interview
+
+Use the **assert-then-confirm** cadence from the Discovery Interview: state what the evidence
+suggests and ask the owner to confirm or override. This is a genuine interview turn — you MUST
+wait for the answer.
+
+> "The contacts table holds 41,800 rows for roughly 26,000 real customers, and 22% of support
+> tickets mention a colleague's missing notes. My reading is that reps cannot reconstruct a
+> customer's history, and the cost is repeated work and lost renewals. Is that the consequence
+> that matters, or is something else more urgent?"
+
+### Step 3 — Translate causes into problems
+
+A technical finding is a **cause**. A Customer Problem is the **business consequence** that
+cause produces, stated with a Subject and a Penalty. Technical debt is real, and it belongs in
+the Business Context as a constraint — it is not a Customer Problem.
+
+### Anti-Patterns to Avoid (Brownfield)
+
+| ❌ Wrong (the finding restated) | ✅ Correct (its consequence) |
+|--------------------------------|------------------------------|
+| ❌ "The CRM is a PHP monolith with jQuery front-ends and no tests" | ✅ "Sales managers must wait two weeks for any pipeline change, losing deals that turn on a same-week response" |
+| ❌ "The team must rewrite the legacy system and migrate to microservices" | ✅ "Support agents cannot reconstruct a customer's history, so 22% of conversations repeat work already done" |
+| ❌ "We should build a new CRM system to replace the old one" | ✅ "Account managers lose renewals because no one is alerted when a contract is 30 days from expiry" |
+| ❌ "Buy Salesforce instead" | ✅ "Compliance officers cannot produce a record of who changed a customer's data, breaching the audit obligation" |
+
+Each ❌ names a technology, a rewrite, or a purchase — none of them says who suffers or what it
+costs. Each ✅ names a subject and a penalty, and stays true whichever technology is chosen.
+
+### Mode 3 Checklist
+
+- [ ] Evidence harvested with its source recorded
+- [ ] Findings asserted back to the system's owner and confirmed or overridden
+- [ ] Every CP traces to observed evidence, not to inference from code alone
+- [ ] No CP names a technology, a rewrite, or a product to buy
+- [ ] Technical debt recorded as a constraint, not promoted to a Customer Problem
+
+---
+
+## CP Structured Notation
 Each Customer Problem MUST follow this syntax:
 
 ```


### PR DESCRIPTION
Closes #78.

## The defect

The canvas's primary brownfield entry point — the **Learn & Create Spec** button, the first thing a user with an existing codebase clicks — told the agent to:

> Use the `problem_based_srs` tool to run the full methodology.
> Scan the workspace for existing code, README, and documentation to provide context.

That is precisely what the methodology forbids. `skills/problem-based-srs/reference/problems.md` Skip Conditions say:

> A README, source code, or other repository documentation alone does **NOT** satisfy these — autonomously inferring context from repo files is precisely what the interview exists to prevent.

Two shipped surfaces, opposite instructions, **and no test compared them.** `interview-guard.test.mjs` guarded the skill markdown; nothing guarded the prompts that *invoke* the skill.

**Second half of the same defect:** `problems.md` documented only Mode 1 (from business context) and Mode 2 (review drafts). There was no brownfield path at all — yet `evals/cases/brownfield.case.mjs` grades `skill: "problems"` and penalizes `no-rewrite`, `no-stack-complaint`, `no-solution-verbs`. The rubric graded behavior the skill never taught.

## TDD — red first

Two new deterministic guards, both written failing before any fix:

**1. `tests/brownfield-guard.test.mjs` (13 tests) — cross-surface guard.**
Deliberately stated as a general property rather than a string match on one prompt: a prompt fails only if it **both** runs the methodology **and** reads the workspace **and** does not carry the interview obligation (names "Discovery Interview" *and* has a `does not|never` … `waive|replace|substitute|satisfy|skip` clause). That correctly exempts the `implement` action prompt (reads the repo, writes code, never invokes the methodology) and `LOAD_PROMPT`, and it will catch a *future* prompt that reintroduces the contradiction. It also asserts the brownfield mode exists in the skill the prompt actually runs, and that the bundled canvas copy matches byte-for-byte.

**2. `evals/tests/brownfield-coverage.test.mjs` (8 tests) — "don't grade what you don't teach".**
Reads the penalties straight out of the brownfield eval case and requires a ❌ example in the skill that each penalty catches, and requires the ✅ examples to survive the rubric. Penalty classification is behavioral, not naming-based: a rubric check is an absence check iff `check.run("").pass === true`.

**Refactor to make the behavior observable.** `extension.mjs` imports `@github/copilot-sdk/extension`, so `node --test` cannot load it — the old tests scraped its *source text*, which guards a substring, not the shipped value. `LEARN_PROMPT`, `LOAD_PROMPT`, `srsActionCommand` and `buildActionPrompt` move into a new pure `lib/prompts.mjs` (the repo's convention for testable modules), and three `action-bar.test.mjs` tests now assert on the **built** prompt. Behavior-neutral: suite stayed at 231 pass across the refactor.

## Then green

- **`reference/problems.md` gains Mode 3: Brownfield Discovery** — governing rule (*"Repository evidence is input to the Discovery Interview and never a basis to skip it"*), a 3-step evidence → interview → translation flow, the ❌/✅ anti-pattern table the eval rubric grades, and a Mode 3 checklist.
- **`LEARN_PROMPT` rewritten** — the scan *prepares* the interview rather than replacing it, states explicitly that repository evidence never satisfies the Skip Conditions, and instructs the agent to present findings **for confirmation** instead of asserting a finished spec.
- **Copy fixed everywhere it promised an autonomous draft** — `SKILL.md`, `docs/docs.html` (tutorial + landing-modal replica), the canvas `README.md`, and the landing-modal button subtitle in `lib/renderer.mjs` (now "Scan your project, confirm what hurts, generate a spec"). The `docs.html` replica is kept byte-identical to `renderer.mjs`.
- Bundled canvas skills regenerated via `scripts/sync-skills.mjs` — not hand-edited.

## Verification

| Suite | Result |
|---|---|
| Canvas extension (`npm test`) | **244 / 244** |
| Skill evals | **280 / 280** |
| Canvas e2e (Playwright) | **41 / 41** |
| Plugin validation | **OK** |
| **Overall** | **566 / 566** |

`docs/skills-health.json` / `.html` regenerated from that full run, per repo convention.

## Negative-tested

Every new assertion was proven to fail by mutating the **real tracked files**, running the guard, and restoring — a test that never fails guards nothing. All 10 mutations caught, controls green before and after:

| Mutation | Guard |
|---|---|
| `LEARN_PROMPT` drops the interview obligation | 🔴 caught |
| `LEARN_PROMPT` stops citing the Skip Conditions | 🔴 caught |
| `problems.md` softens "never a basis to skip" | 🔴 caught |
| Bundled canvas copy drifts from canonical | 🔴 caught |
| Every brownfield heading removed | 🔴 caught |
| Rewrite anti-pattern example removed | 🔴 caught (`no-rewrite`) |
| **All** tech-stack anti-pattern examples removed | 🔴 caught (`no-stack-complaint`) |
| Solution-verb anti-pattern example removed | 🔴 caught (`no-solution-verbs`) |
| Mode 3 kept but all worked examples deleted | 🔴 caught |
| Renderer subtitle drifts from `docs.html` | 🔴 caught |

One earlier mutation initially showed a MISS — removing *only* the "PHP monolith / jQuery" row left the guard green, because `❌ "Buy Salesforce instead"` still trips `no-stack-complaint`. That is the guard behaving correctly (coverage survives while *some* example demonstrates the penalty), and the isolated re-run removing both rows goes red as expected.

## Not in scope

The README release badge pointing at a nonexistent `v2.6.0` tag and the stale `skills.sh` listing belong to open PR #77 (distribution drift) — deliberately untouched to avoid conflicts.

**Please do not merge without review.**