### PR TITLE
feat: Drive the canvas from the published archive, not the checkout (#90)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,35 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **The canvas can now be driven from a published release archive**
+  (`evals/tools/open-archive-canvas.mjs`). Every proof of `/live` ran against this
+  repository: `serve-canvas.mjs` renders out of `lib/`, `visual.test.mjs` points at the
+  server it starts, and `from-archive-install.test.mjs` — the one place that stages a real
+  archive — kept the boot sequence sealed inside a `node --test` file. Nothing could hand a
+  browser a URL backed by the artefact a user downloads, so the screenshot #90 asks for could
+  not be taken at all. The tool installs a host-SDK stub and nothing else (no `npm install`,
+  matching the archive's no-`node_modules`/no-lockfile contract), loads `extension.mjs` from
+  the extracted tree, opens the canvas and prints the loopback URL — stdout carries the URL
+  and nothing else, so it feeds `CANVAS_URL` directly and `playwright.config.mjs` then starts
+  no canvas server of its own.
+  - It **refuses any path under `.github/`**, which is the assertion that gives the evidence
+    its value: aimed at `.github/extensions/srs-navigator/` it would boot happily,
+    `extension.mjs` would switch to in-repo mode and resolve the methodology from `skills/`,
+    Playwright would go green — and the capture filed as published-archive evidence would be
+    the checkout. Presence standing in for function is the substitution #69 kept making; a
+    tool that can prove the wrong thing silently makes it cheaper.
+  - By default it passes the archive's **own** `lib/demo-spec.mjs` explicitly rather than
+    letting the extension fall through to its "no spec found" path, which lays a landing
+    overlay over the same graph and swallows the health-bar clicks `visual.test.mjs` makes —
+    an archive-driven run would have failed on the overlay and read as a `/live` regression.
+    `--landing` captures that first-run state deliberately.
+  - `evals/tests/from-archive-install.test.mjs` now imports the stub from the tool instead of
+    keeping its own copy, so the two cannot drift; `archive-canvas-tool.test.mjs` (21 tests)
+    fails if the duplicate comes back, if the `.github` refusal is weakened, if the CLI
+    prints anything but the URL, or if the Playwright config stops honouring `CANVAS_URL`.
+
 ### Fixed
 
 - **The changelog linked release tags the pipeline never creates.** `[2.6.0]` and `[2.5.0]`

--- a/evals/README.md
+++ b/evals/README.md
@@ -59,6 +59,14 @@ Pure `node --test` files with no external dependencies:
   both distribution paths — the `skills.sh` listing and the SRS Navigator canvas
   extension — are documented on the README **and** the landing page. A published
   page that nothing links to is a claim nobody can check.
+- `tests/archive-canvas-tool.test.mjs` — guards `tools/open-archive-canvas.mjs`, the tool
+  that boots the canvas out of an **extracted release archive** so a browser can be
+  pointed at the artefact a user downloads. Its most important assertion is a
+  **refusal**: aimed at `.github/extensions/srs-navigator/` the tool would start fine and
+  Playwright would go green, but the capture would be the repository checkout filed as
+  published-archive evidence. It also pins the CLI contract (one loopback URL on stdout,
+  nothing else) and that `playwright.config.mjs` skips its own canvas server when
+  `CANVAS_URL` is set.
 - `tests/release-hygiene.test.mjs` — ties `.claude-plugin/plugin.json`, the top
   `CHANGELOG.md` section, and every version a visitor is shown together, and keeps
   the plugin (`vX.Y`) and canvas (`vX.Y.Z`) release trains from being confused for
@@ -163,6 +171,43 @@ pwsh run-tests.ps1 -IncludeLiveEvals       # + node evals/run-evals.mjs (copilot
 
 `evals/scripts/run-evals.ps1` runs the live evals on their own.
 
+## Driving the canvas from a published release archive
+
+Every other proof of `/live` renders out of this repository. `tools/open-archive-canvas.mjs`
+is the one that does not: give it a directory an **extracted release archive** unpacks to and
+it installs a stub of the host SDK (nothing else — no `npm install`), loads `extension.mjs`
+from that tree, opens the canvas, and prints the loopback URL. Nothing else goes to stdout,
+so the URL composes straight into `CANVAS_URL`.
+
+```bash
+gh release download v1.1.1 -p 'srs-navigator-*.zip' -D /tmp/canvas-archive
+unzip -q /tmp/canvas-archive/srs-navigator-1.1.1.zip -d /tmp/ext
+node evals/tools/open-archive-canvas.mjs /tmp/ext/srs-navigator
+```
+
+Then point the visual suite at that URL instead of the repo dev server — with `CANVAS_URL`
+set, `playwright.config.mjs` starts no canvas server of its own, so the screenshots in
+`test-results/` come from the published artefact:
+
+```bash
+CANVAS_URL=http://127.0.0.1:PORT/ npm --prefix .github/extensions/srs-navigator run test:e2e
+```
+
+```powershell
+$env:CANVAS_URL = "http://127.0.0.1:PORT/"
+npm --prefix .github/extensions/srs-navigator run test:e2e
+```
+
+It refuses a path under `.github/`. That is the whole point: `extension.mjs` treats such a
+path as an in-repo project install and resolves the methodology from `skills/` rather than
+from the archive, so a capture taken there proves the checkout renders — not the release.
+
+| Flag | Effect |
+|------|--------|
+| `--spec <file>` | render a specification JSON instead of the archive's bundled demo |
+| `--instance <id>` | canvas instance id (default `open-archive-canvas`) |
+| `--landing` | keep the extension's first-run landing overlay (off by default, because it swallows the health-bar clicks `visual.test.mjs` makes) |
+
 ## The "SDK"
 
 `lib/copilot-sdk.mjs` wraps the `@github/copilot` CLI in headless mode:
@@ -185,6 +230,8 @@ evals/
 │   ├── skills.mjs           # SKILL.md loader/parser
 │   └── graders.mjs          # rubric grading + LLM judge
 ├── tests/                   # deterministic node --test files (offline)
+├── tools/
+│   └── open-archive-canvas.mjs  # boot the canvas from an extracted release archive
 ├── cases/                   # live eval cases (opt-in)
 │   ├── _shared.mjs
 │   └── *.case.mjs

--- a/evals/tests/archive-canvas-tool.test.mjs
+++ b/evals/tests/archive-canvas-tool.test.mjs
@@ -1,0 +1,412 @@
+// The canvas has never been driven from the artefact a user downloads.
+//
+// Every existing proof of `/live` runs against the repository: `serve-canvas.mjs` renders
+// out of `lib/`, `visual.test.mjs` points at the server that script starts, and
+// `from-archive-install.test.mjs` — which does stage a real archive — keeps the whole
+// sequence locked inside a `node --test` file as a private helper. So the one thing #90
+// asks for, *"Playwright screenshots prove the graph renders from the extracted published
+// archive"*, had no way to happen: nothing outside the test runner could produce a URL
+// pointing at an archive-booted canvas.
+//
+// `evals/tools/open-archive-canvas.mjs` is that missing half. This suite is what makes it
+// trustworthy, and the assertion that matters most is not "it boots" — it is **that it
+// refuses to boot the wrong thing**. Point the tool at `.github/extensions/srs-navigator/`
+// and it would start happily, Playwright would go green, and the PNG attached to #90 as
+// *published-archive evidence* would be the monorepo checkout, complete with its
+// `node_modules` and its in-repo skill path. That is the same defect #69 kept re-committing
+// under a different name: presence standing in for function. A tool that can prove the wrong
+// thing silently is worse than no tool, so the refusal is tested before the success.
+import { describe, it, before, after } from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { spawn } from "node:child_process";
+import { fileURLToPath } from "node:url";
+
+import { stage } from "../../scripts/package-extension.mjs";
+import {
+  openArchiveCanvas,
+  installHostStub,
+  assertExtractedArchive,
+  HOST_SDK_PACKAGE,
+} from "../tools/open-archive-canvas.mjs";
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(here, "../..");
+const TOOL = path.join(repoRoot, "evals", "tools", "open-archive-canvas.mjs");
+const EXT_DIR = path.join(repoRoot, ".github", "extensions", "srs-navigator");
+
+/** The canonical chain the demo spec ships; #90 requires it visible in the rendered graph. */
+const CANONICAL_CHAIN = ["CP.01", "CN.01.1", "FR.01.1.1", "NFR.01"];
+
+/** Node ids the renderer embedded in the served page. */
+function renderedIds(html) {
+  return [...new Set([...html.matchAll(/"id":"((?:CP|CN|FR|NFR)\.[0-9.]+)"/g)].map((m) => m[1]))];
+}
+
+/** Stage a real archive into a temp directory that cannot be mistaken for the checkout. */
+function stageArchive(prefix) {
+  const tmp = fs.mkdtempSync(path.join(fs.realpathSync(os.tmpdir()), prefix));
+  const dir = stage(tmp);
+  assert.ok(
+    !dir.split(path.sep).includes(".github"),
+    `staging root ${dir} looks like a project install; this suite would test the checkout`,
+  );
+  return { tmp, dir };
+}
+
+/* ------------------------------------------------------- it refuses to prove the wrong thing */
+
+describe("open-archive-canvas refuses anything that is not an extracted archive", () => {
+  it("rejects the monorepo checkout, naming what the run would have proven", () => {
+    let error;
+    try {
+      assertExtractedArchive(EXT_DIR);
+    } catch (e) {
+      error = e;
+    }
+    assert.ok(
+      error,
+      "pointing the tool at .github/extensions/srs-navigator must fail. extension.mjs " +
+        'switches to in-repo mode on `__dirname.includes(".github")`, so booting it there ' +
+        "renders the checkout — and a screenshot of the checkout attached as published-" +
+        "archive evidence is exactly the substitution #69 kept making.",
+    );
+    assert.match(
+      error.message,
+      /\.github/,
+      "the error must name the condition that triggered it so it is actionable",
+    );
+    assert.match(
+      error.message,
+      /checkout|repositor/i,
+      "the error must say the run would have proven the checkout, not the published archive",
+    );
+  });
+
+  it("rejects a path that does not exist", () => {
+    const missing = path.join(os.tmpdir(), "pbsrs-does-not-exist-ever");
+    assert.throws(
+      () => assertExtractedArchive(missing),
+      (e) => e.message.includes(missing),
+      "the error must name the path the caller passed",
+    );
+  });
+
+  it("rejects a directory with no extension.mjs, and says where to point instead", () => {
+    const tmp = fs.mkdtempSync(path.join(fs.realpathSync(os.tmpdir()), "pbsrs-empty-"));
+    try {
+      let error;
+      try {
+        assertExtractedArchive(tmp);
+      } catch (e) {
+        error = e;
+      }
+      assert.ok(error, "a directory without extension.mjs is not an extracted archive");
+      assert.match(error.message, /extension\.mjs/);
+      assert.match(
+        error.message,
+        /srs-navigator/,
+        "the archive carries its own srs-navigator/ root, so the commonest mistake is " +
+          "pointing at the extract target rather than the directory inside it — say so",
+      );
+    } finally {
+      fs.rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+
+  it("accepts a genuinely extracted archive", () => {
+    const { tmp, dir } = stageArchive("pbsrs-accept-");
+    try {
+      assert.equal(assertExtractedArchive(dir), fs.realpathSync(dir));
+    } finally {
+      fs.rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+});
+
+/* ------------------------------------------------------------ it boots the published shape */
+
+describe("open-archive-canvas serves the graph out of an extracted archive", () => {
+  let tmp;
+  let dir;
+  let opened;
+  let html;
+
+  before(async () => {
+    ({ tmp, dir } = stageArchive("pbsrs-open-"));
+    opened = await openArchiveCanvas(dir, { instanceId: "archive-canvas-tool" });
+    html = await (await fetch(opened.url)).text();
+  });
+
+  after(async () => {
+    await opened?.close();
+    fs.rmSync(tmp, { recursive: true, force: true });
+  });
+
+  it("returns a loopback URL Playwright can be pointed at", () => {
+    assert.match(
+      opened.url,
+      /^http:\/\/127\.0\.0\.1:\d+\/$/,
+      "CANVAS_URL is consumed verbatim by playwright.config.mjs; anything else is unusable",
+    );
+  });
+
+  it("renders the graph itself, not merely a page that returned 200", () => {
+    assert.match(html, /<svg|d3\./);
+    for (const id of CANONICAL_CHAIN) {
+      assert.ok(html.includes(id), `the served page is missing ${id}`);
+    }
+  });
+
+  it("renders the whole demo spec the visual suite counts", () => {
+    assert.equal(
+      renderedIds(html).length,
+      29,
+      "visual.test.mjs asserts 29 rendered nodes. If the archive serves a different graph, " +
+        "an archive-driven Playwright run fails for a reason that has nothing to do with /live",
+    );
+  });
+
+  it("renders zero legacy hyphen identifiers", () => {
+    assert.deepEqual(
+      [...new Set(html.match(/\b(?:CP|CN|FR|NFR)-\d+/g) ?? [])],
+      [],
+      "#90 requires the archive-driven capture to show canonical dotted IDs only",
+    );
+  });
+
+  it("does not raise the first-run landing overlay over the graph", () => {
+    assert.match(
+      html,
+      /showLandingOnLoad\s*=\s*false/,
+      "opened with no input the extension finds no .spec/ folder and lays a landing overlay " +
+        "over the demo graph. visual.test.mjs clicks the health bar, the overlay swallows " +
+        "those clicks, and an archive-driven run would fail as if /live had regressed. The " +
+        "tool therefore passes the archive's own lib/demo-spec.mjs explicitly — still " +
+        "entirely from the archive, but rendered through the same path serve-canvas.mjs uses.",
+    );
+  });
+
+  it("can still capture that first-run view when asked for it", async () => {
+    const first = await openArchiveCanvas(dir, {
+      instanceId: "archive-canvas-landing",
+      landing: true,
+    });
+    try {
+      const page = await (await fetch(first.url)).text();
+      assert.match(page, /showLandingOnLoad\s*=\s*true/);
+    } finally {
+      await first.close();
+    }
+  });
+
+  it("needs no npm install: the only thing added is the host SDK stub", () => {
+    const modules = path.join(dir, "node_modules");
+    const scoped = HOST_SDK_PACKAGE.split("/");
+    assert.deepEqual(fs.readdirSync(modules), [scoped[0]]);
+    assert.deepEqual(fs.readdirSync(path.join(modules, scoped[0])), [scoped[1]]);
+  });
+
+  it("renders a caller-supplied specification when one is given", async () => {
+    const spec = {
+      name: "Archive Tool Spec",
+      version: "1.0",
+      problems: [{ id: "CP.01", title: "Scattered Customer Information", description: "d" }],
+      needs: [
+        {
+          id: "CN.01.1",
+          title: "Centralized Customer Database",
+          description: "d",
+          problemIds: ["CP.01"],
+        },
+      ],
+      functionalRequirements: [
+        {
+          id: "FR.01.1.1",
+          title: "Contact and Company Management",
+          description: "d",
+          needIds: ["CN.01.1"],
+        },
+      ],
+      nonFunctionalRequirements: [],
+    };
+    const custom = await openArchiveCanvas(dir, { instanceId: "archive-canvas-spec", spec });
+    try {
+      const page = await (await fetch(custom.url)).text();
+      assert.ok(page.includes("Archive Tool Spec"));
+      assert.ok(page.includes("FR.01.1.1"));
+    } finally {
+      await custom.close();
+    }
+  });
+
+  it("releases the port when closed, so a capture run leaves nothing listening", async () => {
+    const short = await openArchiveCanvas(dir, { instanceId: "archive-canvas-close" });
+    await short.close();
+    await assert.rejects(() => fetch(short.url));
+  });
+});
+
+/* ------------------------------------------------------------------------- the CLI contract */
+
+describe("the open-archive-canvas CLI", () => {
+  let tmp;
+  let dir;
+
+  before(() => ({ tmp, dir } = stageArchive("pbsrs-cli-")));
+  after(() => fs.rmSync(tmp, { recursive: true, force: true }));
+
+  /** Run the CLI, exposing its streams and a lazily-awaited first stdout line. */
+  function runCli(args) {
+    const child = spawn(process.execPath, [TOOL, ...args], { cwd: repoRoot });
+    let out = "";
+    let err = "";
+    let exited = null;
+    child.stdout.on("data", (d) => (out += d));
+    child.stderr.on("data", (d) => (err += d));
+    child.on("exit", (code) => (exited = code));
+
+    // Created on demand: a promise built up front would still be pending when the
+    // bad-path test ends, and its rejection would surface as an unhandledRejection.
+    const firstLine = () =>
+      new Promise((resolve, reject) => {
+        const timer = setTimeout(
+          () => reject(new Error(`no stdout line in 30s. stderr:\n${err}`)),
+          30000,
+        );
+        const check = () => {
+          const nl = out.indexOf("\n");
+          if (nl === -1) return false;
+          clearTimeout(timer);
+          resolve(out.slice(0, nl).trim());
+          return true;
+        };
+        if (check()) return;
+        child.stdout.on("data", check);
+        child.on("exit", (code) => {
+          clearTimeout(timer);
+          reject(new Error(`exited ${code} before printing a URL. stderr:\n${err}`));
+        });
+      });
+
+    return {
+      child,
+      firstLine,
+      stdout: () => out,
+      stderr: () => err,
+      exit: () =>
+        exited !== null ? Promise.resolve(exited) : new Promise((r) => child.on("exit", r)),
+    };
+  }
+
+  it("prints exactly one loopback URL on stdout and keeps serving", async () => {
+    const cli = runCli([dir]);
+    try {
+      const url = await cli.firstLine();
+      assert.match(
+        url,
+        /^http:\/\/127\.0\.0\.1:\d+\/$/,
+        "the documented usage is CANVAS_URL=$(node evals/tools/open-archive-canvas.mjs …), " +
+          "so stdout must carry the URL and nothing else",
+      );
+      const page = await (await fetch(url)).text();
+      assert.ok(page.includes("FR.01.1.1"), "the process must still be serving after it prints");
+      assert.equal(
+        cli.stdout().trim(),
+        url,
+        "stdout must carry the URL and nothing else, or command substitution captures noise",
+      );
+    } finally {
+      cli.child.kill();
+      await cli.exit();
+    }
+  });
+
+  it("exits non-zero with a diagnostic when pointed somewhere unusable", async () => {
+    const bogus = path.join(os.tmpdir(), "pbsrs-cli-nowhere");
+    const cli = runCli([bogus]);
+    const code = await cli.exit();
+    assert.notEqual(code, 0, "a silent success on a bad path would produce empty evidence");
+    assert.match(cli.stderr(), new RegExp(bogus.replace(/[\\^$.*+?()[\]{}|]/g, "\\$&")));
+  });
+});
+
+/* ------------------------------------------- the harness the tool is meant to plug into */
+
+describe("the archive-driven capture is actually wired to Playwright", () => {
+  const config = fs.readFileSync(path.join(EXT_DIR, "playwright.config.mjs"), "utf8");
+  const visual = fs.readFileSync(path.join(EXT_DIR, "tests", "visual.test.mjs"), "utf8");
+
+  it("lets CANVAS_URL choose the target", () => {
+    assert.match(config, /process\.env\.CANVAS_URL/);
+    assert.match(visual, /process\.env\.CANVAS_URL/);
+  });
+
+  it("does not start its own canvas server when CANVAS_URL is set", () => {
+    assert.match(
+      config,
+      /if\s*\(!process\.env\.CANVAS_URL\)/,
+      "if the config started serve-canvas.mjs anyway, an archive-driven run would race the " +
+        "repo checkout for the port and could screenshot the checkout instead",
+    );
+  });
+});
+
+/* --------------------------------------------------- the tool is the sequence, not a copy */
+
+describe("the tool is the extraction the from-archive suite already proves", () => {
+  const suite = fs.readFileSync(path.join(here, "from-archive-install.test.mjs"), "utf8");
+
+  it("supplies the host SDK stub that suite installs", () => {
+    assert.match(
+      suite,
+      /from\s+"\.\.\/tools\/open-archive-canvas\.mjs"/,
+      "from-archive-install.test.mjs must import the stub from the tool. Two copies of the " +
+        "clean-machine boot sequence means the tool can drift from the one that is proven, " +
+        "and the drift would show up only in evidence nobody re-checks.",
+    );
+    assert.doesNotMatch(
+      suite,
+      /^\s*function\s+installHostStub\b/m,
+      "the local copy of installHostStub must be gone, not merely unused",
+    );
+  });
+
+  it("stubs only the host SDK, so the archive must supply everything else", () => {
+    const tmp = fs.mkdtempSync(path.join(fs.realpathSync(os.tmpdir()), "pbsrs-stub-"));
+    try {
+      installHostStub(tmp);
+      const pkg = JSON.parse(
+        fs.readFileSync(path.join(tmp, "node_modules", HOST_SDK_PACKAGE, "package.json"), "utf8"),
+      );
+      assert.equal(pkg.name, HOST_SDK_PACKAGE);
+      assert.deepEqual(fs.readdirSync(path.join(tmp, "node_modules")), ["@github"]);
+    } finally {
+      fs.rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+});
+
+/* ------------------------------------------------------------------------- documentation */
+
+describe("the archive-driven verification is documented where the evals are", () => {
+  const readme = fs.readFileSync(path.join(repoRoot, "evals", "README.md"), "utf8");
+
+  it("names the tool by its real path", () => {
+    assert.ok(
+      readme.includes("evals/tools/open-archive-canvas.mjs"),
+      "evals/README.md must document the archive-driven run. Naming it there also puts it " +
+        "under evals-readme.test.mjs, which fails if the path stops existing.",
+    );
+  });
+
+  it("says what it is for, not just how to type it", () => {
+    assert.match(
+      readme,
+      /published|release archive/i,
+      "the point of the tool is that the capture comes from the published artefact",
+    );
+  });
+});

--- a/evals/tests/from-archive-install.test.mjs
+++ b/evals/tests/from-archive-install.test.mjs
@@ -28,6 +28,7 @@ import { pathToFileURL } from "node:url";
 import { fileURLToPath } from "node:url";
 
 import { ARCHIVE_ROOT, installManifest, stage } from "../../scripts/package-extension.mjs";
+import { installHostStub } from "../tools/open-archive-canvas.mjs";
 
 const here = path.dirname(fileURLToPath(import.meta.url));
 const repoRoot = path.resolve(here, "../..");
@@ -79,38 +80,12 @@ export function packageOf(specifier) {
  * Write the smallest possible stand-in for the host SDK into the staged tree's own
  * node_modules, and nothing else. It records the session config the extension registers so
  * the test can drive the same canvas and tool the Copilot app would.
+ *
+ * Lives in `evals/tools/open-archive-canvas.mjs` now, so the tool that boots the canvas for
+ * an archive-driven Playwright capture (#90) and this suite share one boot sequence. Two
+ * copies would let the tool drift from the path this suite proves, and the drift would only
+ * ever show up in evidence nobody re-checks.
  */
-function installHostStub(stagedDir) {
-  const dir = path.join(stagedDir, "node_modules", "@github", "copilot-sdk");
-  fs.mkdirSync(dir, { recursive: true });
-  fs.writeFileSync(
-    path.join(dir, "package.json"),
-    JSON.stringify({
-      name: "@github/copilot-sdk",
-      version: "0.0.0-test-stub",
-      type: "module",
-      exports: { "./extension": "./extension.mjs" },
-    }),
-  );
-  fs.writeFileSync(
-    path.join(dir, "extension.mjs"),
-    [
-      "globalThis.__srsHostCapture = { tools: [], canvases: [], events: [] };",
-      "export class CanvasError extends Error {",
-      "  constructor(code, message) { super(message); this.code = code; }",
-      "}",
-      "export function createCanvas(definition) { return definition; }",
-      "export async function joinSession(config) {",
-      "  globalThis.__srsHostCapture.tools = config.tools || [];",
-      "  globalThis.__srsHostCapture.canvases = config.canvases || [];",
-      "  return {",
-      "    on(event) { globalThis.__srsHostCapture.events.push(event); },",
-      "    log() {}, send() {}, workspacePath: '',",
-      "  };",
-      "}",
-    ].join("\n"),
-  );
-}
 
 /* --------------------------------------------------- the install, actually installed */
 

--- a/evals/tools/open-archive-canvas.mjs
+++ b/evals/tools/open-archive-canvas.mjs
@@ -1,0 +1,300 @@
+#!/usr/bin/env node
+// Boot the SRS Navigator canvas out of an **extracted release archive** and print the
+// loopback URL it serves on, so Playwright can be pointed at the artefact a user actually
+// downloads instead of at this repository.
+//
+// Why this exists (issue #90). Every proof of `/live` we had ran against the checkout:
+// `scripts/serve-canvas.mjs` renders straight out of `lib/`, `tests/visual.test.mjs` points
+// at the server that script starts, and `evals/tests/from-archive-install.test.mjs` — the
+// one place that does stage a real archive — keeps the boot sequence sealed inside a
+// `node --test` file. Nothing could hand a *published-archive* URL to a browser, so the
+// screenshot #90 asks for could not be taken. This is that sequence, lifted out and given a
+// CLI. `from-archive-install.test.mjs` imports the stub from here rather than keeping a
+// second copy, so the tool cannot drift from the boot path that suite proves.
+//
+// The guard is the point. Aimed at `.github/extensions/srs-navigator/` this would start
+// perfectly well — `extension.mjs` switches to in-repo mode on `__dirname.includes(".github")`
+// — Playwright would go green, and the PNG filed as published-archive evidence would be the
+// checkout. `assertExtractedArchive()` refuses that outright, because evidence that proves
+// the wrong thing is worse than none.
+//
+// Usage:
+//   node evals/tools/open-archive-canvas.mjs <extracted-archive-dir> [options]
+//
+//   --spec <file>      render this specification JSON instead of the archive's demo
+//   --instance <id>    canvas instance id (default: open-archive-canvas)
+//   --landing          keep the extension's "no spec found" landing overlay
+//
+// The URL is the only thing written to stdout, so this composes:
+//   CANVAS_URL=$(node evals/tools/open-archive-canvas.mjs /tmp/ext/srs-navigator)
+
+import fs from "node:fs";
+import path from "node:path";
+import { pathToFileURL } from "node:url";
+
+/** The single bare specifier the Copilot app injects; everything else must be in the archive. */
+export const HOST_SDK_PACKAGE = "@github/copilot-sdk";
+
+/** The canvas `/live` opens, and the directory the archive unpacks into. */
+export const CANVAS_ID = "srs-navigator";
+
+/** Fresh module graph per call, so a second open on the same directory really re-registers. */
+let importCounter = 0;
+
+/**
+ * Reject anything that is not an extracted archive, and return its real path.
+ *
+ * The `.github` rule is not a stylistic preference: it is the exact condition
+ * `extension.mjs` uses to decide it is a project install and resolve the methodology from
+ * `<repoRoot>/skills/` instead of the archive's own bundled copies. A canvas booted there is
+ * the repository, not the release.
+ *
+ * @param {string} dir directory the archive was extracted to (the `srs-navigator/` one)
+ * @returns {string} the resolved real path
+ */
+export function assertExtractedArchive(dir) {
+  if (!dir) throw new Error("open-archive-canvas: no archive directory given");
+  const resolved = path.resolve(dir);
+
+  if (!fs.existsSync(resolved)) {
+    throw new Error(
+      `open-archive-canvas: no such directory: ${resolved}\n` +
+        "Download and extract the release archive first, then point at the " +
+        `${CANVAS_ID}/ directory inside it.`,
+    );
+  }
+  if (!fs.statSync(resolved).isDirectory()) {
+    throw new Error(`open-archive-canvas: not a directory: ${resolved}`);
+  }
+
+  const real = fs.realpathSync(resolved);
+  if (real.split(path.sep).includes(".github")) {
+    throw new Error(
+      `open-archive-canvas: refusing to boot from ${real}\n` +
+        'This path sits under a ".github" directory, which is precisely the condition ' +
+        "extension.mjs uses to treat itself as an in-repo project install (it then resolves " +
+        "the methodology from the repository instead of the archive). Driving it would prove " +
+        "the repository checkout renders, not the published archive — and a capture taken " +
+        "here would be filed as evidence for something it never touched.\n" +
+        "Extract the release archive outside the repository and point at the " +
+        `${CANVAS_ID}/ directory it contains.`,
+    );
+  }
+
+  if (!fs.existsSync(path.join(real, "extension.mjs"))) {
+    throw new Error(
+      `open-archive-canvas: ${real} contains no extension.mjs, so it is not an extracted ` +
+        `archive.\nThe archive carries its own ${CANVAS_ID}/ root, so extracting it to ` +
+        `/tmp/ext gives you /tmp/ext/${CANVAS_ID} — point at that, not at its parent.`,
+    );
+  }
+
+  return real;
+}
+
+/**
+ * Write the smallest possible stand-in for the host SDK into a tree's own `node_modules`,
+ * and nothing else. It records the session config the extension registers, so a caller can
+ * drive the same canvas and tool the Copilot app would.
+ *
+ * Nothing else is installed on purpose: whatever the extension needs beyond this has to come
+ * out of the archive or the import throws, which is the clean-machine condition expressed as
+ * code. The archive ships no `node_modules` and no lockfile, so an install step here would
+ * quietly re-create the very tree the packaging work removed.
+ *
+ * @param {string} extensionDir the extracted archive directory
+ * @returns {string} path to the installed stub package
+ */
+export function installHostStub(extensionDir) {
+  const dir = path.join(extensionDir, "node_modules", ...HOST_SDK_PACKAGE.split("/"));
+  fs.mkdirSync(dir, { recursive: true });
+  fs.writeFileSync(
+    path.join(dir, "package.json"),
+    JSON.stringify({
+      name: HOST_SDK_PACKAGE,
+      version: "0.0.0-test-stub",
+      type: "module",
+      exports: { "./extension": "./extension.mjs" },
+    }),
+  );
+  fs.writeFileSync(
+    path.join(dir, "extension.mjs"),
+    [
+      // Every registration is kept, so repeat imports (a second canvas from the same
+      // directory) do not read the previous one's canvases. `__srsHostCapture` stays as the
+      // most recent session for callers that only ever import once.
+      "globalThis.__srsArchiveHostSessions ||= [];",
+      "export class CanvasError extends Error {",
+      "  constructor(code, message) { super(message); this.code = code; }",
+      "}",
+      "export function createCanvas(definition) { return definition; }",
+      "export async function joinSession(config) {",
+      "  const session = {",
+      "    tools: config.tools || [],",
+      "    canvases: config.canvases || [],",
+      "    events: [],",
+      "  };",
+      "  globalThis.__srsArchiveHostSessions.push(session);",
+      "  globalThis.__srsHostCapture = session;",
+      "  return {",
+      "    on(event) { session.events.push(event); },",
+      "    log() {}, send() {}, workspacePath: '',",
+      "  };",
+      "}",
+    ].join("\n"),
+  );
+  return dir;
+}
+
+/** Load the extension from the archive and return the session the host stub captured. */
+async function loadExtension(extensionDir) {
+  installHostStub(extensionDir);
+
+  // A workspace path would send the extension looking for `.spec/` outside the archive, so
+  // the graph could come from whatever directory the tool happened to be run in.
+  const saved = process.env.COPILOT_WORKSPACE_PATH;
+  delete process.env.COPILOT_WORKSPACE_PATH;
+  try {
+    const entry = pathToFileURL(path.join(extensionDir, "extension.mjs")).href;
+    await import(`${entry}?openArchiveCanvas=${++importCounter}`);
+  } finally {
+    if (saved === undefined) delete process.env.COPILOT_WORKSPACE_PATH;
+    else process.env.COPILOT_WORKSPACE_PATH = saved;
+  }
+
+  const sessions = globalThis.__srsArchiveHostSessions ?? [];
+  const session = sessions[sessions.length - 1];
+  if (!session) {
+    throw new Error(
+      `open-archive-canvas: importing ${extensionDir}/extension.mjs never reached ` +
+        "joinSession — the archive is missing something it needs to load.",
+    );
+  }
+  return session;
+}
+
+/**
+ * Open the canvas from an extracted archive and return its URL.
+ *
+ * With no specification the archive's **own** `lib/demo-spec.mjs` is passed explicitly
+ * rather than letting the extension fall through to its "no spec found" path. That path
+ * renders the same demo graph but lays a landing overlay over it, which swallows the clicks
+ * `tests/visual.test.mjs` makes on the health bar — so an archive-driven Playwright run
+ * would fail on the overlay and read as a `/live` regression. Pass `landing: true` to
+ * capture that first-run state deliberately.
+ *
+ * @param {string} dir extracted archive directory
+ * @param {{spec?: object, specPath?: string, instanceId?: string, landing?: boolean}} [options]
+ * @returns {Promise<{url: string, close: () => Promise<void>, canvas: object,
+ *                    instanceId: string, extensionDir: string, specName: string|null}>}
+ */
+export async function openArchiveCanvas(dir, options = {}) {
+  const { specPath, instanceId = "open-archive-canvas", landing = false } = options;
+  const extensionDir = assertExtractedArchive(dir);
+  const session = await loadExtension(extensionDir);
+
+  const canvas = session.canvases.find((c) => c.id === CANVAS_ID);
+  if (!canvas) {
+    throw new Error(
+      `open-archive-canvas: the archive registered no "${CANVAS_ID}" canvas; registered: ` +
+        `${session.canvases.map((c) => c.id).join(", ") || "(none)"}`,
+    );
+  }
+
+  let spec = options.spec ?? null;
+  if (!spec && specPath) {
+    spec = JSON.parse(fs.readFileSync(path.resolve(specPath), "utf8"));
+  }
+  if (!spec && !landing) {
+    const demo = pathToFileURL(path.join(extensionDir, "lib", "demo-spec.mjs")).href;
+    ({ DEMO_SPEC: spec } = await import(demo));
+  }
+
+  const result = await canvas.open({
+    instanceId,
+    input: spec ? { specification: spec } : {},
+  });
+
+  return {
+    url: result.url,
+    title: result.title,
+    specName: spec?.name ?? null,
+    canvas,
+    instanceId,
+    extensionDir,
+    close: async () => {
+      try {
+        await canvas.onClose({ instanceId });
+      } catch {
+        /* already closed */
+      }
+    },
+  };
+}
+
+/* --------------------------------------------------------------------------------- CLI */
+
+function parseArgs(argv) {
+  const out = { dir: null, specPath: null, instanceId: undefined, landing: false };
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i];
+    if (arg === "--spec") out.specPath = argv[++i];
+    else if (arg === "--instance") out.instanceId = argv[++i];
+    else if (arg === "--landing") out.landing = true;
+    else if (arg === "--help" || arg === "-h") out.help = true;
+    else if (arg.startsWith("-")) throw new Error(`open-archive-canvas: unknown option ${arg}`);
+    else if (!out.dir) out.dir = arg;
+    else throw new Error(`open-archive-canvas: unexpected argument ${arg}`);
+  }
+  return out;
+}
+
+const USAGE = `Usage: node evals/tools/open-archive-canvas.mjs <extracted-archive-dir> [options]
+
+  --spec <file>     render this specification JSON instead of the archive's demo
+  --instance <id>   canvas instance id (default: open-archive-canvas)
+  --landing         keep the extension's "no spec found" landing overlay
+
+Prints the loopback URL on stdout and keeps serving until interrupted, so:
+  CANVAS_URL=$(node evals/tools/open-archive-canvas.mjs /tmp/ext/srs-navigator)`;
+
+async function main() {
+  const opts = parseArgs(process.argv.slice(2));
+  if (opts.help || !opts.dir) {
+    process.stderr.write(`${USAGE}\n`);
+    process.exit(opts.help ? 0 : 1);
+  }
+
+  const opened = await openArchiveCanvas(opts.dir, {
+    specPath: opts.specPath,
+    instanceId: opts.instanceId,
+    landing: opts.landing,
+  });
+
+  // stdout carries the URL and nothing else; everything human goes to stderr.
+  process.stdout.write(`${opened.url}\n`);
+  process.stderr.write(
+    `SRS Navigator canvas serving ${opened.specName ?? "the archive's first-run view"} ` +
+      `from ${opened.extensionDir}\nPress Ctrl+C to stop.\n`,
+  );
+
+  let closing = false;
+  const shutdown = async () => {
+    if (closing) return;
+    closing = true;
+    await opened.close();
+    process.exit(0);
+  };
+  process.on("SIGINT", shutdown);
+  process.on("SIGTERM", shutdown);
+}
+
+const invokedDirectly =
+  process.argv[1] && pathToFileURL(path.resolve(process.argv[1])).href === import.meta.url;
+
+if (invokedDirectly) {
+  main().catch((error) => {
+    process.stderr.write(`${error.message}\n`);
+    process.exit(1);
+  });
+}


### PR DESCRIPTION
Closes nothing on its own — this is the **tooling half** of #90 [5/7]. The publish half
(dispatch `release-canvas.yml`, cut `v1.1.1`) is a maintainer action gated on #87 and stays
unticked.

## Why this issue, and why now

The sequenced plan is #86 [1/7] → #92 [7/7]. Steps 1–4 are merges and a tag push — actions a
pull request cannot perform — and #91 is a third-party re-submission. **#90 is the first
issue in the sequence that carries work a PR can do**, and the issue says so itself:

> `evals/tools/open-archive-canvas.mjs` does not exist yet … Writing it is part of this issue.

It is also on #92's critical path: that issue's strongest criterion is *"at least one
screenshot comes from the **published** artefact rather than the checkout"*, which was
impossible until this existed.

## The gap

Every proof of `/live` ran against **this repository**. `scripts/serve-canvas.mjs` renders
straight out of `lib/`, `tests/visual.test.mjs` points at the server that script starts, and
`evals/tests/from-archive-install.test.mjs` — the one place that does stage a real archive —
keeps the whole boot sequence sealed inside a `node --test` file as a private helper. Nothing
outside the test runner could produce a URL backed by the artefact a user downloads, so the
screenshot #90 asks for could not be taken at all.

`playwright.config.mjs` already honoured `CANVAS_URL` and already skipped its own canvas
server when it was set. The missing half was something that could hand it such a URL.

## What this adds

`evals/tools/open-archive-canvas.mjs` — API + CLI. It installs a host-SDK stub and **nothing
else** (no `npm install`, matching the archive's no-`node_modules`/no-lockfile contract),
loads `extension.mjs` out of the extracted tree, opens the canvas, and prints the loopback
URL. stdout carries the URL and nothing else, so it composes:

```bash
CANVAS_URL=$(node evals/tools/open-archive-canvas.mjs /tmp/ext/srs-navigator)
```

### The refusal is the point

Aimed at `.github/extensions/srs-navigator/` the tool would boot perfectly well —
`extension.mjs` switches to in-repo mode on `__dirname.includes(".github")` and resolves the
methodology from `skills/` instead of the archive — Playwright would go green, and the PNG
filed as *published-archive evidence* would be the checkout. Presence standing in for
function is the substitution #69 kept making; a tool that can prove the wrong thing silently
makes it cheaper. `assertExtractedArchive()` refuses that path outright, and says what the
run would have proven instead.

### One design decision, verified rather than assumed

Opened with no input, the extension finds no `.spec/` folder and lays a **landing overlay**
over the demo graph. The tool therefore passes the archive's *own* `lib/demo-spec.mjs`
explicitly — still entirely from the archive, but through the same render path
`serve-canvas.mjs` uses. I checked what happens without that, rather than asserting it:

```
$ node evals/tools/open-archive-canvas.mjs …/srs-navigator --landing
$ CANVAS_URL=… npx playwright test --project=canvas -g "clicking a health metric filters the graph"
  1 failed
    clicking a health metric filters the graph
    > 218 |       await clusters.click();
    - waiting for element to be visible, enabled and stable
```

The overlay intercepts the click, so an archive-driven run would have failed and read as a
`/live` regression. `--landing` captures that first-run state deliberately when you want it.

### The "thin extraction" the issue specifies

`from-archive-install.test.mjs` now **imports** the host stub from the tool instead of
keeping its own copy, so the tool is provably the same sequence that suite proves rather than
a lookalike that can drift from it. A test fails if the duplicate comes back.

## Evidence — an actual archive, actually driven

```
$ node scripts/package-extension.mjs
Created build/srs-navigator-1.1.1.tar.gz          # 23 entries, 96.4 KB (#90 asks ≤30 / ≤150 KB)
$ tar -xzf build/srs-navigator-1.1.1.tar.gz -C $TEMP/pbsrs-published   # outside the repo
$ node evals/tools/open-archive-canvas.mjs $TEMP/pbsrs-published/srs-navigator
http://127.0.0.1:53101/
SRS Navigator canvas serving CRM System from …\pbsrs-published\srs-navigator

$ CANVAS_URL=http://127.0.0.1:53101/ npx playwright test --project=canvas
  ok 10 … no rendered node label uses legacy hyphen identifiers
  ok 11 … every rendered node label uses canonical dotted identifiers
  ok 12 … the health bar reports 29 nodes, 5 need clusters and 100% traceability
  ok 13 … captures dotted-notation evidence for the /live wow-moment
  22 passed (1.1m)
```

`test-results/live-dotted-notation.png` (383 KB) was produced **from the extracted archive** —
the first time that screenshot has come from the packaged artefact rather than the checkout.
Both identifier assertions #90 names are in that run.

## Suites

| Suite | Result |
|---|---|
| `node --test evals/tests/*.test.mjs` | **371 / 371** (350 + 21 new) |
| `npm test` (canvas) | **265 / 265** |
| `npx playwright test --project=canvas` against the archive | **22 / 22** |
| `python scripts/build-plugin.py validate` | clean |

## Negative-tested

Every new assertion was proven capable of failing by mutating the **real tracked files** and
restoring them:

| Mutation | Guard that fired |
|---|---|
| `.github` refusal removed | rejects the monorepo checkout, naming what the run would have proven |
| missing-directory error stops naming the path | rejects a path that does not exist |
| landing overlay becomes the default | does not raise the first-run landing overlay over the graph |
| CLI prints a banner on stdout too | prints exactly one loopback URL on stdout and keeps serving |
| CLI exits 0 on a bad path | exits non-zero with a diagnostic when pointed somewhere unusable |
| host stub installs a second package | needs no npm install: the only thing added is the host SDK stub |
| from-archive suite re-inlines its own stub | supplies the host SDK stub that suite installs |
| `evals/README.md` stops naming the tool | names the tool by its real path |
| playwright config starts its own canvas server anyway | does not start its own canvas server when `CANVAS_URL` is set |

9 / 9 went red, then green again after restore.

## Conflict surface

Deliberately **zero overlap** with the merge queue #86–#88 describes. This touches
`evals/tools/`, `evals/tests/`, `evals/README.md` and `CHANGELOG.md` only — not
`scripts/check-distribution.mjs`, `.github/copilot-instructions.md`, `VERSION`, or
`create-release.yml`, all of which PRs #83/#84/#85/#94/#95/#96 are contending over. The
`CHANGELOG.md` change is a new `### Added` block at the top of `[Unreleased]`, above the
`### Fixed` entries those PRs edit.

**Not merged** — merge order is #86 → #87 → #88's call, and this is independent of all three.