### PR TITLE
fix: Open the archive the release publishes, and close two drift gaps behind it

### DIFF
--- a/.github/extensions/srs-navigator/package-lock.json
+++ b/.github/extensions/srs-navigator/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "srs-navigator",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "srs-navigator",
-      "version": "1.1.0",
+      "version": "1.1.1",
       "license": "ISC",
       "devDependencies": {
         "@ai-sdk/anthropic": "^4.0.18",
@@ -206,6 +206,13 @@
         "zod": "^3.23.8"
       }
     },
+    "node_modules/@dmsnell/diff-match-patch": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@dmsnell/diff-match-patch/-/diff-match-patch-1.1.0.tgz",
+      "integrity": "sha512-yejLPmM5pjsGvxS9gXablUSbInW7H976c/FJ4iQxWIm7/38xBySRemTPDe34lhg1gVLbJntX0+sH0jYfU+PN9A==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
     "node_modules/@opentelemetry/api": {
       "version": "1.9.0",
       "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.0.tgz",
@@ -236,13 +243,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
       "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@types/diff-match-patch": {
-      "version": "1.0.36",
-      "resolved": "https://registry.npmjs.org/@types/diff-match-patch/-/diff-match-patch-1.0.36.tgz",
-      "integrity": "sha512-xFdR6tkm0MWvBfO8xXCSsinYxHcqkQUlcHeSpMC2ukzOb6lwQAfDmW+Qt0AvlGd8HpsS28qKsB+oPeJn9I39jg==",
       "dev": true,
       "license": "MIT"
     },
@@ -311,19 +311,6 @@
         "zod": "^3.23.8"
       }
     },
-    "node_modules/chalk": {
-      "version": "5.6.2",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
-      "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "^12.17.0 || ^14.13 || >=16.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/chalk?sponsor=1"
-      }
-    },
     "node_modules/dequal": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
@@ -333,13 +320,6 @@
       "engines": {
         "node": ">=6"
       }
-    },
-    "node_modules/diff-match-patch": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/diff-match-patch/-/diff-match-patch-1.0.5.tgz",
-      "integrity": "sha512-IayShXAgj/QMXgB0IWmKx+rOPuGMhqm5w6jvFxmVenXKIzRqTAAsbBPT3kWQeGANj3jGgvcvv4yK6SxqYmikgw==",
-      "dev": true,
-      "license": "Apache-2.0"
     },
     "node_modules/eventsource-parser": {
       "version": "3.1.0",
@@ -374,15 +354,13 @@
       "license": "(AFL-2.1 OR BSD-3-Clause)"
     },
     "node_modules/jsondiffpatch": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/jsondiffpatch/-/jsondiffpatch-0.6.0.tgz",
-      "integrity": "sha512-3QItJOXp2AP1uv7waBkao5nCvhEv+QmJAd38Ybq7wNI74Q+BBmnLn4EDKz6yI9xGAIQoUF87qHt+kc1IVxB4zQ==",
+      "version": "0.7.6",
+      "resolved": "https://registry.npmjs.org/jsondiffpatch/-/jsondiffpatch-0.7.6.tgz",
+      "integrity": "sha512-zE9+AXFq+MkTolDor2Cw1nJzLC0aleqPkYf52Kb4Kn4mJcka/gFHpGI2JBVEJCfWOvBl0OoxZS+wuLdislQcqg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@types/diff-match-patch": "^1.0.36",
-        "chalk": "^5.3.0",
-        "diff-match-patch": "^1.0.5"
+        "@dmsnell/diff-match-patch": "^1.1.0"
       },
       "bin": {
         "jsondiffpatch": "bin/jsondiffpatch.js"

--- a/.github/extensions/srs-navigator/package.json
+++ b/.github/extensions/srs-navigator/package.json
@@ -27,5 +27,8 @@
     "ai": "^4.3.19",
     "playwright": "^1.61.1",
     "zod": "^3.25.76"
+  },
+  "overrides": {
+    "jsondiffpatch": "^0.7.2"
   }
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -102,6 +102,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   chain, and `landing-proof.test.mjs` holds it to the spec the way it already held the
   landing page: renaming a problem in `.spec/crm-system.json` now fails both surfaces instead
   of neither.
+- **A moderate XSS advisory sat in the canvas dev tree** (`jsondiffpatch < 0.7.2`,
+  [GHSA-33vc-wfww-vjfv](https://github.com/advisories/GHSA-33vc-wfww-vjfv)), reachable only
+  as a transitive dependency of `ai@4`. `npm audit fix --force` would have taken `ai` from
+  v4 to v7 — a breaking SDK migration whose only consumers are the provider-gated LLM suites,
+  which cannot be run without API keys, so the fix could not have been verified. Pinned with
+  an `overrides` entry instead: `npm audit` drops from 5 findings (2 moderate) to 4 low, and
+  `generateText`/`tool` still resolve on the v4 API the harness documents. The four remaining
+  low advisories all require that migration and are left for a deliberate change.
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -94,6 +94,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   actually reaches the canvas: `live` is not an argument the orchestrator accepts, and a
   guard now rejects any `/problem-based-srs <action>` the agent claims that `SKILL.md`'s
   Available Actions table does not list.
+- **The README and the landing page told two different origin stories.** The site opens on
+  `CP.01 · Scattered Customer Information`, quoted from the shipped `.spec/crm-system.json`;
+  the README opened on an invented reporting-dashboard problem and reused **`CP.01` for
+  different content** — so a reader who met both surfaces in sequence, then installed and ran
+  `/live`, saw a third thing. The README now walks the same `CP.01 → CN.01.1 → FR.01.1.1`
+  chain, and `landing-proof.test.mjs` holds it to the spec the way it already held the
+  landing page: renaming a problem in `.spec/crm-system.json` now fails both surfaces instead
+  of neither.
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -81,8 +81,35 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   Notation table declares `NFR.{n}` → `NFR.01`, and the shipped demo spec uses `NFR.01`. The
   notation guard added in #63/#66 only rejects *hyphen* IDs, so a wrong-arity dotted ID
   walked straight through.
+- **The agent shipped two links that resolved outside the release archive.**
+  `agents/problem-based-srs/AGENT.md` linked its worked examples through
+  `../skills/problem-based-srs/reference/…`, which from `agents/problem-based-srs/` lands in
+  `agents/skills/` — a directory that exists in neither the repository nor the archive. It
+  was wrong in every published `problem-based-srs-vX.Y.zip`. `skills-static.test.mjs` does
+  resolve every relative link, but only under `skills/`, and `evals/` contained no reference
+  to `agents/` at all, so nothing looked at one of the five paths `PACKAGE_INCLUDES` ships.
+- **The agent could not dispatch `/live`.** `SKILL.md` routes nine actions, `AGENT.md`
+  advertised eight: the canvas entry point — the one #69 keeps asking about — was missing
+  from the table the plugin archive ships. It now names `/live`, which is the command that
+  actually reaches the canvas: `live` is not an argument the orchestrator accepts, and a
+  guard now rejects any `/problem-based-srs <action>` the agent claims that `SKILL.md`'s
+  Available Actions table does not list.
 
 ### Added
+
+- **The plugin release archive has an install path, and a guard that opens it**
+  (`evals/tests/plugin-archive-install.test.mjs`, 14 assertions). `problem-based-srs-vX.Y.zip`
+  is the only asset attached to every methodology release, and no surface said what to do
+  with it: the README documented four install paths and none of them was the file on the
+  release page. It is now documented — where to extract it, that the archive brings its own
+  `problem-based-srs/` root so the target is the directory *above* it, and which folder to
+  copy for the skill alone. The guard stages what the packager ships into a temp directory
+  outside the checkout and reads it as an installer would: every relative link must resolve
+  *inside* the archive, the agent must advertise every action `SKILL.md` dispatches, and every
+  path the README quotes must be in the tree. Both the include list and the archive root are
+  read out of `build-plugin.py` and `plugin.json`, and one cross-check runs the real
+  `build-plugin.py package` and requires the staged tree to equal the zip — so a change to the
+  archive's layout fails the documentation assertion with it.
 
 - **Drift guard for the canvas app's agent-facing instructions**
   (`.github/extensions/srs-navigator/tests/app-prompts.test.mjs`, 21 assertions, wired into

--- a/README.md
+++ b/README.md
@@ -222,6 +222,37 @@ claude --plugin-dir ./Problem-Based-SRS
 /plugin install https://github.com/RafaelGorski/Problem-Based-SRS
 ```
 
+### Plugin release archive
+
+Both commands above need the repository on disk. Every methodology release also attaches
+**`problem-based-srs-v<version>.zip`** — the same plugin with no repository around it, for
+installing without `git`. The canvas app ships on its own `vX.Y.Z` tags interleaved with
+the methodology's `vX.Y` ones, so check the title: methodology releases are named
+*🎉 Version …*. Download the asset from the
+[releases page](https://github.com/RafaelGorski/Problem-Based-SRS/releases).
+
+The archive already carries its own `problem-based-srs/` folder, so extract it into the
+directory *above* the one the plugin will occupy:
+
+| Scope | Extract into | Produces |
+|-------|--------------|----------|
+| Personal (all projects) | `~/plugins/` | `~/plugins/problem-based-srs/.claude-plugin/plugin.json` |
+| Project (one repo) | `vendor/` | `vendor/problem-based-srs/.claude-plugin/plugin.json` |
+
+Then point Claude Code at the extracted folder — `claude --plugin-dir ~/plugins/problem-based-srs`.
+
+What is inside, and how to use each piece on its own:
+
+| Path inside the archive | What it is |
+|-------------------------|------------|
+| `problem-based-srs/.claude-plugin/plugin.json` | the plugin manifest |
+| `problem-based-srs/skills/problem-based-srs/` | the methodology skill and its `reference/<action>.md` files — copy this one folder into `.github/skills/` (Copilot) or `.claude/skills/` (Claude Code) to use the skill without the plugin wrapper |
+| `problem-based-srs/agents/problem-based-srs/` | the agent that orchestrates the actions |
+
+There is **no `npm install` and no build step**: the archive is markdown plus a JSON
+manifest. It carries the methodology only — the SRS Navigator canvas app is a separate
+download, below.
+
 ### AgentSkills CLI
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -35,17 +35,30 @@ page always reflects the last full run on `main`.
 
 ## The problem this solves
 
-A stakeholder says: *"We need a reporting dashboard with 20 charts."*
+A stakeholder says: *"We need a CRM — with a mobile app and a dashboard."*
 
-You build it. Three weeks. Ship it. They use 3 charts. The actual problem was slow data access, not visualization. Two weeks wasted, one frustrated team.
+Hand that to an AI agent and you get a feature list in seconds. Six months later nobody can
+say why the dashboard exists, which customer problem it closes, or what breaks if you delete
+it. The requirements were never written down — only the code was.
 
-This happens because requirements start with *what stakeholders ask for* instead of *what they need*. Problem-Based SRS fixes the order: identify the problem first, then derive the solution.
+This happens because requirements start with *what stakeholders ask for* instead of *what
+they need*. Problem-Based SRS fixes the order: identify the problem first, then derive the
+solution.
 
 **With this methodology, the same request becomes:**
 
-> **CP.01**: "Managers must access sales data within 5 seconds to make decisions."
+> **CP.01 · Scattered Customer Information**
+> Sales teams waste valuable time searching for customer information across multiple
+> disconnected systems.
 
-From that problem, you derive the need (CN: real-time data access), then the requirement (FR: data API + 3 targeted charts). Built in one week. Solves the actual problem.
+The need follows from the problem, the requirement from the need. Each identifier names its
+parent, so the chain reads in both directions — forward to what you build, backward to why:
+
+**CP.01** → **CN.01.1** Centralized Customer Database → **FR.01.1.1** Contact and Company Management
+
+That is not an illustration. It is [`.spec/crm-system.json`](.spec/crm-system.json), the
+specification shipped with the plugin: 5 problems, 7 needs, 12 requirements, 5 quality
+attributes, no orphans. Run `/live` and the SRS Navigator opens that graph.
 
 ## How it works
 

--- a/agents/problem-based-srs/AGENT.md
+++ b/agents/problem-based-srs/AGENT.md
@@ -76,6 +76,7 @@ dispatching to a step via an **action** argument:
 | `functional-requirements` | `/problem-based-srs functional-requirements` | Step 5: Generate functional requirements |
 | `validate` | `/problem-based-srs validate` | Validate traceability across domains (ZigZag) |
 | `complexity` | `/problem-based-srs complexity` | Optional: Axiomatic Design quality analysis |
+| `live` | `/live` | Open the SRS Navigator canvas on the current spec |
 | `full` | `/problem-based-srs` | Run the complete methodology (Step 0 → Step 5) |
 
 ## How to Use This Agent
@@ -189,5 +190,5 @@ Use the `/problem-based-srs validate` action to check existing artifacts without
 ## Examples
 
 For complete walkthroughs, see:
-- [CRM Example](../skills/problem-based-srs/reference/crm-example.md) — Business domain
-- [MicroER Example](../skills/problem-based-srs/reference/microer-example.md) — Technical domain
+- [CRM Example](../../skills/problem-based-srs/reference/crm-example.md) — Business domain
+- [MicroER Example](../../skills/problem-based-srs/reference/microer-example.md) — Technical domain

--- a/evals/tests/dependency-pins.test.mjs
+++ b/evals/tests/dependency-pins.test.mjs
@@ -1,0 +1,86 @@
+// `npm audit` needs a network and a registry that changes under you, so it cannot be a
+// gate. The part that *is* deterministic is whether the fix is still in place: an override
+// pin is one `npm install --force` or one careless lockfile regeneration away from
+// disappearing, and nothing would say so until the next advisory sweep.
+//
+// This reads the two files npm itself writes and asserts they agree: every override the
+// canvas package declares must actually be what the lockfile resolved. It is offline, has
+// no dependencies, and fails loudly if a security pin stops being applied.
+import { describe, test } from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const REPO_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..", "..");
+const CANVAS = ".github/extensions/srs-navigator";
+const readJson = (rel) => JSON.parse(fs.readFileSync(path.join(REPO_ROOT, rel), "utf8"));
+
+const PKG = readJson(`${CANVAS}/package.json`);
+const LOCK = readJson(`${CANVAS}/package-lock.json`);
+
+/** Every version the lockfile resolved for a package name, wherever it appears in the tree. */
+export function resolvedVersions(lock, name) {
+  return Object.entries(lock.packages ?? {})
+    .filter(([p]) => p === `node_modules/${name}` || p.endsWith(`/node_modules/${name}`))
+    .map(([, meta]) => meta.version)
+    .filter(Boolean);
+}
+
+/** Compare dotted numeric versions: -1, 0 or 1. Prerelease tags are ignored. */
+export function compareVersions(a, b) {
+  const parts = (v) => String(v).split("-")[0].split(".").map(Number);
+  const [x, y] = [parts(a), parts(b)];
+  for (let i = 0; i < Math.max(x.length, y.length); i++) {
+    const d = (x[i] ?? 0) - (y[i] ?? 0);
+    if (d !== 0) return d < 0 ? -1 : 1;
+  }
+  return 0;
+}
+
+/** The floor a `^x.y.z` / `~x.y.z` / `>=x.y.z` / `x.y.z` range allows. */
+export function rangeFloor(range) {
+  return String(range).replace(/^[\^~>=\s]+/, "").trim();
+}
+
+describe("canvas dependency overrides are actually applied", () => {
+  test("declares at least one override, and the lockfile honours every one", () => {
+    const overrides = Object.entries(PKG.overrides ?? {});
+    assert.ok(
+      overrides.length > 0,
+      "the canvas package declares no overrides — if the security pin was intentionally " +
+        "removed because the upstream fix landed, delete this suite in the same change",
+    );
+    for (const [name, range] of overrides) {
+      const resolved = resolvedVersions(LOCK, name);
+      assert.ok(
+        resolved.length > 0,
+        `package.json overrides ${name}, but package-lock.json resolves no copy of it — ` +
+          "the override is documentation, not a fix",
+      );
+      const floor = rangeFloor(range);
+      const below = resolved.filter((v) => compareVersions(v, floor) < 0);
+      assert.deepEqual(
+        below,
+        [],
+        `${name} is pinned to ${range}, but the lockfile still resolves ${below.join(", ")}. ` +
+          "Run `npm install` in .github/extensions/srs-navigator and commit the lockfile.",
+      );
+    }
+  });
+
+  test("the lockfile describes the package.json beside it", () => {
+    // A lockfile generated from a different manifest is why the pin can look applied and
+    // not be: npm only enforces overrides it was asked to resolve.
+    assert.equal(
+      LOCK.packages?.[""]?.version,
+      PKG.version,
+      "package-lock.json is stale — regenerate it with `npm install`",
+    );
+    assert.deepEqual(
+      LOCK.packages?.[""]?.devDependencies ?? {},
+      PKG.devDependencies ?? {},
+      "package-lock.json's recorded devDependencies must match package.json's",
+    );
+  });
+});

--- a/evals/tests/landing-proof.test.mjs
+++ b/evals/tests/landing-proof.test.mjs
@@ -94,3 +94,85 @@ describe("landing page — the before/after quotes the real specification", () =
     assert.deepEqual(legacy, [], "the before/after copy must use dotted IDs, not legacy hyphen IDs");
   });
 });
+
+// The same proof claim, asked of the README — which is where a reader who arrives from the
+// registry or a `git clone` starts, and which had no such guard. It told a different origin
+// story ("a reporting dashboard with 20 charts") and reused CP.01 for a problem the shipped
+// spec does not contain: the landing page's CP.01 is "Scattered Customer Information", the
+// README's was "Managers must access sales data within 5 seconds". Same identifier, two
+// different meanings, on the two surfaces a reader sees in sequence.
+const README = fs.readFileSync(path.join(REPO_ROOT, "README.md"), "utf8");
+
+/** The README's origin story: the section that opens with the stakeholder's request. */
+function originStory(md, heading = "## The problem this solves") {
+  const from = md.indexOf(heading);
+  if (from === -1) return "";
+  const rest = md.slice(from + heading.length);
+  const end = rest.search(/^## /m);
+  return end === -1 ? rest : rest.slice(0, end);
+}
+
+/**
+ * Markdown prose as one line: blockquote markers and emphasis dropped, whitespace collapsed.
+ * The counterpart of `normalize()` for the page — a statement quoted verbatim is still
+ * quoted verbatim when the paragraph it sits in happens to wrap.
+ */
+function flatten(md) {
+  return md
+    .replace(/^\s*>\s?/gm, "")
+    .replace(/\*\*|`/g, "")
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+describe("README — the origin story is the same one the landing page tells", () => {
+  test("quotes the shipped CP.01, not an invented one", () => {
+    const story = flatten(originStory(README));
+    assert.ok(story.length > 0, "the README must keep its origin-story section");
+    const cp = byId(SPEC.problems, "CP.01");
+    assert.ok(
+      story.includes(cp.title),
+      `README.md must name CP.01 as "${cp.title}" — the problem the shipped spec actually ` +
+        `contains and the landing page already quotes`,
+    );
+    assert.ok(
+      story.includes(cp.description),
+      "README.md must quote CP.01's real statement verbatim, so a reader who installs and " +
+        "runs /live sees the problem the README promised",
+    );
+  });
+
+  test("walks a chain that is a real path through the spec", () => {
+    const story = flatten(originStory(README));
+    const cn = byId(SPEC.needs, "CN.01.1");
+    const fr = byId(SPEC.functionalRequirements, "FR.01.1.1");
+    for (const node of [cn, fr]) {
+      assert.ok(
+        story.includes(node.id) && story.includes(node.title),
+        `the README's chain must name ${node.id} as "${node.title}"`,
+      );
+    }
+    assert.ok(cn.problemIds.includes("CP.01"), "CN.01.1 must trace to CP.01 — the README claims it");
+    assert.ok(
+      fr.needIds.includes("CN.01.1"),
+      "FR.01.1.1 must trace to CN.01.1 — the README claims it",
+    );
+  });
+
+  test("uses canonical dotted identifiers", () => {
+    const legacy = originStory(README).match(/\b(?:CP|CN|FR|NFR)-\d+/g) ?? [];
+    assert.deepEqual(legacy, [], "the origin story must use dotted IDs, not legacy hyphen IDs");
+  });
+
+  test("names the same problem the landing page opens with", () => {
+    // Derived from the spec on both sides rather than compared as free text: the surfaces
+    // agree because they both quote the artifact, which is the property worth guarding.
+    const cp = byId(SPEC.problems, "CP.01");
+    const story = flatten(originStory(README));
+    assert.ok(
+      PAGE.includes(cp.title) && story.includes(cp.title),
+      "landing page and README must open on the same customer problem — a reader meets them " +
+        "in sequence, and two origin stories is two products",
+    );
+  });
+});

--- a/evals/tests/plugin-archive-install.test.mjs
+++ b/evals/tests/plugin-archive-install.test.mjs
@@ -1,0 +1,505 @@
+// The plugin release archive is the artifact every `vX.Y` release publishes — and the
+// artifact the release issue #69 keeps asking for (`git tag v2.6 && git push origin v2.6`)
+// will publish. Nothing had ever opened it.
+//
+// Eight passes on #69 proved the two *other* install paths: #73 loaded the canvas archive
+// from a staged tree, #74 staged what `npx skills add` copies. Both found real defects by
+// looking at the shipped tree instead of the checkout. The plugin archive — the primary
+// product, and the only asset attached to a plugin release — had neither a guard nor a
+// documented install path, and `evals/` contained zero references to `agents/`, one of the
+// five things `PACKAGE_INCLUDES` ships.
+//
+// It shipped broken. `agents/problem-based-srs/AGENT.md` linked
+// `../skills/problem-based-srs/reference/crm-example.md`, which from
+// `agents/problem-based-srs/` resolves to `agents/skills/…` — a directory that exists in
+// neither the repository nor the archive. `skills-static.test.mjs` resolves every relative
+// link it knows about, but only under `skills/`, so nothing looked. Same shape as the ISO
+// link #74 found: the only test covering the property never covered the shipped file.
+//
+// This suite stages what the packager ships into a temp directory outside the checkout and
+// reads it as an installer would. Two layers, on purpose:
+//
+//   A. Substantive assertions run everywhere, offline, with no Python: the staged set is
+//      derived by reading PACKAGE_INCLUDES out of build-plugin.py and the archive root out
+//      of plugin.json — the packager's own two inputs.
+//   B. One fidelity cross-check actually runs `build-plugin.py package` and compares the
+//      real zip's entry list against layer A's staging. It skips cleanly without a Python
+//      interpreter — only the cross-check skips, never a guard.
+import { describe, it, before, after } from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { spawnSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(here, "../..");
+
+const read = (rel) => fs.readFileSync(path.join(repoRoot, rel), "utf8");
+
+/* ------------------------------------------------------------------ helpers */
+
+/**
+ * The paths `build-plugin.py` puts in the archive, read out of the script rather than
+ * restated here. A test that hard-codes what the packager hard-codes is a second copy of
+ * the packager, and it agrees with itself while the archive drifts.
+ */
+export function packageIncludes(pySource) {
+  const block = pySource.match(/^PACKAGE_INCLUDES\s*=\s*\[([\s\S]*?)^\]/m);
+  if (!block) return [];
+  return [...block[1].matchAll(/["']([^"']+)["']/g)].map((m) => m[1]);
+}
+
+/** Every file under a directory, as forward-slash paths relative to it. */
+export function walk(dir, base = dir) {
+  return fs.readdirSync(dir, { withFileTypes: true }).flatMap((e) => {
+    const full = path.join(dir, e.name);
+    return e.isDirectory() ? walk(full, base) : [path.relative(base, full).replaceAll("\\", "/")];
+  });
+}
+
+/**
+ * Markdown link targets that point at another file: not a URL, not a bare anchor, not a
+ * mail link. The trailing `#fragment` is dropped — a link to a heading in a real file is
+ * still a link to that file.
+ */
+export function relativeLinkTargets(md) {
+  return [...md.matchAll(/\[[^\]]*\]\(\s*([^)\s]+)/g)]
+    .map((m) => m[1])
+    .filter((t) => !/^(?:[a-z][a-z0-9+.-]*:|#|\/\/)/i.test(t))
+    .map((t) => t.split("#")[0])
+    .filter(Boolean);
+}
+
+/**
+ * The actions `SKILL.md` dispatches, taken from the table that maps each action to its
+ * `reference/<action>.md`. That table is the orchestrator's contract — `skills-static`
+ * already asserts every row resolves — so it is the right source for "every action the
+ * methodology has", parsed at runtime instead of listed here.
+ */
+export function dispatchActions(skillMd) {
+  return [
+    ...skillMd.matchAll(/^\|\s*`([a-z-]+)`\s*\|\s*\[`reference\/([a-z-]+)\.md`\]/gm),
+  ]
+    .filter((m) => m[1] === m[2])
+    .map((m) => m[1]);
+}
+
+/** The actions a markdown table under `heading` lists in its first column. */
+export function actionsInTable(md, heading) {
+  const from = md.indexOf(heading);
+  if (from === -1) return [];
+  const section = md.slice(from + heading.length);
+  const end = section.search(/^#{2,4} /m);
+  const table = end === -1 ? section : section.slice(0, end);
+  return [...table.matchAll(/^\|\s*`([a-z-]+)`\s*\|/gm)].map((m) => m[1]);
+}
+
+/** The actions `AGENT.md` advertises in its Available Actions table. */
+export function agentActions(agentMd) {
+  return actionsInTable(agentMd, "## Available Actions");
+}
+
+/**
+ * Stage the archive's contents into `dest`, using the packager's own two inputs: the
+ * include list and the archive root (`plugin.json`'s name, which is what `package()`
+ * prefixes every arcname with). Returns the staged root.
+ */
+export function stagePluginArchive(dest, { includes, rootName }) {
+  const root = path.join(dest, rootName);
+  fs.mkdirSync(root, { recursive: true });
+  for (const rel of includes) {
+    const src = path.join(repoRoot, rel);
+    if (!fs.existsSync(src)) continue;
+    fs.cpSync(src, path.join(root, rel), { recursive: true });
+  }
+  return root;
+}
+
+/* -------------------------------------------------------------------- setup */
+
+const BUILD_PY = read("scripts/build-plugin.py");
+const PLUGIN_META = JSON.parse(read(".claude-plugin/plugin.json"));
+const INCLUDES = packageIncludes(BUILD_PY);
+const ROOT_NAME = PLUGIN_META.name;
+const README = read("README.md");
+const SKILL_MD = read("skills/problem-based-srs/SKILL.md");
+
+let tmpDir = "";
+let stagedRoot = "";
+let stagedFiles = [];
+
+before(() => {
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "pbsrs-plugin-archive-"));
+  stagedRoot = stagePluginArchive(tmpDir, { includes: INCLUDES, rootName: ROOT_NAME });
+  stagedFiles = walk(stagedRoot);
+});
+
+after(() => {
+  if (tmpDir) fs.rmSync(tmpDir, { recursive: true, force: true });
+});
+
+const staged = (rel) => path.join(stagedRoot, rel);
+const stagedExists = (rel) => fs.existsSync(staged(rel));
+
+/* --------------------------------------------------- the staging is faithful */
+
+describe("the staged tree is derived from the packager, not restated", () => {
+  it("reads a non-empty include list out of build-plugin.py", () => {
+    assert.ok(
+      INCLUDES.length > 0,
+      "PACKAGE_INCLUDES could not be parsed from scripts/build-plugin.py — every assertion " +
+        "below stages from it, so a silent parse failure would make this suite vacuous",
+    );
+    for (const rel of INCLUDES) {
+      assert.ok(
+        fs.existsSync(path.join(repoRoot, rel)),
+        `PACKAGE_INCLUDES names ${rel}, which is not in the repository: the archive would ` +
+          `silently ship without it (package() skips missing paths)`,
+      );
+    }
+  });
+
+  it("ships the plugin manifest, the agent and the skills", () => {
+    // These three are the plugin: without any one of them the extracted tree is not a
+    // Claude Code plugin at all. Asserted against the staged tree, not the include list,
+    // so a directory that exists but is empty still fails.
+    assert.ok(stagedExists(".claude-plugin/plugin.json"), "the manifest must be in the archive");
+    assert.ok(
+      stagedFiles.some((f) => f.startsWith("agents/") && f.endsWith("AGENT.md")),
+      "the agent definition must be in the archive",
+    );
+    assert.ok(
+      stagedExists("skills/problem-based-srs/SKILL.md"),
+      "the orchestrator skill must be in the archive",
+    );
+  });
+
+  it("carries no build tooling, tests or lockfiles", () => {
+    // The canvas archive shipped 187 node_modules entries and the manifest that rebuilds
+    // them (#73). The same question, asked of the plugin archive before it is published.
+    const unwanted = stagedFiles.filter((f) =>
+      /(^|\/)(node_modules|evals|tests|scripts|dist|build)\//.test(f) ||
+      /(^|\/)(package-lock\.json|\.gitignore)$/.test(f),
+    );
+    assert.deepEqual(unwanted, [], "the install archive must not carry development tooling");
+  });
+
+  it("matches what build-plugin.py actually packages", (t) => {
+    // The fidelity cross-check. Layer A stages from the packager's inputs; this proves the
+    // staging equals the packager's output. Only this check needs Python, and only this
+    // check may skip.
+    const outDir = fs.mkdtempSync(path.join(os.tmpdir(), "pbsrs-plugin-zip-"));
+    try {
+      // Probe for an interpreter separately from running the packager. Treating a non-zero
+      // exit as "no Python" would delete this check the moment build-plugin.py broke — the
+      // one failure it exists to catch — and blame a missing interpreter for it.
+      const python = ["python3", "python"].find(
+        (exe) => spawnSync(exe, ["--version"], { encoding: "utf8" }).status === 0,
+      );
+      if (!python) {
+        t.skip("no python interpreter available to cross-check the packaged archive");
+        return;
+      }
+      const res = spawnSync(
+        python,
+        ["-B", path.join(repoRoot, "scripts/build-plugin.py"), "package", "--out-dir", outDir],
+        { encoding: "utf8", cwd: repoRoot, env: { ...process.env, PYTHONDONTWRITEBYTECODE: "1" } },
+      );
+      assert.equal(
+        res.status,
+        0,
+        `build-plugin.py package failed (exit ${res.status}) — the release cannot be built:\n` +
+          `${res.stdout ?? ""}${res.stderr ?? ""}`,
+      );
+      const zips = fs.readdirSync(outDir).filter((f) => f.endsWith(".zip"));
+      assert.equal(zips.length, 1, "package() must emit exactly one archive");
+      assert.match(
+        zips[0],
+        new RegExp(`^${ROOT_NAME}-v\\d`),
+        "the asset name is <plugin name>-v<version>.zip — the README names it, so it is a contract",
+      );
+      const entries = zipEntries(path.join(outDir, zips[0]));
+      const inArchive = entries
+        .filter((e) => e.startsWith(`${ROOT_NAME}/`))
+        .map((e) => e.slice(ROOT_NAME.length + 1))
+        .sort();
+      assert.deepEqual(
+        inArchive,
+        [...stagedFiles].sort(),
+        "the staged tree must equal what package() writes; if they diverge, every assertion " +
+          "in this suite is checking a tree nobody ships",
+      );
+      assert.deepEqual(
+        entries.filter((e) => !e.startsWith(`${ROOT_NAME}/`)),
+        [],
+        `every archive entry must sit under the single ${ROOT_NAME}/ root the README tells ` +
+          `installers to expect`,
+      );
+    } finally {
+      fs.rmSync(outDir, { recursive: true, force: true });
+    }
+  });
+});
+
+/* ------------------------------------------------- the shipped tree resolves */
+
+describe("every link in the shipped tree resolves inside it", () => {
+  it("has no relative link that escapes the archive or misses a file", () => {
+    const broken = [];
+    for (const rel of stagedFiles.filter((f) => f.endsWith(".md"))) {
+      const dir = path.dirname(staged(rel));
+      for (const target of relativeLinkTargets(fs.readFileSync(staged(rel), "utf8"))) {
+        const resolved = path.resolve(dir, target);
+        const inside = !path.relative(stagedRoot, resolved).startsWith("..");
+        if (!inside || !fs.existsSync(resolved)) broken.push(`${rel} -> ${target}`);
+      }
+    }
+    assert.deepEqual(
+      broken,
+      [],
+      "a relative link in a shipped file must resolve to a file that is also shipped. " +
+        "Resolving it from the checkout is not the same question: `../skills/…` from " +
+        "agents/problem-based-srs/ lands in agents/skills/, which exists nowhere, and " +
+        "skills-static.test.mjs never looked because it only walks skills/.",
+    );
+  });
+});
+
+/* ------------------------------------- the agent orchestrates what it ships */
+
+describe("the agent ships the methodology it orchestrates", () => {
+  const agentFile = () => stagedFiles.find((f) => f.endsWith("AGENT.md"));
+
+  it("dispatches exactly the actions the archive ships a reference file for", () => {
+    // The floor this replaces (`actions.length >= 8`) was set one below reality, so a
+    // parser that lost a row would shrink the comparison set instead of failing — and the
+    // row it loses first is `live`, the only one with prose after the link. Derived from
+    // the shipped reference/ listing, by the rule evals/lib/skills.mjs already uses:
+    // every `*.md` that is not an `*-example.md` walkthrough.
+    const shipped = stagedFiles
+      .filter((f) => f.startsWith("skills/problem-based-srs/reference/"))
+      .map((f) => path.basename(f, ".md"))
+      .filter((a) => !a.endsWith("-example"))
+      .sort();
+    assert.ok(shipped.length > 0, "no reference files staged — every check below is vacuous");
+    assert.deepEqual(
+      [...dispatchActions(SKILL_MD)].sort(),
+      shipped,
+      "SKILL.md's dispatch table must route every action the archive ships and no others; " +
+        "it is what this suite compares the agent against, so a row it fails to parse " +
+        "silently stops covering that action",
+    );
+  });
+
+  it("advertises every action the orchestrator dispatches", () => {
+    const actions = dispatchActions(SKILL_MD);
+    const advertised = new Set(agentActions(fs.readFileSync(staged(agentFile()), "utf8")));
+    const missing = actions.filter((a) => !advertised.has(a));
+    assert.deepEqual(
+      missing,
+      [],
+      "the agent's Available Actions table must name every action SKILL.md dispatches — " +
+        "an action the agent cannot reach is one the archive ships and nobody can run",
+    );
+  });
+
+  it("advertises no action the orchestrator cannot dispatch", () => {
+    const dispatchable = new Set([
+      ...dispatchActions(SKILL_MD),
+      ...actionsInTable(SKILL_MD, "## Available Actions"),
+    ]);
+    const phantom = agentActions(fs.readFileSync(staged(agentFile()), "utf8")).filter(
+      (a) => !dispatchable.has(a),
+    );
+    assert.deepEqual(phantom, [], "the agent must not advertise an action with no reference file");
+  });
+
+  it("ships a reference file for every dispatched action", () => {
+    const missing = dispatchActions(SKILL_MD).filter(
+      (a) => !stagedExists(`skills/problem-based-srs/reference/${a}.md`),
+    );
+    assert.deepEqual(missing, [], "every dispatched action's reference file must be in the archive");
+  });
+
+  it("claims no /problem-based-srs invocation the orchestrator does not accept", () => {
+    // `live` is reached by its own `/live` command: SKILL.md's Available Actions table —
+    // the one listing what the orchestrator takes as an argument — has no `live` row, and
+    // the canvas extension's action enum has no `live` member. So an agent row reading
+    // `/problem-based-srs live` documents a call that fails. Derived from SKILL.md, so
+    // promoting `live` to a real orchestrator action makes this pass on its own.
+    const accepted = new Set(actionsInTable(SKILL_MD, "## Available Actions"));
+    assert.ok(accepted.size > 0, "SKILL.md's Available Actions table could not be parsed");
+    const agentMd = fs.readFileSync(staged(agentFile()), "utf8");
+    const bogus = tableColumn(agentMd, "Command")
+      .flatMap((cell) => [...cell.matchAll(/`\/problem-based-srs\s+([a-z-]+)`/g)].map((m) => m[1]))
+      .filter((a) => !accepted.has(a));
+    assert.deepEqual(
+      bogus,
+      [],
+      "the agent's Command column must only show invocations the orchestrator accepts",
+    );
+  });
+
+  it("keeps the agent's frontmatter name matching its directory", () => {
+    // build-plugin.py enforces this for skills and never looks at agents/. The agent is
+    // discovered by directory the same way, so the same rule applies to it.
+    const rel = agentFile();
+    const dir = path.basename(path.dirname(rel));
+    const name = fs.readFileSync(staged(rel), "utf8").match(/^name:\s*(.+)$/m)?.[1]?.trim();
+    assert.equal(name, dir, `${rel} frontmatter name must match its directory`);
+  });
+});
+
+/* ------------------------------------ the archive has an install path at all */
+
+describe("the release archive is installable from what the README says", () => {
+  const assetPattern = new RegExp(`${ROOT_NAME}-v[^\\s\`]*\\.zip`);
+
+  it("names the asset a plugin release actually publishes", () => {
+    assert.match(
+      README,
+      assetPattern,
+      `README.md must name ${ROOT_NAME}-v<version>.zip. It is the only asset attached to ` +
+        "every plugin release, and until it is written down the release page hands the " +
+        "reader a file with no instructions — the same gap #72 fixed for the canvas archive",
+    );
+  });
+
+  it("sends the reader to the releases page for it", () => {
+    const section = pluginArchiveSection(README);
+    assert.match(
+      section,
+      /https:\/\/github\.com\/[\w-]+\/[\w-]+\/releases/,
+      "the section naming the asset must link the releases page it is attached to",
+    );
+  });
+
+  it("states where to extract it", () => {
+    const targets = extractTargets(pluginArchiveSection(README));
+    assert.ok(
+      targets.length > 0,
+      "the section must say where to extract the archive — an asset with no extract target " +
+        "is the gap #72 found on the canvas train, where the two surfaces disagreed and the " +
+        "README was the wrong one",
+    );
+  });
+
+  it("does not tell the reader to extract into the folder the archive brings", () => {
+    // #72's finding, asked of the other train: the archive carries its own
+    // `problem-based-srs/` root, so an extract target ending in that name nests the tree one
+    // level too deep and the plugin does not load. The root is derived, not restated.
+    const nested = extractTargets(pluginArchiveSection(README)).filter((t) =>
+      nestsArchiveRoot(t, ROOT_NAME),
+    );
+    assert.deepEqual(
+      nested,
+      [],
+      `the archive already contains a ${ROOT_NAME}/ directory, so no documented extract ` +
+        `target may end in it`,
+    );
+  });
+
+  it("names paths inside the archive that are really there", () => {
+    // Every `problem-based-srs/...` path the section quotes must exist in the staged tree.
+    // This is what makes the instruction checkable rather than plausible.
+    const section = pluginArchiveSection(README);
+    const quoted = [...section.matchAll(/`(problem-based-srs\/[^`]+)`/g)].map((m) => m[1]);
+    assert.ok(
+      quoted.length > 0,
+      "the section must point at something concrete inside the extracted tree",
+    );
+    const missing = quoted
+      .map((q) => q.replace(/^problem-based-srs\//, "").replace(/\/$/, ""))
+      .filter((rel) => !stagedExists(rel) && !stagedFiles.some((f) => f.startsWith(`${rel}/`)));
+    assert.deepEqual(missing, [], "a documented path inside the archive must be in the archive");
+  });
+});
+
+/**
+ * The README region that documents the plugin release archive: from the heading whose
+ * section names the asset, to the next heading. Asserting "somewhere in the README" would
+ * let the extract target and the asset name drift into unrelated sections.
+ */
+export function pluginArchiveSection(md, rootName = ROOT_NAME) {
+  const asset = new RegExp(`${rootName}-v[^\\s\`]*\\.zip`);
+  const parts = md.split(/^(?=#{2,4} )/m);
+  return parts.find((p) => asset.test(p)) ?? "";
+}
+
+/** Cells of a markdown table column, verbatim. */
+export function tableColumn(md, header) {
+  const lines = md.split("\n");
+  const row = (l) =>
+    l
+      .trim()
+      .replace(/^\|/, "")
+      .replace(/\|$/, "")
+      .split("|")
+      .map((c) => c.trim());
+  const head = lines.findIndex((l) => l.trim().startsWith("|") && row(l).includes(header));
+  if (head === -1) return [];
+  const col = row(lines[head]).indexOf(header);
+  const out = [];
+  for (let i = head + 2; i < lines.length; i++) {
+    if (!lines[i].trim().startsWith("|")) break;
+    const cell = row(lines[i])[col];
+    if (cell !== undefined) out.push(cell.trim());
+  }
+  return out;
+}
+
+/**
+ * Directories the README tells the reader to extract into — the "Extract into" column, or
+ * the prose form. Reading the column rather than every backticked path keeps the guard
+ * pointed at instructions instead of at illustrations. Each cell yields the path it
+ * quotes, not the whole cell: `` `~/plugins/problem-based-srs/` (create it first) `` is
+ * still an instruction to extract into the archive's own root, and stripping the backticks
+ * instead would leave trailing prose that slides past the end-anchored nesting check.
+ */
+export function extractTargets(md) {
+  return [
+    ...tableColumn(md, "Extract into").map((cell) => (cell.match(/`([^`]+)`/)?.[1] ?? cell).trim()),
+    ...[...md.matchAll(/extract(?:\s+\w+)?\s+into\s+`([^`]+)`/gi)].map((m) => m[1].trim()),
+  ];
+}
+
+/** True when `target` is the archive's own root rather than the directory above it. */
+export function nestsArchiveRoot(target, root) {
+  return new RegExp(`(^|[\\\\/])${root}[\\\\/]?$`).test(target.trim());
+}
+
+/** Entry names in a zip, read without a dependency, from the central directory. */
+export function zipEntries(zipPath) {
+  const buf = fs.readFileSync(zipPath);
+  // Scanning local file headers instead would walk the compressed payloads too, and any
+  // payload containing the four bytes `PK\x03\x04` — deterministic for a stored entry —
+  // would advance the cursor by a garbage length and drop a real entry silently. The
+  // central directory is authoritative and immune to that.
+  let eocd = -1;
+  for (let i = buf.length - 22; i >= 0; i--) {
+    if (buf.readUInt32LE(i) === 0x06054b50) {
+      eocd = i;
+      break;
+    }
+  }
+  assert.notEqual(eocd, -1, `${zipPath} has no end-of-central-directory record`);
+  const count = buf.readUInt16LE(eocd + 10);
+  let at = buf.readUInt32LE(eocd + 16);
+  const names = [];
+  for (let n = 0; n < count; n++) {
+    assert.equal(
+      buf.readUInt32LE(at),
+      0x02014b50,
+      `${zipPath}: central directory entry ${n} has a bad signature`,
+    );
+    const nameLen = buf.readUInt16LE(at + 28);
+    const extraLen = buf.readUInt16LE(at + 30);
+    const commentLen = buf.readUInt16LE(at + 32);
+    names.push(buf.toString("utf8", at + 46, at + 46 + nameLen));
+    at += 46 + nameLen + extraLen + commentLen;
+  }
+  assert.equal(names.length, count, `${zipPath}: read ${names.length} of ${count} entries`);
+  return names.filter((n) => !n.endsWith("/")).sort();
+}


### PR DESCRIPTION
Sweep of every open issue. Nine were open (#69, #86–#93); six are merge, release, or third-party-submission actions that no pull request can perform. This lands the three that are in-repo work, each with a guard that fails if it regresses.

---

## 1 · The archive the release publishes had never been opened (#69, #92)

#69's remaining box is *"cut `v2.6`."* The half that lives in this repository is the artifact that release attaches. `problem-based-srs-vX.Y.zip` is the only asset on a methodology release, and **no test had ever opened it**.

It shipped broken:

| # | Finding | Evidence |
|---|---|---|
| 1 | `AGENT.md` linked `../skills/problem-based-srs/reference/…`, which from `agents/problem-based-srs/` resolves to `agents/skills/` — a directory in neither the repo nor the archive | wrong in the published `v2.4.1` zip; would have shipped in `v2.6` |
| 2 | The shipped agent advertised 8 actions where `SKILL.md` dispatches 9 — `live`, the entry point #69 keeps citing, was missing | `SKILL.md:91-99` vs the agent's table |
| 3 | `evals/` contained **zero** references to `agents/` | one of five `PACKAGE_INCLUDES` paths had no guard at all |
| 4 | The archive had no documented install path | the README documented four install methods, none of them the file on the release page |

Finding 3 is why 1 and 2 survived. `skills-static.test.mjs` resolves every relative link — but only under `skills/`. Same shape as the ISO link #74 found: the only test covering the property never covered the shipped file.

**`evals/tests/plugin-archive-install.test.mjs`** (16 assertions) stages what the packager ships into a temp directory *outside the checkout* and reads it as an installer would. The include list comes out of `build-plugin.py` and the archive root out of `plugin.json`, so it derives rather than restates; one cross-check runs the real `build-plugin.py package` and requires the staged tree to equal the zip, so a layout change fails the documentation assertions with it. `README.md` gains a `### Plugin release archive` section.

### Review round

An adversarial review found three ways the guard could have gone quiet. Each **passed green before its fix**:

| Defect | Consequence | Fix |
|---|---|---|
| The cross-check treated *any* non-zero exit as "no python" | A broken packager — the one failure that blocks a release — would have deleted the only check that builds it, and blamed a missing interpreter | Probe the interpreter separately; assert `status === 0` and surface stderr |
| `actions.length >= 8`, one below reality | A parser losing the `live` row (the only dispatch row with prose after the link) would shrink the comparison set instead of failing | Derive the expected set from the shipped `reference/` listing |
| `zipEntries` scanned local headers *through* the payloads | A stored payload containing `PK\x03\x04` advances the cursor by a garbage length and drops real entries — against `zipfile.namelist()` the old code returned **1 of 3** names; the central-directory read returns all 3 | Read the central directory via EOCD |

It also caught a documentation error I introduced: the new `live` row said `/problem-based-srs live`, but `live` is not an argument the orchestrator accepts (`SKILL.md`'s Available Actions table has no `live` row; the canvas extension's action enum has no `live` member). It now says `/live`, and a new assertion rejects any `/problem-based-srs <action>` the agent claims that `SKILL.md` does not list.

**On #92's app track:** all five screenshots it asks for are already captured and green (`live-dotted-notation`, `skills-health-dashboard`, `landing-install`, `landing-version-badge`, `landing-live-demo`), and the ISO/IEC/IEEE 29148 citation already resolves to a public URL. The rest of #92 depends on releases being cut.

## 2 · The README and the landing page told two different origin stories (#93, rank 4)

The site opens on `CP.01 · Scattered Customer Information`, quoted from the shipped `.spec/crm-system.json`. The README opened on an invented reporting-dashboard problem and **reused `CP.01` for different content** — so a reader who met both surfaces in sequence, then installed and ran `/live`, was told three things. The README's `CP.01` was also phrased as a constraint (*"Managers must access sales data within 5 seconds"*), which is the shape the methodology's own first rule rejects.

`landing-proof.test.mjs` already tied the landing page to the spec; the README had no such guard, which is how it drifted. It now has the same one — and the decisive mutation proves it derives rather than restates: **renaming `CP.01` in `.spec/crm-system.json` now turns both surfaces red instead of neither.**

## 3 · A moderate XSS sat in the canvas dev tree (#93, rank 2)

[GHSA-33vc-wfww-vjfv](https://github.com/advisories/GHSA-33vc-wfww-vjfv) reaches the tree only via `ai@4 → jsondiffpatch@0.6.0`. `npm audit fix --force` resolves it by installing **`ai@7.0.47`** — a breaking change across a major line that `tests/skill-behavior/providers.mjs` already documents as different (*"this repo installs `ai` v4 … the tool/loop API differs"*). Those suites are provider-gated and skip without API keys, so a migration done here **could not be executed** — and shipping an unverified migration is the failure mode this repository's issues keep naming.

An `overrides` pin fixes the advisory without touching the SDK surface: audit goes from 5 findings (2 moderate) to **4 low**, `jsondiffpatch` resolves at 0.7.6, and `generateText`/`tool` still load on the v4 API. The four remaining low findings all require that migration and are left for a deliberate change.

`evals/tests/dependency-pins.test.mjs` keeps the pin honest. `npm audit` needs a network and a registry that moves, so it cannot gate CI; what *is* deterministic is whether the fix is still applied. The guard reads the two files npm writes and requires every declared override to be what the lockfile actually resolved.

> The lockfile also picks up the pre-existing `1.1.0 → 1.1.1` version sync, which npm rewrites from `package.json`. PR #83 resets both to `1.1.0`; this only makes the lockfile agree with the manifest as `main` has it today.

---

## Verification

| Check | Result |
|---|---|
| Skill evals | **372/372** (+22) |
| Canvas extension | **265/265** |
| Canvas e2e (Playwright) | **41/41** |
| Plugin validation | clean |
| Coverage, all three suites | **100%** lines / branches / functions |
| Negative tests | **27/27 mutations caught** |

Every assertion was proven capable of failing by mutating a **real tracked file** — not a fixture — confirming red, then restoring. `git status` clean after each run.

## What this PR deliberately does not do

| Issue | Why not |
|---|---|
| #86, #87, #88 — land PRs #84/#83/#85 | merge actions |
| #89, #90 — cut plugin `v2.6` / canvas `v1.1.1` | release actions; #89 depends on #86–#88 |
| #91 — re-submit the skills.sh listing | third-party surface, no repository half left |
| #93 rank 5 — clean-VM install | needs a machine, not a diff |

Scope is disjoint from the three open PRs: #83/#84/#85 touch `.github/copilot-instructions.md`, `check-distribution.mjs`, `release-hygiene.test.mjs`, `distribution-drift.test.mjs`, the workflows, and `VERSION`. **None touches `README.md`, `agents/`, or `landing-proof.test.mjs`.** `CHANGELOG.md` and the canvas `package.json` overlap; both are additive here.

Also untouched on purpose: `docs/index.html` (already defers to the README for install methods), `docs/skills-health.*` (a snapshot from a feature branch would not reflect `main`), and `skills/` (would require re-running `sync-skills.mjs`).

Closes nothing. **Do not merge without review.**