### PR TITLE
Read the artefacts we ship, instead of trusting them

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -602,7 +602,7 @@ is a notification, not a broken build: it is out of the PR gate on purpose.
 | `unpublishable-release-link` | error | A reference definition **in `CHANGELOG.md`** (the file `build-plugin.py` reads for release notes, so its labels are plugin-train claims) names a tag **no pipeline creates for that version**. `create-release.yml` tags `v${VERSION}` where `VERSION` is `build-plugin.py`'s *normalized* version, so `2.6.0` publishes at `v2.6` — and GitHub serves `/releases/tag/<tag>` by exact name. Links outside that file stay under `dangling-release-links`, because the canvas train tags `v${VERSION}` verbatim and does not strip the `.0`. | Correct the link to the tag named in the finding. Cutting a release will **not** clear this one. |
 | `stranded-release-link` | error | A reference definition **in `CHANGELOG.md`** names a version the manifest has **already moved past**. `create-release.yml` runs `build-plugin.py build --version <tag>`, which validates the tag against `plugin.json` — so `v2.5` fails on `version mismatch: plugin.json has 2.6.0` and is no longer publishable from `main`. Not impossible, and the finding says so: `checkout@v4` restores the *tagged commit*, so tagging the older commit that still read `2.5.0` would build — but it would publish a tree and notes that predate what the section documents now, and `extract_notes()` publishes exactly one section, so those notes reach no release from `main` either. Deeper than `unpublishable-release-link`, so it wins when a link is both. | **Do not cut it from `main`** — that fails the workflow, and a historical tag ships the wrong notes. Fold the section into `## [<manifest version>]`, the release that will actually deliver those changes, and delete the link definition. Guarded offline by `evals/tests/release-hygiene.test.mjs`, which requires every changelog section below the manifest version to name a tag present in `git tag --list`, and by `evals/tests/stranded-release-claim.test.mjs`, which holds the wording to what the repository's history supports. |
 | `plugin-release-missing` / `canvas-release-missing` | error | The version a surface advertises has no release behind it, **and no tag for it exists** — the tag was never pushed. Each finding names the newest release **on its own train**; the trains are told apart by the title their workflow writes (`🎉 Version …` / `srs-navigator …`). When a train has no releases at all it says so, rather than quoting the other train's newest. | Cut it on the matching train — `vX.Y` for the plugin, `vX.Y.Z` for the canvas. |
-| `release-tag-without-release` | error | A tag **is** on origin but no release was published for it — a publish run that failed after the tag existed (`Create Release` run `28527065984` is the precedent). This supersedes the `*-release-missing` finding for that train and takes the link out of `dangling-release-links`, because in this state both of those advise a re-push, and **re-pushing an existing tag emits no `push` event**, so nothing re-runs. | Plugin train: `gh workflow run create-release.yml -f version=X.Y` — `gh release create` attaches to the tag that already exists. Canvas train: `git push --delete origin vX.Y.Z` **first**, then re-run `release-canvas.yml`; `bump-version.mjs` skips any version whose tag exists, so leaving the tag skips that version forever. |
+| `release-tag-without-release` | error | A tag **is** on origin but no release was published for it — a publish run that failed after the tag existed (`Create Release` run `28527065984` is the precedent). This supersedes the `*-release-missing` finding for that train and takes the link out of `dangling-release-links`, because in this state both of those advise a re-push, and **re-pushing an existing tag emits no `push` event**, so nothing re-runs. | Plugin train: `gh workflow run create-release.yml --ref vX.Y -f version=X.Y` — `gh release create` attaches to the tag that already exists, and `--ref` makes the run package the tagged commit rather than whatever `main` holds now. Canvas train: `git push --delete origin vX.Y.Z` **first**, then re-run `release-canvas.yml`; `bump-version.mjs` skips any version whose tag exists, so leaving the tag skips that version forever. |
 | `surface-unreachable` | warning | A registry or the releases API could not be reached at all. | A fetch failure, **not** proof of drift. Re-run; if it persists, check the surface by hand. |
 | `registry-listing-unreadable` | warning | The listing responded but carried no JSON-LD `CollectionPage`. | Its markup probably changed. Check the page by hand and update `parseRegistryListing` — until then a clean run proves nothing. |
 | `registry-skill-unreadable` | warning | A per-skill page carried no `SoftwareApplication` block, or **none** of the shipped skill's sections appeared in it. A page serving something else and a page this checker can no longer parse look identical from here, so no drift is claimed. | Read the page by hand. If the site was redesigned, update `parseSkillPage`/`pageText`; a clean `registry-skill-stale` proves nothing while this warning stands. |
@@ -693,12 +693,26 @@ again. Git sends nothing for a ref that is already up to date, so no `push` even
 Fix the cause, then re-publish onto the tag that is already there:
 
 ```bash
-gh workflow run create-release.yml -f version=X.Y   # gh release create attaches to the tag
-gh run watch --exit-status
+gh workflow run create-release.yml --ref vX.Y -f version=X.Y   # attaches to the existing tag
+gh run watch "$(gh run list --workflow 'Create Release' --event workflow_dispatch \
+                  --limit 1 --json databaseId --jq '.[0].databaseId')" --exit-status
 ```
+
+`--ref` pins the provenance and is not optional. The workflow checks out with
+`actions/checkout@v4` and no `ref:`, so it packages whatever the **dispatched** ref holds,
+and `gh workflow run` defaults to the repository's default branch. Recovering without it
+builds from `main` as it stands now and attaches those bytes to a tag naming a different
+commit — a release that exists, looks correct, and does not match its own tag. Watching by
+run **ID** rather than bare `gh run watch` matters for the same reason the release runbook
+gives: a concurrent run can otherwise be the one that gets watched, and the evidence then
+records a green run that is not this one.
 
 On the **canvas** train the equivalent recovery is different: delete the tag first
 (`git push --delete origin vX.Y.Z`) before re-running `release-canvas.yml`, because
 `bump-version.mjs` skips any version whose tag exists and would otherwise walk past the
 stranded version permanently. `check-distribution.mjs` reports this state as
 `release-tag-without-release` and prints the matching command.
+
+The full pre-flight rehearsal, the post-publication verification of the **downloaded**
+artefact, and the manual clean-profile `/live` procedure live in
+[`docs/release-verification.md`](../docs/release-verification.md).

--- a/.github/extensions/srs-navigator/lib/graph-metrics.mjs
+++ b/.github/extensions/srs-navigator/lib/graph-metrics.mjs
@@ -1,0 +1,129 @@
+// Graph metrics for the SRS Navigator health bar — one implementation, shared by the
+// renderer and by anything that needs to *derive* those numbers instead of quoting them.
+//
+// Why this was extracted (issue #107). The evidence plan on #92 gated on "29 nodes, 5 need
+// clusters, 100% traceability". Those are snapshots of one specification, and the review
+// said so:
+//
+//   "'need clusters' is a renderer metric based on graph degree >= 4, not a direct spec-array
+//    count; reuse/extract that calculation and guard it with fixtures."
+//
+// It was right about the mechanism: `hubs` counts nodes whose total degree reaches 4, which
+// is a property of the *graph*, not of any array in the specification. Nothing outside the
+// browser could compute it, so a pack wanting the number had to read it off a screenshot —
+// and a number read off a screenshot is edited to match the screenshot.
+//
+// The renderer now injects `computeHotspots` and `healthMetrics` into the page verbatim
+// (see `graphMetricsSource()`), so the browser and Node run the same function rather than
+// two functions that agree today.
+//
+// `computeHotspots` deliberately annotates the nodes it is given (`_degree`, `_hotspot`,
+// `_hotspotSeverity`, `_radius`): the force simulation reads those fields off the same
+// objects. Callers that only want the counts can pass copies.
+
+/**
+ * Classify every node by connectivity and annotate it for rendering.
+ *
+ * The four classes are ordered, and the order is the definition — a problem with no
+ * outgoing edge is *orphaned*, never *isolated*, even though both have degree 0 on that
+ * side, because the first names a traceability gap and the second names a stray node.
+ *
+ * @param {Array<{id:string,type:string}>} nodes
+ * @param {Array<{source:any,target:any}>} links
+ * @returns {{orphanedProblems:string[], unmetNeeds:string[], hubs:string[], leafNodes:string[], maxDegree:number}}
+ */
+export function computeHotspots(nodes, links) {
+  const inDegree = {};
+  const outDegree = {};
+  nodes.forEach((n) => {
+    inDegree[n.id] = 0;
+    outDegree[n.id] = 0;
+  });
+  links.forEach((l) => {
+    const src = typeof l.source === "object" ? l.source.id : l.source;
+    const tgt = typeof l.target === "object" ? l.target.id : l.target;
+    outDegree[src] = (outDegree[src] || 0) + 1;
+    inDegree[tgt] = (inDegree[tgt] || 0) + 1;
+  });
+
+  const orphanedProblems = []; // CP with no downstream
+  const unmetNeeds = []; // CN with no downstream FR/NFR
+  const hubs = []; // High connectivity (degree >= 4)
+  const leafNodes = []; // Nodes with no connections at all
+
+  nodes.forEach((n) => {
+    const totalDegree = (inDegree[n.id] || 0) + (outDegree[n.id] || 0);
+    n._degree = totalDegree;
+    n._hotspot = null;
+    n._hotspotSeverity = 0; // 0=none, 1=info, 2=warning, 3=critical
+
+    if (n.type === "problem" && (outDegree[n.id] || 0) === 0) {
+      orphanedProblems.push(n.id);
+      n._hotspot = "orphaned";
+      n._hotspotSeverity = 3;
+    } else if (n.type === "need" && (outDegree[n.id] || 0) === 0) {
+      unmetNeeds.push(n.id);
+      n._hotspot = "unmet";
+      n._hotspotSeverity = 2;
+    } else if (totalDegree >= 4) {
+      hubs.push(n.id);
+      n._hotspot = "hub";
+      n._hotspotSeverity = 1;
+    } else if (totalDegree === 0) {
+      leafNodes.push(n.id);
+      n._hotspot = "isolated";
+      n._hotspotSeverity = 3;
+    }
+  });
+
+  // Node size scale: base 22, only scale up for "Need Cluster" hubs
+  const maxDegree = Math.max(...nodes.map((n) => n._degree), 1);
+  nodes.forEach((n) => {
+    n._radius = n._hotspot === "hub" ? 22 + (n._degree / maxDegree) * 10 : 22;
+  });
+
+  return { orphanedProblems, unmetNeeds, hubs, leafNodes, maxDegree };
+}
+
+/**
+ * The figures the health bar shows, from a graph.
+ *
+ * Coverage is "nodes that are not a gap", where a gap is an orphaned problem, an unmet need
+ * or an isolated node — so 100% means every node participates in a chain, not that every
+ * requirement traces (which `validation.mjs` answers separately).
+ *
+ * @param {{nodes:Array, links:Array}} graphData
+ * @returns {{nodes:number, links:number, orphanedProblems:number, unmetNeeds:number, isolated:number, needClusters:number, gaps:number, traceability:number}}
+ */
+export function healthMetrics(graphData) {
+  const nodes = (graphData?.nodes ?? []).map((n) => ({ ...n }));
+  const links = graphData?.links ?? [];
+  const hotspots = computeHotspots(nodes, links);
+  const total = nodes.length;
+  const gaps =
+    hotspots.orphanedProblems.length + hotspots.unmetNeeds.length + hotspots.leafNodes.length;
+  return {
+    nodes: total,
+    links: links.length,
+    orphanedProblems: hotspots.orphanedProblems.length,
+    unmetNeeds: hotspots.unmetNeeds.length,
+    isolated: hotspots.leafNodes.length,
+    needClusters: hotspots.hubs.length,
+    gaps,
+    traceability: total > 0 ? Math.round(((total - gaps) / total) * 100) : 100,
+  };
+}
+
+/**
+ * The source the renderer injects into the page, so the browser runs *these* functions
+ * rather than a copy that agrees with them today.
+ *
+ * `Function.prototype.toString()` returns the original source text, which is what makes
+ * this a share rather than a duplication: editing `computeHotspots` above changes what the
+ * page executes, and there is no second definition to forget.
+ *
+ * @returns {string} evaluatable JavaScript defining computeHotspots and healthMetrics
+ */
+export function graphMetricsSource() {
+  return `${computeHotspots.toString()}\n${healthMetrics.toString()}`;
+}

--- a/.github/extensions/srs-navigator/lib/renderer.mjs
+++ b/.github/extensions/srs-navigator/lib/renderer.mjs
@@ -5,6 +5,7 @@
 import { readFileSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';
 import { dirname, resolve } from 'node:path';
+import { graphMetricsSource } from './graph-metrics.mjs';
 
 const REPO_URL = 'https://github.com/RafaelGorski/Problem-Based-SRS';
 
@@ -2074,68 +2075,22 @@ export function renderGraphHtml(graphData, options = {}) {
     const nodes = graphData.nodes.map(d => ({...d}));
 
     // === HOT-SPOT DETECTION ===
-    // Compute connectivity and identify nodes that need attention
-    const hotspots = (function() {
-      const inDegree = {};
-      const outDegree = {};
-      nodes.forEach(n => { inDegree[n.id] = 0; outDegree[n.id] = 0; });
-      links.forEach(l => {
-        const src = typeof l.source === 'object' ? l.source.id : l.source;
-        const tgt = typeof l.target === 'object' ? l.target.id : l.target;
-        outDegree[src] = (outDegree[src] || 0) + 1;
-        inDegree[tgt] = (inDegree[tgt] || 0) + 1;
-      });
+    // Compute connectivity and identify nodes that need attention.
+    //
+    // computeHotspots and healthMetrics are injected verbatim from lib/graph-metrics.mjs
+    // (see graphMetricsSource) so this page and Node run the same function. #107 asked for
+    // the need-cluster figure to be *derivable* outside the browser: it is a degree >= 4
+    // graph property, so an evidence pack that quoted it had to read it off a screenshot.
+${graphMetricsSource()}
 
-      const orphanedProblems = []; // CP with no downstream
-      const unmetNeeds = [];       // CN with no downstream FR/NFR
-      const hubs = [];             // High connectivity (degree >= 4)
-      const leafNodes = [];        // Nodes with no connections at all
-
-      nodes.forEach(n => {
-        const totalDegree = (inDegree[n.id] || 0) + (outDegree[n.id] || 0);
-        n._degree = totalDegree;
-        n._hotspot = null;
-        n._hotspotSeverity = 0; // 0=none, 1=info, 2=warning, 3=critical
-
-        if (n.type === 'problem' && (outDegree[n.id] || 0) === 0) {
-          orphanedProblems.push(n.id);
-          n._hotspot = 'orphaned';
-          n._hotspotSeverity = 3;
-        } else if (n.type === 'need' && (outDegree[n.id] || 0) === 0) {
-          unmetNeeds.push(n.id);
-          n._hotspot = 'unmet';
-          n._hotspotSeverity = 2;
-        } else if (totalDegree >= 4) {
-          hubs.push(n.id);
-          n._hotspot = 'hub';
-          n._hotspotSeverity = 1;
-        } else if (totalDegree === 0) {
-          leafNodes.push(n.id);
-          n._hotspot = 'isolated';
-          n._hotspotSeverity = 3;
-        }
-      });
-
-      // Node size scale: base 22, only scale up for "Need Cluster" hubs
-      const maxDegree = Math.max(...nodes.map(n => n._degree), 1);
-      nodes.forEach(n => {
-        // Only hubs (Need Clusters) get larger; all other nodes stay at base size
-        if (n._hotspot === 'hub') {
-          n._radius = 22 + (n._degree / maxDegree) * 10;
-        } else {
-          n._radius = 22;
-        }
-      });
-
-      return { orphanedProblems, unmetNeeds, hubs, leafNodes, maxDegree };
-    })();
+    const hotspots = computeHotspots(nodes, links);
 
     // Render health bar
     (function renderHealthBar() {
       const bar = document.getElementById('health-bar');
-      const total = nodes.length;
-      const gaps = hotspots.orphanedProblems.length + hotspots.unmetNeeds.length + hotspots.leafNodes.length;
-      const coverage = total > 0 ? Math.round(((total - gaps) / total) * 100) : 100;
+      const metrics = healthMetrics({ nodes, links });
+      const total = metrics.nodes;
+      const coverage = metrics.traceability;
 
       if (total === 0) {
         bar.innerHTML = '<div class="health-metric"><span class="label">No nodes to analyze</span></div>';

--- a/.github/extensions/srs-navigator/package.json
+++ b/.github/extensions/srs-navigator/package.json
@@ -9,7 +9,7 @@
     "test": "tests"
   },
   "scripts": {
-    "test": "node --test tests/parser.test.mjs tests/validation.test.mjs tests/renderer.test.mjs tests/action-bar.test.mjs tests/app-prompts.test.mjs tests/integration.test.mjs tests/decompose.test.mjs tests/skill-sync.test.mjs tests/interview-guard.test.mjs tests/brownfield-guard.test.mjs tests/http-guard.test.mjs tests/text-refs.test.mjs tests/notation.test.mjs tests/serve-canvas.test.mjs tests/serve-site.test.mjs tests/test-wiring.test.mjs",
+    "test": "node --test tests/parser.test.mjs tests/validation.test.mjs tests/renderer.test.mjs tests/action-bar.test.mjs tests/app-prompts.test.mjs tests/integration.test.mjs tests/decompose.test.mjs tests/skill-sync.test.mjs tests/interview-guard.test.mjs tests/brownfield-guard.test.mjs tests/http-guard.test.mjs tests/text-refs.test.mjs tests/notation.test.mjs tests/graph-metrics.test.mjs tests/evidence-attribution.test.mjs tests/serve-canvas.test.mjs tests/serve-site.test.mjs tests/test-wiring.test.mjs",
     "test:skill-behavior": "node --test tests/skill-behavior/*.test.mjs",
     "test:e2e": "playwright test",
     "record-demo": "node scripts/record-demo.mjs",

--- a/.github/extensions/srs-navigator/tests/evidence-attribution.test.mjs
+++ b/.github/extensions/srs-navigator/tests/evidence-attribution.test.mjs
@@ -1,0 +1,231 @@
+/**
+ * Evidence attribution: a capture proves what the suite that wrote it was rendering.
+ *
+ * Why this exists. The evidence plan on #92 attached `skills-health-dashboard.png` to the
+ * graph health bar's figures (29 nodes, 5 need clusters, 100% traceability). That image is
+ * a full-page shot of the *landing page*, written by `tests/site.test.mjs`; the graph
+ * assertion lives in `tests/visual.test.mjs`. The claim and the picture came from different
+ * suites rendering different surfaces, and nothing caught it — the pack was reviewed by
+ * reading it, which is exactly the substitution of presence for function that #69 is about.
+ *
+ * So the mapping in `docs/release-verification.md` is *derived from the suites here*, not
+ * restated. Renaming a capture, or moving the health-bar assertion into another file, fails
+ * this test rather than quietly making the runbook wrong.
+ *
+ * Nothing in this file may hard-code the list of captures: it is read out of the sources.
+ */
+
+import { test, describe } from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const HERE = path.dirname(fileURLToPath(import.meta.url));
+const EXT_ROOT = path.resolve(HERE, "..");
+const REPO_ROOT = path.resolve(EXT_ROOT, "../../..");
+const RUNBOOK = path.join(REPO_ROOT, "docs", "release-verification.md");
+
+/** Suites that write screenshot evidence, and the surface each one renders. */
+const SUITES = Object.freeze([
+  Object.freeze({ file: "visual.test.mjs", surface: "the canvas" }),
+  Object.freeze({ file: "site.test.mjs", surface: "the landing page" }),
+  Object.freeze({ file: "demo.test.mjs", surface: "the landing page's demo figure" }),
+]);
+
+const read = (p) => fs.readFileSync(p, "utf8");
+
+/** Every `shot('name.png')` a suite writes. */
+function capturesIn(file) {
+  const src = read(path.join(EXT_ROOT, "tests", file));
+  const names = [...src.matchAll(/shot\(\s*['"]([^'"]+\.png)['"]\s*\)/g)].map((m) => m[1]);
+  return [...new Set(names)];
+}
+
+/** name -> [suite files that write it] */
+function attribution() {
+  const map = new Map();
+  for (const { file } of SUITES) {
+    for (const name of capturesIn(file)) {
+      if (!map.has(name)) map.set(name, []);
+      map.get(name).push(file);
+    }
+  }
+  return map;
+}
+
+/** The runbook's attribution table rows, as { capture, suite, surface }. */
+function runbookRows() {
+  const doc = read(RUNBOOK);
+  const heading = "### Which capture supports which claim";
+  const start = doc.indexOf(heading);
+  assert.notEqual(start, -1, `${heading} must exist in the runbook`);
+  const section = doc.slice(start);
+  const rows = [];
+  for (const line of section.split("\n")) {
+    const m = line.match(/^\|\s*`([^`]+\.png)`\s*\|\s*`([^`]+)`\s*\|\s*([^|]+?)\s*\|/);
+    if (m) rows.push({ capture: m[1], suite: path.basename(m[2]), surface: m[3].trim() });
+  }
+  return rows;
+}
+
+describe("evidence attribution — captures map to the suite that writes them", () => {
+  test("every screenshot a suite writes is attributed in the runbook", () => {
+    const written = attribution();
+    assert.ok(written.size > 0, "the suites must write at least one capture");
+    const documented = new Set(runbookRows().map((r) => r.capture));
+    for (const name of written.keys()) {
+      assert.ok(
+        documented.has(name),
+        `${name} is written by ${written.get(name).join(", ")} but the runbook's ` +
+          `attribution table does not list it — an undocumented capture is one a pack ` +
+          `can attach to any claim it likes`,
+      );
+    }
+  });
+
+  test("the runbook attributes each capture to the suite that actually writes it", () => {
+    const written = attribution();
+    for (const row of runbookRows()) {
+      const actual = written.get(row.capture);
+      assert.ok(actual, `the runbook lists ${row.capture}, which no suite writes`);
+      assert.ok(
+        actual.includes(row.suite),
+        `the runbook credits ${row.capture} to ${row.suite}, but it is written by ` +
+          `${actual.join(", ")}. This is the #92 defect exactly: a claim and a picture ` +
+          `from different suites`,
+      );
+    }
+  });
+
+  test("no capture is written by two suites", () => {
+    for (const [name, files] of attribution()) {
+      assert.equal(
+        files.length,
+        1,
+        `${name} is written by ${files.join(" and ")}; a capture with two authors cannot ` +
+          `be attributed to a surface`,
+      );
+    }
+  });
+
+  test("the runbook records the surface each suite renders", () => {
+    const bySuite = new Map(SUITES.map((s) => [s.file, s.surface]));
+    for (const row of runbookRows()) {
+      assert.equal(
+        row.surface,
+        bySuite.get(row.suite),
+        `${row.capture} is attributed to ${row.suite}, which renders ` +
+          `"${bySuite.get(row.suite)}", but the runbook says "${row.surface}"`,
+      );
+    }
+  });
+});
+
+describe("evidence attribution — the graph health bar", () => {
+  test("the health-bar figures are asserted in the canvas suite, not the site suite", () => {
+    const visual = read(path.join(EXT_ROOT, "tests", "visual.test.mjs"));
+    assert.match(
+      visual,
+      /health bar reports .*nodes.*need clusters.*traceability/i,
+      "visual.test.mjs must carry the health-bar figures assertion; if it moved, the " +
+        "runbook's attribution of live-dotted-notation.png moved with it",
+    );
+    const site = read(path.join(EXT_ROOT, "tests", "site.test.mjs"));
+    assert.doesNotMatch(
+      site,
+      /health bar reports .*need clusters/i,
+      "site.test.mjs renders the landing page; if it starts asserting the graph health " +
+        "bar, the runbook must say so rather than leaving the #92 misattribution true",
+    );
+  });
+
+  test("the capture that can support the health-bar claim is written by the same suite", () => {
+    const written = attribution();
+    const authors = written.get("live-dotted-notation.png");
+    assert.ok(authors, "live-dotted-notation.png must still be captured");
+    assert.deepEqual(
+      authors,
+      ["visual.test.mjs"],
+      "the health-bar assertion and the capture cited for it must run in the same suite, " +
+        "or the pack is again citing a picture from somewhere else",
+    );
+  });
+
+  test("the runbook denies that the landing-page dashboard shows the graph health bar", () => {
+    const doc = read(RUNBOOK);
+    const row = doc
+      .split("\n")
+      .find((l) => l.includes("`skills-health-dashboard.png`") && l.startsWith("|"));
+    assert.ok(row, "the runbook must attribute skills-health-dashboard.png");
+    assert.match(
+      row,
+      /\*\*Not\*\* the graph health bar/,
+      "the row for skills-health-dashboard.png must state what it cannot support — this " +
+        "is the specific claim #92 got wrong",
+    );
+  });
+});
+
+describe("evidence attribution — what can speak for the published archive", () => {
+  test("only one suite reads CANVAS_URL", () => {
+    const readers = SUITES.filter(({ file }) =>
+      read(path.join(EXT_ROOT, "tests", file)).includes("CANVAS_URL"),
+    ).map((s) => s.file);
+    assert.deepEqual(
+      readers,
+      ["visual.test.mjs"],
+      "the runbook tells a maintainer to point CANVAS_URL at an extracted release " +
+        "archive; if another suite gains or loses that support, the claim about which " +
+        "captures can speak for the published artefact changes",
+    );
+  });
+
+  test("the runbook names that suite as the only one that can", () => {
+    const doc = read(RUNBOOK);
+    assert.match(
+      doc,
+      /\*\*Only `tests\/visual\.test\.mjs` reads `CANVAS_URL`\.\*\*/,
+      "the runbook must state which suite can be pointed at a published archive",
+    );
+    assert.match(
+      doc,
+      /open-archive-canvas\.mjs --provenance/,
+      "and must pair it with the provenance record that identifies the bytes that ran",
+    );
+  });
+});
+
+describe("evidence attribution — CI attaches nothing when green", () => {
+  const ci = () => read(path.join(REPO_ROOT, ".github", "workflows", "ci.yml"));
+
+  test("the Playwright report is uploaded only on failure", () => {
+    const src = ci();
+    const idx = src.indexOf("playwright-report");
+    assert.notEqual(idx, -1, "ci.yml must still upload a Playwright report");
+    const before = src.slice(Math.max(0, idx - 400), idx);
+    assert.match(
+      before,
+      /if:\s*failure\(\)/,
+      "if this upload becomes unconditional, the runbook's 'a green run attaches " +
+        "nothing' instruction is wrong and a pack may cite a CI artifact instead",
+    );
+  });
+
+  test("test-results/ — where the captures land — is never uploaded", () => {
+    assert.doesNotMatch(
+      ci(),
+      /path:\s*.*test-results/,
+      "the captures a pack attaches are not produced by CI; if that changes the runbook " +
+        "must stop telling maintainers to run the suite locally",
+    );
+  });
+
+  test("the runbook says so", () => {
+    assert.match(
+      read(RUNBOOK),
+      /\*\*A green CI run attaches nothing\.\*\*/,
+      "the runbook must state that the pack comes from a local run",
+    );
+  });
+});

--- a/.github/extensions/srs-navigator/tests/graph-metrics.test.mjs
+++ b/.github/extensions/srs-navigator/tests/graph-metrics.test.mjs
@@ -1,0 +1,258 @@
+// The health-bar metrics used to live inside a template literal in `renderer.mjs`, which
+// meant nothing outside a browser could compute them. Issue #92's evidence plan gated on
+// "29 nodes, 5 need clusters, 100% traceability" — three numbers that could only be read
+// off a screenshot, and a number read off a screenshot gets edited to match the screenshot.
+//
+// #107's review named the mechanism exactly:
+//
+//   "'need clusters' is a renderer metric based on graph degree >= 4, not a direct
+//    spec-array count; reuse/extract that calculation and guard it with fixtures."
+//
+// So this suite does two things. It pins the *classification rules* with fixtures — small
+// graphs where the right answer is obvious by inspection — and it pins the *sharing*: the
+// renderer must inject these functions rather than keep a copy that agrees with them today.
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { computeHotspots, graphMetricsSource, healthMetrics } from "../lib/graph-metrics.mjs";
+import { DEMO_SPEC } from "../lib/demo-spec.mjs";
+import { buildGraphData } from "../lib/parser.mjs";
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+const extRoot = path.resolve(here, "..");
+
+const node = (id, type) => ({ id, type });
+const link = (source, target) => ({ source, target });
+
+/* ------------------------------------------------------------------- classification */
+
+describe("computeHotspots classifies by connectivity, not by array membership", () => {
+  it("calls a problem with no downstream orphaned", () => {
+    const nodes = [node("CP.01", "problem"), node("CN.01.1", "need")];
+    const h = computeHotspots(nodes, []);
+    assert.deepEqual(h.orphanedProblems, ["CP.01"]);
+    assert.equal(nodes[0]._hotspot, "orphaned");
+    assert.equal(nodes[0]._hotspotSeverity, 3);
+  });
+
+  it("calls a need with no downstream unmet — a problem's need is not automatically met", () => {
+    const nodes = [node("CP.01", "problem"), node("CN.01.1", "need")];
+    const h = computeHotspots(nodes, [link("CP.01", "CN.01.1")]);
+    assert.deepEqual(h.orphanedProblems, [], "CP.01 now has a downstream edge");
+    assert.deepEqual(h.unmetNeeds, ["CN.01.1"]);
+    assert.equal(nodes[1]._hotspotSeverity, 2, "an unmet need is a warning, not critical");
+  });
+
+  it("counts a need cluster at total degree 4, and not at 3", () => {
+    // The threshold is the whole definition of "need cluster", and it is a *total* degree —
+    // in + out. A need with one problem above and two requirements below is degree 3.
+    const below = (n) =>
+      Array.from({ length: n }, (_, i) => ({
+        id: `FR.01.1.${i + 1}`,
+        type: "requirement",
+      }));
+
+    const atThree = [node("CP.01", "problem"), node("CN.01.1", "need"), ...below(2)];
+    const three = computeHotspots(atThree, [
+      link("CP.01", "CN.01.1"),
+      link("CN.01.1", "FR.01.1.1"),
+      link("CN.01.1", "FR.01.1.2"),
+    ]);
+    assert.equal(atThree[1]._degree, 3);
+    assert.deepEqual(three.hubs, [], "degree 3 is not a cluster");
+
+    const atFour = [node("CP.01", "problem"), node("CN.01.1", "need"), ...below(3)];
+    const four = computeHotspots(atFour, [
+      link("CP.01", "CN.01.1"),
+      link("CN.01.1", "FR.01.1.1"),
+      link("CN.01.1", "FR.01.1.2"),
+      link("CN.01.1", "FR.01.1.3"),
+    ]);
+    assert.equal(atFour[1]._degree, 4);
+    assert.deepEqual(four.hubs, ["CN.01.1"], "degree 4 is");
+  });
+
+  it("calls a disconnected node isolated, but never a problem or a need", () => {
+    // Order is the definition: a bare CP is orphaned (a traceability gap), a bare
+    // requirement is isolated (a stray node). Both have degree 0; they are not the same
+    // finding, and swapping the branches would silently retitle every orphan.
+    const nodes = [
+      node("CP.01", "problem"),
+      node("CN.01.1", "need"),
+      node("FR.01.1.1", "requirement"),
+    ];
+    const h = computeHotspots(nodes, []);
+    assert.deepEqual(h.orphanedProblems, ["CP.01"]);
+    assert.deepEqual(h.unmetNeeds, ["CN.01.1"]);
+    assert.deepEqual(h.leafNodes, ["FR.01.1.1"]);
+    assert.equal(nodes[2]._hotspot, "isolated");
+  });
+
+  it("scales only clusters, so node size means one thing", () => {
+    const nodes = [
+      node("CP.01", "problem"),
+      node("CN.01.1", "need"),
+      node("FR.01.1.1", "requirement"),
+      node("FR.01.1.2", "requirement"),
+      node("FR.01.1.3", "requirement"),
+    ];
+    computeHotspots(nodes, [
+      link("CP.01", "CN.01.1"),
+      link("CN.01.1", "FR.01.1.1"),
+      link("CN.01.1", "FR.01.1.2"),
+      link("CN.01.1", "FR.01.1.3"),
+    ]);
+    const [, need, ...leaves] = nodes;
+    assert.equal(need._hotspot, "hub");
+    assert.ok(need._radius > 22, "a cluster is drawn larger");
+    for (const leaf of leaves) assert.equal(leaf._radius, 22, "everything else keeps base size");
+  });
+
+  it("survives links whose endpoints were replaced by objects", () => {
+    // d3's force simulation mutates `link.source`/`link.target` from ids into node objects
+    // in place. Reading a graph after a tick must give the same answer as before it.
+    const nodes = [node("CP.01", "problem"), node("CN.01.1", "need")];
+    const byId = Object.fromEntries(nodes.map((n) => [n.id, n]));
+    const before = computeHotspots(nodes, [link("CP.01", "CN.01.1")]);
+    const after = computeHotspots(nodes, [link(byId["CP.01"], byId["CN.01.1"])]);
+    assert.deepEqual(after, before);
+  });
+
+  it("does not divide by zero on an empty graph", () => {
+    assert.deepEqual(computeHotspots([], []), {
+      orphanedProblems: [],
+      unmetNeeds: [],
+      hubs: [],
+      leafNodes: [],
+      maxDegree: 1,
+    });
+  });
+});
+
+/* ------------------------------------------------------------------- the health bar */
+
+describe("healthMetrics reports what the health bar shows", () => {
+  it("treats every class of gap as a gap", () => {
+    const m = healthMetrics({
+      nodes: [node("CP.01", "problem"), node("CN.01.1", "need"), node("FR.01.1.1", "requirement")],
+      links: [],
+    });
+    assert.equal(m.gaps, 3);
+    assert.equal(m.traceability, 0);
+  });
+
+  it("reaches 100% only when no node is a gap", () => {
+    const m = healthMetrics({
+      nodes: [node("CP.01", "problem"), node("CN.01.1", "need"), node("FR.01.1.1", "requirement")],
+      links: [link("CP.01", "CN.01.1"), link("CN.01.1", "FR.01.1.1")],
+    });
+    assert.equal(m.gaps, 0);
+    assert.equal(m.traceability, 100);
+  });
+
+  it("does not annotate the caller's nodes", () => {
+    // The counting path must not have the side effect the rendering path relies on, or
+    // asking for the numbers would perturb the simulation.
+    const nodes = [node("CP.01", "problem")];
+    healthMetrics({ nodes, links: [] });
+    assert.equal(nodes[0]._hotspot, undefined);
+    assert.equal(nodes[0]._radius, undefined);
+  });
+
+  it("answers 100% for an empty graph rather than NaN", () => {
+    assert.equal(healthMetrics({ nodes: [], links: [] }).traceability, 100);
+    assert.equal(healthMetrics(undefined).traceability, 100);
+  });
+
+  it("derives the demo specification's figures instead of quoting them", () => {
+    // This is the assertion #92's evidence pack needed and did not have: the three numbers
+    // its plan hard-coded, computed from the specification by the same code the page runs.
+    // If the demo spec changes, this fails and the pack's expected values change with it —
+    // which is the point. The numbers are not sacred; deriving them is.
+    const graph = buildGraphData(DEMO_SPEC);
+    const m = healthMetrics(graph);
+    assert.equal(m.nodes, 29);
+    assert.equal(m.links, 32);
+    assert.equal(m.needClusters, 5);
+    assert.equal(m.traceability, 100);
+    assert.equal(m.gaps, 0);
+  });
+
+  it("agrees with the specification's own arrays where the two overlap", () => {
+    // Node count *is* an array count, so it can be cross-checked. Cluster count is not,
+    // which is exactly why it needed extracting.
+    const graph = buildGraphData(DEMO_SPEC);
+    const m = healthMetrics(graph);
+    const declared =
+      DEMO_SPEC.problems.length +
+      DEMO_SPEC.needs.length +
+      DEMO_SPEC.functionalRequirements.length +
+      DEMO_SPEC.nonFunctionalRequirements.length;
+    assert.equal(m.nodes, declared);
+    assert.notEqual(
+      m.needClusters,
+      DEMO_SPEC.needs.length,
+      "if these ever coincide the fixture stopped distinguishing a degree metric from a count",
+    );
+  });
+});
+
+/* --------------------------------------------------------------- the renderer shares it */
+
+describe("the page runs this module, not a copy of it", () => {
+  const rendererSrc = fs.readFileSync(path.join(extRoot, "lib/renderer.mjs"), "utf8");
+
+  it("injects the shared source into the page", () => {
+    assert.match(
+      rendererSrc,
+      /\$\{graphMetricsSource\(\)\}/,
+      "renderer.mjs must inject graphMetricsSource(), not restate the functions",
+    );
+    assert.match(rendererSrc, /from ['"]\.\/graph-metrics\.mjs['"]/);
+  });
+
+  it("keeps no second definition of the extracted functions", () => {
+    // The failure mode this guards is not a wrong number — it is two right numbers that
+    // drift apart later, which is undetectable from either side alone.
+    for (const fn of ["computeHotspots", "healthMetrics"]) {
+      const defs = rendererSrc.match(new RegExp(`function\\s+${fn}\\s*\\(`, "g")) ?? [];
+      assert.equal(defs.length, 0, `renderer.mjs redefines ${fn}`);
+    }
+  });
+
+  it("emits source the page can actually evaluate", () => {
+    const src = graphMetricsSource();
+    assert.match(src, /function computeHotspots/);
+    assert.match(src, /function healthMetrics/);
+    for (const hazard of ["`", "${", "</script>"]) {
+      assert.ok(
+        !src.includes(hazard),
+        `graphMetricsSource() contains ${hazard}, which cannot survive injection into the renderer's template literal`,
+      );
+    }
+  });
+
+  it("the injected source computes what the module computes", () => {
+    // Evaluate the emitted text the way the page will, then run both implementations on
+    // the demo graph. Equality here is what makes "one implementation" a fact.
+    const graph = buildGraphData(DEMO_SPEC);
+    const evaluate = new Function(`${graphMetricsSource()}\nreturn { computeHotspots, healthMetrics };`);
+    const injected = evaluate();
+    assert.deepEqual(injected.healthMetrics(graph), healthMetrics(graph));
+    assert.deepEqual(
+      injected.computeHotspots(graph.nodes.map((n) => ({ ...n })), graph.links),
+      computeHotspots(graph.nodes.map((n) => ({ ...n })), graph.links),
+    );
+  });
+
+  it("the health bar reads the shared metrics rather than recounting", () => {
+    assert.match(
+      rendererSrc,
+      /healthMetrics\(\s*\{\s*nodes\s*,\s*links\s*\}\s*\)/,
+      "the health bar must take its totals from healthMetrics()",
+    );
+  });
+});

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,51 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **The release artefact a user downloads is now *loaded*, not just staged.** Three install
+  families ship from this repository, and only two had a reader. `plugin-archive-install`
+  checked what the packager *stages*; nothing opened the published
+  `problem-based-srs-vX.Y.zip`, so the release asset was the one artefact whose contents were
+  taken on trust. `evals/tools/verify-plugin-archive.mjs` extracts and loads it — resolves the
+  manifest, resolves every skill, requires every dispatched action to land on a file present in
+  the extracted tree, and resolves every relative markdown link *against that tree* — and emits
+  a JSON evidence record naming the SHA-256 of the bytes it read. The link check replaces
+  `grep -rn 'agents/skills/'`, which tested one known defect rather than link closure and would
+  not have found the next one. Its gates are closure properties and its counts are recorded but
+  never asserted, so a tenth action does not turn a correct archive red — the failure mode the
+  reviews on #107 called out in the original "9 actions / 12 files" thresholds.
+- **`evals/lib/distribution-artifacts.mjs`** — one definition of what this repository ships:
+  the three artefact families, the README install methods each covers, and the tree/link/
+  dispatch readers the suites and the verifier share. The README's method list is read, not
+  restated, so a seventh install method must be mapped to a family or the suite fails.
+- **`docs/release-verification.md`** — the release procedure, in a tracked file. The reviews on
+  #104 and #108 both flagged that it lived in `.spec/release-readiness/`, which is gitignored:
+  the instructions a future maintainer needs were unavailable to them, and nothing could tell
+  whether they still matched the pipeline. `evals/tests/release-verification-runbook.test.mjs`
+  derives its assertions from the workflows, the README and `extension.mjs`, so the runbook
+  goes red when the pipeline moves rather than quietly becoming wrong.
+- **`.github/extensions/srs-navigator/lib/graph-metrics.mjs`** — the health-bar metrics,
+  extracted from the renderer's template literal and injected back into the page verbatim, so
+  the browser and Node run one implementation instead of two that agree today. "29 nodes,
+  5 need clusters, 100% traceability" can now be *derived* from a specification rather than
+  read off a screenshot; "need clusters" is a graph degree ≥ 4 property, not an array length,
+  which is why nothing outside the browser could compute it before.
+- **`--provenance` on `evals/tools/open-archive-canvas.mjs`** — records the extracted path, the
+  archive version and the SHA-256 of the `extension.mjs` that ran, so a capture can be tied to
+  the bytes that produced it, and states which install each half of `/live` comes from (the
+  command ships with the skill; the panel ships with the canvas archive).
+- **Screenshot evidence is now attributed to the suite that writes it**
+  (`.github/extensions/srs-navigator/tests/evidence-attribution.test.mjs`, 12 assertions, wired
+  into `npm test`; the table it guards is in `docs/release-verification.md`). The evidence plan
+  on #92 cited `skills-health-dashboard.png` for the *graph* health bar's figures — that image
+  is a full-page shot of the landing page written by `tests/site.test.mjs`, while the figures
+  are asserted in `tests/visual.test.mjs`. The claim and the picture came from different suites
+  rendering different surfaces, and the pack was reviewed by reading it, so nothing caught it.
+  The mapping is now derived from the suites' own `shot(...)` calls, so renaming a capture or
+  moving an assertion fails the document instead of silently invalidating it. Two consequences
+  are pinned with it: only `tests/visual.test.mjs` reads `CANVAS_URL`, so it is the only suite
+  whose output can speak for a *published* archive rather than the checkout; and `ci.yml`
+  uploads `playwright-report` under `if: failure()` and never uploads `test-results/`, so a
+  green CI run attaches no evidence at all and the pack must come from a local run.
 - **`.claude-plugin/marketplace.json` — this repository can now be catalogued.**
   `/plugin marketplace add` reads a marketplace manifest from the repository root, and we
   shipped only `plugin.json`: a plugin that no marketplace could list, including its own.
@@ -32,7 +77,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   the very next action on the release backlog is a tag push. `check-distribution.mjs` now reads
   git refs as well, and reports that state as its own finding —
   `release-tag-without-release` — carrying the recovery each train actually needs: dispatch for
-  the plugin train (`gh workflow run create-release.yml -f version=X.Y`, since
+  the plugin train (`gh workflow run create-release.yml --ref vX.Y -f version=X.Y`, since
   `gh release create` attaches to the tag that already exists), and **deleting the tag first**
   for the canvas train, because `bump-version.mjs` skips any version whose tag exists and would
   otherwise walk past the stranded version permanently. A link naming such a tag moves out of

--- a/docs/release-verification.md
+++ b/docs/release-verification.md
@@ -1,0 +1,252 @@
+# Release verification runbook
+
+How a release is rehearsed before it is cut, and how the **artefact a user receives** is
+verified after it is published.
+
+This file is the durable home for that procedure. The reviews on #104 and #108 both flagged
+that the sequenced plan lived in `.spec/release-readiness/execution-plan.md`, which is
+gitignored — so the instructions a future maintainer needs were unavailable to them. The
+process lives here; `.github/copilot-instructions.md` keeps the *policy* (which train owns
+which tag, what the distribution monitor reports) and links back to this file for the steps.
+
+- [Distribution artefact families](#distribution-artefact-families)
+- [Plugin train — cutting `vX.Y`](#plugin-train--cutting-vxy)
+- [Canvas train — cutting `vX.Y.Z`](#canvas-train--cutting-vxyz)
+- [Proving `/live` in the app itself](#proving-live-in-the-app-itself)
+- [Deriving an evidence pack](#deriving-an-evidence-pack)
+
+---
+
+## Distribution artefact families
+
+The README documents **six** install methods. They deliver **three** distinct byte streams,
+and it is the byte streams that need proving — two methods that copy the same tree in a
+different order do not need two proofs. Calling them "three install routes" was wrong twice
+over: it undercounted the methods and overstated what three transcripts cover.
+
+| Family | Artefact | README methods it covers | Verified by |
+|---|---|---|---|
+| **Repository clone** | the repository tree at a ref | AI-assisted · Claude Code plugin · AgentSkills CLI · Manual | `evals/tests/skills-install.test.mjs`, `evals/tests/claude-plugin-install.test.mjs`, a clean-directory `npx skills add` transcript |
+| **Plugin release archive** | `problem-based-srs-v<version>.zip` | Plugin release archive | `evals/tests/plugin-archive-install.test.mjs` (what the packager stages) + `evals/tools/verify-plugin-archive.mjs` (what the release serves) |
+| **Canvas release archive** | `srs-navigator-<version>.zip` / `.tar.gz` | SRS Navigator canvas app | `evals/tests/from-archive-install.test.mjs` + `evals/tools/open-archive-canvas.mjs` |
+
+The equivalence claim inside the first family — that four methods deliver one artefact — is
+asserted against the README by `evals/tests/distribution-artifacts.test.mjs`, so a seventh
+install method cannot be added without either mapping it to a family or failing the suite.
+
+---
+
+## Plugin train — cutting `vX.Y`
+
+### Pre-flight, before any tag is pushed
+
+The tag is the point of no return: `create-release.yml` is triggered **by** the tag push, so
+a failed run leaves a tag behind, and re-pushing an existing ref emits no `push` event.
+Everything that can be checked from a clean `main` is checked first.
+
+```bash
+git checkout main && git pull --tags
+git rev-parse HEAD                                   # record this SHA in the release issue
+
+python scripts/build-plugin.py build --version X.Y   # validates + packages + prints notes
+node scripts/release-train.mjs --tag vX.Y            # must print exactly: plugin
+node --test evals/tests/*.test.mjs
+python scripts/build-plugin.py validate
+( cd .github/extensions/srs-navigator && npm test )
+```
+
+`build-plugin.py` normalizes the version, so a manifest reading `2.6.0` publishes at
+**`v2.6`** — and GitHub serves `/releases/tag/<tag>` by exact name. Push the tag the
+rehearsal named, not the manifest string.
+
+### The cut, and watching the right run
+
+```bash
+git tag vX.Y && git push origin vX.Y
+```
+
+`gh run list --workflow 'Create Release' --limit 1` races: any concurrent run can be the one
+it returns, and the evidence then records a green run that is not the release run. Pin it to
+the event, the ref and the commit that was recorded above:
+
+```bash
+RUN=$(gh run list --workflow 'Create Release' \
+        --event push --branch vX.Y --commit "$SHA" \
+        --limit 1 --json databaseId --jq '.[0].databaseId')
+gh run watch "$RUN" --exit-status
+gh run view "$RUN" --json headSha,event,headBranch    # assert it is the run you meant
+```
+
+### Post-publication — verify the artefact, not the repository
+
+`npx skills add` clones the repository; it never opens the release asset. Download what the
+release serves and load it:
+
+```bash
+gh release download vX.Y -p 'problem-based-srs-*.zip' -D /tmp/pbsrs-asset
+cd /tmp/pbsrs-asset && unzip -q problem-based-srs-vX.Y.zip -d extracted
+shasum -a 256 problem-based-srs-vX.Y.zip              # record; compare with the asset digest
+
+node <repo>/evals/tools/verify-plugin-archive.mjs extracted --json evidence.json
+curl -s -o /dev/null -w '%{http_code}\n' \
+  https://github.com/RafaelGorski/Problem-Based-SRS/releases/tag/vX.Y   # 200
+node <repo>/scripts/check-distribution.mjs
+```
+
+`verify-plugin-archive.mjs` **loads** the plugin rather than listing the zip: it resolves the
+manifest, resolves every skill, requires every dispatched action to land on a file present in
+the extracted tree, and resolves every relative markdown link against that tree. That last
+check replaces `grep -rn 'agents/skills/'`, which tested one known defect rather than link
+closure — the shipped defect it was written for was two links escaping the archive root, and
+a grep for the symptom would not have found the next one.
+
+Counts in its output are **recorded, not gated**. The gates are closure properties, so a
+tenth action does not turn a correct archive red.
+
+### If the run fails with the tag already pushed
+
+Do not re-push — git sends nothing for a ref that is up to date, so no `push` event fires.
+Re-publish by dispatch, **pinned to the tag**:
+
+```bash
+gh workflow run create-release.yml --ref vX.Y -f version=X.Y
+```
+
+`--ref` is not optional. `actions/checkout@v4` in that workflow takes the dispatched ref, and
+`gh workflow run` defaults to the repository's default branch — so without it the recovery
+packages whatever `main` holds *now* and attaches those bytes to a tag that names a different
+commit. `gh release create` attaches to the tag that already exists.
+
+---
+
+## Canvas train — cutting `vX.Y.Z`
+
+The canvas train is dispatch-only and creates its tag as part of publishing, so a failed
+publish cannot strand a tag:
+
+```bash
+gh workflow run release-canvas.yml
+```
+
+Do not hand-bump `VERSION`: `bump-version.mjs` *increments* from what it finds, so a
+hand-bumped number is never published. Recovery is the mirror image of the plugin train —
+delete the tag **first**, because `bump-version.mjs` skips any version whose tag exists and
+would otherwise walk past the stranded version forever:
+
+```bash
+git push --delete origin vX.Y.Z
+gh workflow run release-canvas.yml
+```
+
+### Verifying the published canvas archive
+
+```bash
+gh release download vX.Y.Z -p 'srs-navigator-*.zip' -D /tmp/canvas-archive
+cd /tmp/canvas-archive && shasum -a 256 srs-navigator-X.Y.Z.zip     # record
+unzip -q srs-navigator-X.Y.Z.zip -d /tmp/ext                        # gives /tmp/ext/srs-navigator
+
+node <repo>/evals/tools/open-archive-canvas.mjs /tmp/ext/srs-navigator \
+  --provenance /tmp/canvas-archive/provenance.json
+```
+
+The tool refuses to boot anything under a `.github/` path, because that is the exact
+condition `extension.mjs` uses to treat itself as an in-repo install — a capture taken there
+would show the checkout while being filed as archive evidence. `--provenance` records the
+extracted path, the archive version and the SHA-256 of `extension.mjs`, so a screenshot can
+be tied to the bytes that produced it.
+
+---
+
+## Proving `/live` in the app itself
+
+The loopback harness proves the **published archive's runtime**. It does not prove the
+Copilot app's **extension loader** accepts the archive: the host's discovery of
+`~/.copilot/extensions/`, its manifest and permission handling, and the panel a user sees are
+all outside it. #69's box names the app, so the app is where that box is answered.
+
+Two conditions make the manual run meaningful, and both were missed by "the extensions
+directory is empty":
+
+1. **Workspace isolation.** An empty `~/.copilot/extensions/` is not a clean loader test on
+   its own — this repository's own workspace contributes `.github/extensions/srs-navigator`
+   as a *project* extension, which loads alongside the user-scope one and registers the same
+   canvas id and tool name twice. Run from a neutral workspace (any directory that is not
+   this repository), or explicitly disable every project copy first.
+2. **Command source.** `/live` and the panel come from **different installs**, and an
+   evidence pack should name both:
+
+   | What | Comes from | Evidence |
+   |---|---|---|
+   | the `/live` command | the skills install (plugin archive or `npx skills add`) | `skills/problem-based-srs/reference/live.md` |
+   | the canvas panel | the canvas archive install | `extension.mjs` registers the `srs-navigator` canvas |
+
+   The canvas archive registers the `srs-navigator` canvas and the `problem_based_srs` tool,
+   and that tool's action enum does **not** include `live`. Installing only the canvas
+   archive and typing `/live` therefore tests a command the archive never shipped.
+
+Procedure:
+
+```bash
+ls ~/.copilot/extensions/                      # must not already contain srs-navigator
+unzip -q srs-navigator-X.Y.Z.zip -d ~/.copilot/extensions/
+cd /some/neutral/workspace                     # NOT this repository
+```
+
+Then, in the Copilot app: reload extensions → confirm `srs-navigator` is listed as **loaded**
+(not `failed`) → run `/live` → capture the panel, and record the extension log path from the
+extension inspector.
+
+If the host refuses to load it, record the refusal verbatim. A failed load is a result; the
+loopback capture answers a different question and cannot be substituted for it.
+
+---
+
+## Deriving an evidence pack
+
+Every number in a pack is either **derived** or **recorded**, and the two are labelled:
+
+| Claim | How it is established |
+|---|---|
+| every action resolves | `verify-plugin-archive.mjs` — dispatch closure over the extracted tree, both directions |
+| no link escapes the tree | `verify-plugin-archive.mjs` — full relative-link closure |
+| skill file count | *recorded* from the installed tree; never a gate. The dispatch table cannot supply it — the tree also carries `SKILL.md` and the `*-example.md` walkthroughs, which no action dispatches |
+| node / need-cluster / traceability figures | *derived* from the loaded specification with `healthMetrics()` in `.github/extensions/srs-navigator/lib/graph-metrics.mjs` — the same function the page runs. "Need clusters" is a degree ≥ 4 graph property, not an array length |
+| `check-distribution.mjs --strict` exits 0 | **zero *error* findings**. Warnings and notices exit 0 by design, so the pack says "zero errors; every warning and notice explained" rather than treating exit 0 as a fully readable third-party surface |
+
+Thresholds are re-checked with **fixture canaries** — small purpose-built trees in the test
+suites that are deliberately broken — not by mutating the tracked tree during a release run.
+Mutating `main` to prove a guard works adds risk to the release without improving the proof
+that ships; the negative-test evidence already attached to the merged PRs is the citation.
+
+### Which capture supports which claim
+
+A screenshot proves whatever the suite that wrote it was rendering — no more. The evidence
+plan on #92 attached `skills-health-dashboard.png` to the *graph* health-bar figures; that
+image is a full-page shot of the **landing page**, written by a different suite, and could
+not have shown them. Attribution is therefore part of the pack, not a detail of it.
+
+| Capture | Written by | Renders | Can support |
+|---|---|---|---|
+| `live-dotted-notation.png` | `tests/visual.test.mjs` | the canvas | the graph, dotted identifiers, and — via the assertion in the same run — the node / need-cluster / traceability figures |
+| `skills-health-dashboard.png` | `tests/site.test.mjs` | the landing page | that the skills-health dashboard is reachable and renders its cards. **Not** the graph health bar |
+| `landing-health-link.png` | `tests/site.test.mjs` | the landing page | that the navigation link to that dashboard is present and has an accessible name |
+| `landing-health-link-narrow.png` | `tests/site.test.mjs` | the landing page | that the same link survives a 420 px viewport |
+| `landing-version-badge.png` | `tests/site.test.mjs` | the landing page | that the badge's **text** is right. It never fetches the release, so it is not evidence the version resolves — the HTTP 200 check and `check-distribution.mjs` are |
+| `landing-install.png` | `tests/site.test.mjs` | the landing page | how the install instructions render |
+| `landing-live-demo.png` | `tests/demo.test.mjs` | the landing page's demo figure | that the site's demo matches what ships. It renders the site, not an archive |
+| `landing-live-demo-reduced.png` | `tests/demo.test.mjs` | the landing page's demo figure | that the demo honours `prefers-reduced-motion` |
+
+Two consequences follow, and both are load-bearing:
+
+- **Only `tests/visual.test.mjs` reads `CANVAS_URL`.** It is therefore the only suite that
+  can be pointed at an extracted release archive, and so the only one whose output can
+  support a claim about the **published** artefact rather than the checkout. Pair it with
+  `open-archive-canvas.mjs --provenance`, which records the SHA-256 of the `extension.mjs`
+  that actually served the page.
+- **A green CI run attaches nothing.** `ci.yml` uploads `playwright-report` under
+  `if: failure()` and never uploads `test-results/`. The pack is produced by a local run and
+  attached by hand; citing a test's source line is not evidence that the test ran.
+
+The mapping above is derived from the suites by
+`.github/extensions/srs-navigator/tests/evidence-attribution.test.mjs`, so moving an
+assertion or renaming a capture fails this document rather than silently invalidating it.

--- a/evals/lib/distribution-artifacts.mjs
+++ b/evals/lib/distribution-artifacts.mjs
@@ -1,0 +1,239 @@
+// Reading a **shipped** distribution tree — an extracted release archive or an installed
+// skill directory — rather than the checkout it was built from.
+//
+// Why this is a library and not another test helper. Three separate places had grown their
+// own half of this: `plugin-archive-install.test.mjs` resolves links and parses the
+// dispatch table against a staged tree, `skills-install.test.mjs` does the same against
+// what `npx skills add` copies, and the evidence plan on #92 asked a human to eyeball
+// `grep -rn 'agents/skills/'`. The reviews on #104 and #107 said the same thing twice:
+//
+//   #104 — "`grep agents/skills/` checks one known defect, not link closure. Run the
+//           existing full relative-link validator against the downloaded zip."
+//   #107 — "Derive the complete file set from the installed/archive tree and validate
+//           dispatch closure separately … Replace the single-string grep with complete
+//           relative-link closure."
+//
+// Both are asking for the checks that already exist to be *runnable against an artefact*,
+// not restated a third time. So the checks live here, the suites import them, and
+// `evals/tools/verify-plugin-archive.mjs` points them at a downloaded archive.
+//
+// Everything is derived from the tree under test. Nothing in this file may hard-code a
+// count: a snapshot presented as a threshold turns a correct product red on its next
+// routine addition, which is how an acceptance criterion quietly becomes a formality.
+
+import fs from "node:fs";
+import path from "node:path";
+
+/* ------------------------------------------------------ distribution artifact families */
+
+/**
+ * The three artefact families this project distributes, and the README install methods
+ * that consume each one.
+ *
+ * The reviews on #92 and #107 both objected to "three install routes": the README
+ * documents six *methods*, so a pack claiming to cover "all three" is either wrong or
+ * using a word it never defined. It is three **artefact families** — three distinct byte
+ * streams a user can receive — and the methods are equivalent within a family because they
+ * differ only in who does the copying. That equivalence is the claim, so it is written
+ * down here and asserted against the README rather than left implied.
+ *
+ * @type {ReadonlyArray<{id:string, label:string, artifact:string, methods:string[], readmeHeadings:string[]}>}
+ */
+export const ARTIFACT_FAMILIES = Object.freeze([
+  Object.freeze({
+    id: "repository-clone",
+    label: "Repository clone",
+    artifact: "the repository tree at a ref",
+    methods: Object.freeze([
+      "AI-assisted (the agent copies skills/ out of a clone)",
+      "Claude Code plugin (the marketplace clones this repository)",
+      "AgentSkills CLI (`npx skills add` clones, then copies)",
+      "Manual (`git clone` then `cp -r`)",
+    ]),
+    readmeHeadings: Object.freeze([
+      "### AI-assisted (recommended)",
+      "### Claude Code plugin",
+      "### AgentSkills CLI",
+      "### Manual",
+    ]),
+  }),
+  Object.freeze({
+    id: "plugin-archive",
+    label: "Plugin release archive",
+    artifact: "problem-based-srs-v<version>.zip",
+    methods: Object.freeze(["Plugin release archive (download, extract, --plugin-dir)"]),
+    readmeHeadings: Object.freeze(["### Plugin release archive"]),
+  }),
+  Object.freeze({
+    id: "canvas-archive",
+    label: "Canvas release archive",
+    artifact: "srs-navigator-<version>.zip / .tar.gz",
+    methods: Object.freeze(["SRS Navigator canvas app (download, extract, /live)"]),
+    readmeHeadings: Object.freeze(["### SRS Navigator canvas app"]),
+  }),
+]);
+
+/** Every README install heading the families claim to account for. */
+export function coveredReadmeHeadings() {
+  return ARTIFACT_FAMILIES.flatMap((f) => [...f.readmeHeadings]).sort();
+}
+
+/**
+ * The `###` headings inside the README's `## Installation` section — the install methods
+ * the README actually documents, read from it rather than listed here.
+ * @param {string} readme
+ * @returns {string[]}
+ */
+export function readmeInstallHeadings(readme) {
+  const text = String(readme ?? "");
+  const from = text.indexOf("## Installation");
+  if (from === -1) return [];
+  const rest = text.slice(from + "## Installation".length);
+  const end = rest.search(/^## /m);
+  const section = end === -1 ? rest : rest.slice(0, end);
+  return [...section.matchAll(/^### .*$/gm)].map((m) => m[0].trim()).sort();
+}
+
+/* ---------------------------------------------------------------------------- the tree */
+
+/**
+ * Every file under `dir`, as forward-slash paths relative to it. Sorted, so two trees
+ * compare without the caller sorting first.
+ * @param {string} dir
+ * @param {string} [base]
+ * @returns {string[]}
+ */
+export function walkTree(dir, base = dir) {
+  return fs
+    .readdirSync(dir, { withFileTypes: true })
+    .flatMap((entry) => {
+      const full = path.join(dir, entry.name);
+      return entry.isDirectory()
+        ? walkTree(full, base)
+        : [path.relative(base, full).replaceAll("\\", "/")];
+    })
+    .sort();
+}
+
+/* --------------------------------------------------------------------- link resolution */
+
+/**
+ * Markdown link targets that point at another file: not a URL, not a bare anchor, not a
+ * mail link. A trailing `#fragment` is dropped — a link to a heading in a real file is
+ * still a link to that file.
+ * @param {string} md
+ * @returns {string[]}
+ */
+export function relativeLinkTargets(md) {
+  return [...String(md ?? "").matchAll(/\[[^\]]*\]\(\s*([^)\s]+)/g)]
+    .map((m) => m[1])
+    .filter((t) => !/^(?:[a-z][a-z0-9+.-]*:|#|\/\/)/i.test(t))
+    .map((t) => t.split("#")[0])
+    .filter(Boolean);
+}
+
+/**
+ * Resolve every relative markdown link in a shipped tree against that tree.
+ *
+ * Two ways to fail, reported the same way because they have the same consequence for a
+ * reader: the target is missing, or it resolves *outside* the tree. The second is the one
+ * `grep 'agents/skills/'` was standing in for — `../skills/…` from `agents/problem-based-srs/`
+ * lands in `agents/skills/`, a directory that exists in neither the repository nor the
+ * archive. Resolving against the checkout does not ask that question, which is why the
+ * defect shipped.
+ *
+ * @param {string} root
+ * @param {{files?: string[]}} [options]
+ * @returns {{checked:number, links:number, broken:Array<{file:string,target:string,reason:string}>}}
+ */
+export function linkClosure(root, options = {}) {
+  const files = (options.files ?? walkTree(root)).filter((f) => f.endsWith(".md"));
+  const broken = [];
+  let links = 0;
+
+  for (const rel of files) {
+    const abs = path.join(root, rel);
+    const dir = path.dirname(abs);
+    for (const target of relativeLinkTargets(fs.readFileSync(abs, "utf8"))) {
+      links++;
+      const resolved = path.resolve(dir, target);
+      const inside = !path.relative(root, resolved).startsWith("..");
+      if (!inside) broken.push({ file: rel, target, reason: "escapes the tree" });
+      else if (!fs.existsSync(resolved)) broken.push({ file: rel, target, reason: "no such file" });
+    }
+  }
+
+  return { checked: files.length, links, broken };
+}
+
+/* --------------------------------------------------------------------- the skill tree */
+
+/**
+ * The actions `SKILL.md` dispatches, taken from the table that maps each action to its
+ * `reference/<action>.md`. The orchestrator's contract, parsed at runtime.
+ * @param {string} skillMd
+ * @returns {string[]}
+ */
+export function dispatchActions(skillMd) {
+  return [
+    ...String(skillMd ?? "").matchAll(/^\|\s*`([a-z-]+)`\s*\|\s*\[`reference\/([a-z-]+)\.md`\]/gm),
+  ]
+    .filter((m) => m[1] === m[2])
+    .map((m) => m[1]);
+}
+
+/**
+ * Describe an installed skill directory (one holding `SKILL.md` and `reference/`) from the
+ * tree itself.
+ *
+ * The complete file set is *not* the dispatch table. #107's review caught the plan
+ * deriving "12 files" from a nine-row table: the installed tree also carries `SKILL.md`
+ * and the `*-example.md` walkthroughs, which no action dispatches. Two different
+ * questions, so two different answers — `files` records what shipped, `actions` gates
+ * whether the orchestrator resolves.
+ *
+ * @param {string} skillDir absolute path to the skill directory
+ * @returns {{dir:string, files:string[], skillMd:string|null, referenceFiles:string[], exampleFiles:string[], actionFiles:string[]}}
+ */
+export function readInstalledSkill(skillDir) {
+  const files = fs.existsSync(skillDir) ? walkTree(skillDir) : [];
+  const skillMdPath = path.join(skillDir, "SKILL.md");
+  const reference = files.filter((f) => f.startsWith("reference/") && f.endsWith(".md"));
+  return {
+    dir: skillDir,
+    files,
+    skillMd: fs.existsSync(skillMdPath) ? fs.readFileSync(skillMdPath, "utf8") : null,
+    referenceFiles: reference,
+    exampleFiles: reference.filter((f) => f.endsWith("-example.md")),
+    actionFiles: reference.filter((f) => !f.endsWith("-example.md")),
+  };
+}
+
+/**
+ * Does every action the orchestrator dispatches resolve to a file that is actually in the
+ * tree, and does every non-example reference file have an action pointing at it?
+ *
+ * Closure both ways on purpose. "Every action resolves" alone passes a tree that ships a
+ * reference file nothing can reach; "every file is dispatched" alone passes a table that
+ * lost a row. The row it loses first is `live` — the only one with prose after the link.
+ *
+ * @param {ReturnType<typeof readInstalledSkill>} skill
+ * @returns {{actions:string[], shipped:string[], unresolved:string[], undispatched:string[], ok:boolean}}
+ */
+export function dispatchClosure(skill) {
+  const actions = dispatchActions(skill.skillMd ?? "");
+  const shipped = skill.actionFiles.map((f) => path.basename(f, ".md")).sort();
+  const shippedSet = new Set(shipped);
+  const actionSet = new Set(actions);
+  return {
+    actions: [...actions].sort(),
+    shipped,
+    unresolved: [...actions].filter((a) => !shippedSet.has(a)).sort(),
+    undispatched: shipped.filter((a) => !actionSet.has(a)),
+    ok:
+      actions.length > 0 &&
+      shipped.length > 0 &&
+      actions.every((a) => shippedSet.has(a)) &&
+      shipped.every((a) => actionSet.has(a)),
+  };
+}

--- a/evals/tests/distribution-artifacts.test.mjs
+++ b/evals/tests/distribution-artifacts.test.mjs
@@ -1,0 +1,329 @@
+// The distribution-artifacts library reads a *shipped* tree, so its own tests are built
+// from fixture trees rather than from the checkout: a check that only ever sees a healthy
+// repository cannot demonstrate it would notice an unhealthy archive.
+//
+// Every gate below has a **canary** — a purpose-built broken tree the check must reject.
+// #107's review asked for exactly this instead of the alternative on the table
+// ("re-check the thresholds by rerunning the pack after a deliberate, reverted addition"):
+// mutating the tracked tree during a release run adds risk to the release without
+// improving the proof that ships.
+import { describe, it, before, after } from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import {
+  ARTIFACT_FAMILIES,
+  coveredReadmeHeadings,
+  dispatchActions,
+  dispatchClosure,
+  linkClosure,
+  readInstalledSkill,
+  readmeInstallHeadings,
+  relativeLinkTargets,
+  walkTree,
+} from "../lib/distribution-artifacts.mjs";
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(here, "../..");
+const read = (rel) => fs.readFileSync(path.join(repoRoot, rel), "utf8");
+
+/* --------------------------------------------------------------------------- fixtures */
+
+let tmp = "";
+
+/** Build a tree from a `{ "rel/path": "contents" }` map and return its root. */
+function fixture(name, files) {
+  const root = path.join(tmp, name);
+  for (const [rel, body] of Object.entries(files)) {
+    const abs = path.join(root, rel);
+    fs.mkdirSync(path.dirname(abs), { recursive: true });
+    fs.writeFileSync(abs, body);
+  }
+  return root;
+}
+
+/** A dispatch table row, in the shape SKILL.md writes them. */
+const row = (action) => `| \`${action}\` | [\`reference/${action}.md\`](reference/${action}.md) |`;
+
+/** A minimal healthy skill directory: three actions, one example walkthrough. */
+const HEALTHY_SKILL = {
+  "SKILL.md": ["| Action | File |", "|---|---|", row("problems"), row("needs"), row("live")].join(
+    "\n",
+  ),
+  "reference/problems.md": "# problems\n",
+  "reference/needs.md": "# needs\n",
+  "reference/live.md": "# live\n",
+  "reference/crm-example.md": "# a walkthrough, dispatched by nothing\n",
+};
+
+before(() => {
+  tmp = fs.mkdtempSync(path.join(os.tmpdir(), "pbsrs-artifacts-"));
+});
+
+after(() => {
+  if (tmp) fs.rmSync(tmp, { recursive: true, force: true });
+});
+
+/* ---------------------------------------------------------------- families vs. README */
+
+describe("the artifact families account for every install method the README documents", () => {
+  it("maps each family onto README headings that exist", () => {
+    const documented = new Set(readmeInstallHeadings(read("README.md")));
+    assert.ok(
+      documented.size > 0,
+      "no `###` headings parsed out of the README's Installation section — every " +
+        "comparison below would be vacuous, which is how a coverage claim goes quietly false",
+    );
+    for (const family of ARTIFACT_FAMILIES) {
+      for (const heading of family.readmeHeadings) {
+        assert.ok(
+          documented.has(heading),
+          `family "${family.id}" claims README heading ${heading}, which the Installation ` +
+            "section does not have — the mapping is stale",
+        );
+      }
+    }
+  });
+
+  it("leaves no install method unaccounted for", () => {
+    // The claim #92 and #107 both objected to was "three install routes". Six methods, three
+    // artefacts: the number is only defensible while every method maps to a family, so a
+    // seventh method has to be mapped or this fails.
+    const documented = readmeInstallHeadings(read("README.md"));
+    const covered = new Set(coveredReadmeHeadings());
+    const unmapped = documented.filter((h) => !covered.has(h));
+    assert.deepEqual(
+      unmapped,
+      [],
+      "an install method with no artifact family is a distribution path nothing verifies; " +
+        "map it to a family (or add one) rather than letting the pack claim full coverage",
+    );
+  });
+
+  it("names three distinct artifacts, one of which is the plugin release archive", () => {
+    const ids = ARTIFACT_FAMILIES.map((f) => f.id);
+    assert.deepEqual(ids, ["repository-clone", "plugin-archive", "canvas-archive"]);
+    assert.equal(new Set(ARTIFACT_FAMILIES.map((f) => f.artifact)).size, 3);
+    assert.match(
+      ARTIFACT_FAMILIES.find((f) => f.id === "plugin-archive").artifact,
+      /problem-based-srs-v<version>\.zip/,
+      "the family that had no reader at all until #107 — the asset every plugin release " +
+        "attaches",
+    );
+  });
+});
+
+/* ------------------------------------------------------------------------ walking a tree */
+
+describe("walkTree reads the tree it is given", () => {
+  it("returns every file, sorted, with forward slashes", () => {
+    const root = fixture("walk", { "a.md": "a", "deep/nested/b.md": "b", "c.json": "{}" });
+    assert.deepEqual(walkTree(root), ["a.md", "c.json", "deep/nested/b.md"]);
+  });
+
+  it("returns an empty list for an empty tree rather than throwing", () => {
+    const root = path.join(tmp, "empty");
+    fs.mkdirSync(root, { recursive: true });
+    assert.deepEqual(walkTree(root), []);
+  });
+});
+
+/* ------------------------------------------------------------------- link extraction */
+
+describe("relativeLinkTargets keeps only links to other files", () => {
+  it("keeps relative paths and drops fragments", () => {
+    assert.deepEqual(relativeLinkTargets("[a](reference/needs.md#section)"), [
+      "reference/needs.md",
+    ]);
+  });
+
+  it("drops URLs, anchors, mail links and protocol-relative links", () => {
+    const md = [
+      "[iso](https://www.iso.org/standard/72089.html)",
+      "[here](#identifier-notation)",
+      "[mail](mailto:someone@example.com)",
+      "[cdn](//example.com/x.md)",
+    ].join("\n");
+    assert.deepEqual(relativeLinkTargets(md), []);
+  });
+
+  it("survives text with no links at all", () => {
+    assert.deepEqual(relativeLinkTargets("# heading\n\nprose"), []);
+    assert.deepEqual(relativeLinkTargets(null), []);
+  });
+});
+
+/* ---------------------------------------------------------------------- link closure */
+
+describe("linkClosure resolves every markdown link against the shipped tree", () => {
+  it("passes a tree whose links all resolve", () => {
+    const root = fixture("links-ok", {
+      "a.md": "[b](sub/b.md)",
+      "sub/b.md": "[a](../a.md)",
+    });
+    const result = linkClosure(root);
+    assert.deepEqual(result.broken, []);
+    assert.equal(result.links, 2);
+    assert.equal(result.checked, 2);
+  });
+
+  it("CANARY: catches the shipped defect — a link resolving into a directory that exists nowhere", () => {
+    // The real defect, reproduced: `agents/problem-based-srs/AGENT.md` linking `../skills/…`
+    // resolves to `agents/skills/`, a directory that exists in neither the repository nor
+    // the archive. It stays *inside* the tree — which is exactly why it is reported as a
+    // missing file rather than an escape, and exactly why resolving it from the checkout
+    // (where `skills/` does exist one level up) never asked the question.
+    const root = fixture("links-agents-skills", {
+      "agents/problem-based-srs/AGENT.md": "[skill](../skills/problem-based-srs/SKILL.md)",
+      "skills/problem-based-srs/SKILL.md": "# skill",
+    });
+    const { broken } = linkClosure(root);
+    assert.equal(broken.length, 1);
+    assert.equal(broken[0].reason, "no such file");
+    assert.equal(broken[0].file, "agents/problem-based-srs/AGENT.md");
+  });
+
+  it("CANARY: catches a link that escapes the tree entirely", () => {
+    // The other half, and the one a grep for a known bad path can never generalise to: a
+    // target that resolves outside the install root reads fine from a checkout with the
+    // repository around it and is unreachable for everyone who downloaded the archive.
+    const root = fixture("links-escape", {
+      "docs/guide.md": "[paper](../../research/paper.md)",
+    });
+    const { broken } = linkClosure(root);
+    assert.equal(broken.length, 1);
+    assert.equal(broken[0].reason, "escapes the tree");
+  });
+
+  it("CANARY: catches a link to a file that is not shipped", () => {
+    const root = fixture("links-missing", { "a.md": "[gone](reference/deleted.md)" });
+    const { broken } = linkClosure(root);
+    assert.equal(broken.length, 1);
+    assert.equal(broken[0].reason, "no such file");
+  });
+
+  it("checks only markdown, so a JSON manifest's strings are not read as links", () => {
+    const root = fixture("links-json", { "plugin.json": '{"homepage":"(x.md)"}' });
+    assert.equal(linkClosure(root).checked, 0);
+  });
+});
+
+/* ------------------------------------------------------------------ the dispatch table */
+
+describe("dispatchActions parses the orchestrator's contract", () => {
+  it("reads the actions out of a dispatch table", () => {
+    assert.deepEqual(dispatchActions(HEALTHY_SKILL["SKILL.md"]), ["problems", "needs", "live"]);
+  });
+
+  it("ignores a row whose action and file disagree", () => {
+    assert.deepEqual(
+      dispatchActions("| `needs` | [`reference/problems.md`](reference/problems.md) |"),
+      [],
+      "a row pointing at another action's file is a typo, not a dispatch — treating it as " +
+        "one would report the wrong file as reachable",
+    );
+  });
+
+  it("reads the live row, which carries prose after the link", () => {
+    const md = "| `live` | [`reference/live.md`](reference/live.md) | Launch the canvas |";
+    assert.deepEqual(dispatchActions(md), ["live"]);
+  });
+});
+
+/* -------------------------------------------------------- the installed skill and closure */
+
+describe("readInstalledSkill derives the file set from the tree", () => {
+  it("separates action files from example walkthroughs", () => {
+    const root = fixture("skill-ok", HEALTHY_SKILL);
+    const skill = readInstalledSkill(root);
+    assert.deepEqual(skill.actionFiles.map((f) => path.basename(f, ".md")).sort(), [
+      "live",
+      "needs",
+      "problems",
+    ]);
+    assert.deepEqual(skill.exampleFiles, ["reference/crm-example.md"]);
+    assert.equal(skill.files.length, 5);
+  });
+
+  it("does not equate the file count with the action count", () => {
+    // #107's review caught the plan deriving "12 files" from a nine-row dispatch table.
+    // The tree also carries SKILL.md and the walkthroughs, so the two numbers answer
+    // different questions and must not be derived from each other.
+    const skill = readInstalledSkill(fixture("skill-counts", HEALTHY_SKILL));
+    assert.notEqual(skill.files.length, dispatchActions(skill.skillMd).length);
+  });
+
+  it("reports an absent directory as empty rather than throwing", () => {
+    const skill = readInstalledSkill(path.join(tmp, "not-installed"));
+    assert.deepEqual(skill.files, []);
+    assert.equal(skill.skillMd, null);
+  });
+});
+
+describe("dispatchClosure gates on closure, not on counts", () => {
+  it("passes a tree where the table and the reference files agree", () => {
+    const closure = dispatchClosure(readInstalledSkill(fixture("closure-ok", HEALTHY_SKILL)));
+    assert.ok(closure.ok);
+    assert.deepEqual(closure.unresolved, []);
+    assert.deepEqual(closure.undispatched, []);
+  });
+
+  it("stays green when an action is added to both sides", () => {
+    // The property that makes this a gate rather than a snapshot: a tenth action does not
+    // turn a correct tree red, so nobody has to edit the number to match reality.
+    const grown = {
+      ...HEALTHY_SKILL,
+      "SKILL.md": `${HEALTHY_SKILL["SKILL.md"]}\n${row("complexity")}`,
+      "reference/complexity.md": "# complexity\n",
+    };
+    const closure = dispatchClosure(readInstalledSkill(fixture("closure-grown", grown)));
+    assert.ok(closure.ok);
+    assert.equal(closure.actions.length, 4);
+  });
+
+  it("CANARY: fails when a dispatched action ships no reference file", () => {
+    const broken = { ...HEALTHY_SKILL };
+    delete broken["reference/live.md"];
+    const closure = dispatchClosure(readInstalledSkill(fixture("closure-missing", broken)));
+    assert.equal(closure.ok, false);
+    assert.deepEqual(closure.unresolved, ["live"]);
+  });
+
+  it("CANARY: fails when a shipped reference file is unreachable", () => {
+    const orphan = {
+      ...HEALTHY_SKILL,
+      "reference/validate.md": "# nothing dispatches this\n",
+    };
+    const closure = dispatchClosure(readInstalledSkill(fixture("closure-orphan", orphan)));
+    assert.equal(closure.ok, false);
+    assert.deepEqual(closure.undispatched, ["validate"]);
+  });
+
+  it("CANARY: fails on an empty dispatch table instead of passing vacuously", () => {
+    const unparseable = { ...HEALTHY_SKILL, "SKILL.md": "# no table here\n" };
+    const closure = dispatchClosure(readInstalledSkill(fixture("closure-empty", unparseable)));
+    assert.equal(
+      closure.ok,
+      false,
+      "a parser that silently returned nothing would otherwise report a tree with no " +
+        "reachable actions as fully closed",
+    );
+  });
+});
+
+/* ------------------------------------------------------- the real tree still satisfies it */
+
+describe("the repository's own skill satisfies the closure this library gates on", () => {
+  it("closes both ways", () => {
+    const closure = dispatchClosure(readInstalledSkill(path.join(repoRoot, "skills/problem-based-srs")));
+    assert.ok(
+      closure.ok,
+      `the canonical skill fails dispatch closure: unresolved=${closure.unresolved.join(",")} ` +
+        `undispatched=${closure.undispatched.join(",")}`,
+    );
+    assert.ok(closure.actions.includes("live"), "the row with prose after the link");
+  });
+});

--- a/evals/tests/registry-listing-content.test.mjs
+++ b/evals/tests/registry-listing-content.test.mjs
@@ -840,3 +840,127 @@ describe("negative canaries", () => {
     assert.ok(!pageText("<h2>Quality Gate</h2>").includes("Quality Gates"));
   });
 });
+
+/* ------------------------------------- the axis #91's criteria may and may not claim */
+
+// Issue #106 asked for no behaviour change — only for #91's acceptance criteria to stop
+// claiming more than the checker verifies. That correction is only worth writing down if
+// something holds the line it draws, because the criteria are prose and the checker is code.
+//
+// The line runs between two kinds of claim:
+//
+//   checker-gated  — the listing's names and count; the body's readability and heading
+//                    presence; the description *when the page publishes one*; the version
+//                    axis, compared or explicitly reported unverified.
+//   observed       — that the page publishes a description at all, and what its identifiers
+//                    mean. Nothing in the checker answers either.
+//
+// The asymmetry between the description axis and the version axis is the crux: an absent
+// version became a *reported* `registry-skill-version-unverifiable` notice (#88/#101), while
+// an absent description is still dropped silently. The captured page happens to publish a
+// description, so the axis is answered on real runs today — but by a property of the page,
+// not of the checker. These tests pin that as it stands, so #91's criteria describe the
+// checker that exists rather than the one the wording implies.
+describe("the description axis is compared only when the page publishes one", () => {
+  it("compares it when the page publishes one", () => {
+    const profile = shipped();
+    const drift = skillPageDrift({
+      ...pageFor({ description: profile.description, sections: profile.sections }),
+      profile,
+    });
+    assert.equal(drift.description.matches, true);
+    assert.equal(drift.description.actual, profile.description);
+  });
+
+  it("does not compare it when the page publishes none — absence is not agreement", () => {
+    // The trap #91's original criteria walked into. `description: null` reads like "nothing
+    // to report", and a criterion saying "the description matches" would be satisfied by a
+    // page that publishes no description at all.
+    const profile = shipped();
+    const drift = skillPageDrift({
+      ...pageFor({ description: undefined, sections: profile.sections }),
+      profile,
+    });
+    assert.equal(drift.description, null, "no description means no comparison, not a pass");
+    assert.notEqual(drift.description?.matches, true);
+  });
+
+  it("raises nothing about a description the page never published", () => {
+    const profile = shipped();
+    const summary = summarize({
+      listing: { skills: [MAIN_SKILL], count: 1, parts: [] },
+      skillPages: [
+        skillPageDrift({
+          ...pageFor({ description: undefined, sections: profile.sections }),
+          profile,
+        }),
+      ],
+      repoSkills: [MAIN_SKILL],
+      releases: [],
+      links: [],
+      tags: [],
+    });
+    const about = [...summary.findings, ...(summary.unverified ?? [])].filter((f) =>
+      JSON.stringify(f).toLowerCase().includes("description"),
+    );
+    assert.deepEqual(
+      about,
+      [],
+      "an absent description currently produces neither a finding nor a notice — #91 may " +
+        "not claim it was verified",
+    );
+  });
+
+  it("the captured page answers the axis today — which is why 'when present' is the wording", () => {
+    // Not hypothetical in either direction. The page skills.sh served on 2026-07-31 *does*
+    // publish a description, and it agrees with the shipped skill. So #91 may claim the
+    // description was compared — but only because of a property of the page, not of the
+    // checker. If skills.sh stops publishing one, the claim silently becomes unfounded and
+    // nothing goes red. That contingency is the whole content of "when present".
+    const page = parseSkillPage(SKILL_PAGE_FIXTURE);
+    assert.ok(page, "fixture must still parse");
+    assert.ok(page.description, "the captured page publishes a description");
+    const drift = skillPageDrift({ page, text: pageText(SKILL_PAGE_FIXTURE), profile: shipped() });
+    assert.equal(drift.description.matches, true);
+    assert.deepEqual(
+      drift.body.missing.length > 0,
+      true,
+      "and the same page is stale in its body — the axes are independent",
+    );
+  });
+
+  it("the version axis does say so, which is why the two are not interchangeable", () => {
+    // Same shape of absence, different treatment — and #91's criteria have to reflect that
+    // rather than average over it. If the description axis ever grows its own notice, this
+    // fails and the criteria get revisited deliberately.
+    const profile = shipped();
+    const drift = skillPageDrift({
+      ...pageFor({ description: undefined, sections: profile.sections }),
+      profile,
+    });
+    assert.equal(drift.version.status, "page-publishes-none");
+    assert.equal(drift.description, null, "the description axis has no equivalent status");
+    assert.match(
+      CHECKER,
+      /registry-skill-version-unverifiable/,
+      "the reported-unverifiable precedent must still exist for the contrast to hold",
+    );
+  });
+
+  it("body readability is a separate claim from either", () => {
+    // #106 also removed Playwright from its close gate: heading presence is what the checker
+    // reads, and it reads it out of the served HTML — no browser is involved, so a criterion
+    // gated on a rendering harness was gating on the wrong thing.
+    const profile = shipped();
+    const drift = skillPageDrift({
+      ...pageFor({ description: undefined, sections: profile.sections.slice(0, 1) }),
+      profile,
+    });
+    assert.ok(drift.body.readable, "sections are found in served text, not in a rendered DOM");
+    assert.ok(drift.body.missing.length > 0, "and missing ones are still reported");
+    assert.ok(
+      !/playwright|puppeteer|headless/i.test(CHECKER),
+      "the checker must not need a browser for the axis #91 gates on",
+    );
+  });
+});

--- a/evals/tests/release-verification-runbook.test.mjs
+++ b/evals/tests/release-verification-runbook.test.mjs
@@ -1,0 +1,275 @@
+// `docs/release-verification.md` is the runbook a maintainer follows during a release, and
+// the reviews on #104 and #108 both made the same point about it: the previous copy of these
+// instructions lived in `.spec/release-readiness/execution-plan.md`, which is gitignored — so
+// the procedure a future maintainer needed was unavailable to them, and nothing could tell
+// whether it still matched the workflows it described.
+//
+// A runbook whose commands have drifted from the pipeline is worse than none: it is followed.
+// So this suite does not check that the file says the right words. It reads the workflows,
+// the README and the shared library, derives what the runbook must say, and asserts the file
+// agrees. When the pipeline changes, this fails — which is the only way a document like this
+// stays true without a human re-reading it every release.
+import { describe, it, before } from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import { spawnSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
+
+import {
+  ARTIFACT_FAMILIES,
+  coveredReadmeHeadings,
+  readmeInstallHeadings,
+} from "../lib/distribution-artifacts.mjs";
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(here, "../..");
+const read = (rel) => fs.readFileSync(path.join(repoRoot, rel), "utf8");
+
+let runbook = "";
+let createRelease = "";
+let releaseCanvas = "";
+
+before(() => {
+  runbook = read("docs/release-verification.md");
+  createRelease = read(".github/workflows/create-release.yml");
+  releaseCanvas = read(".github/workflows/release-canvas.yml");
+});
+
+/* ------------------------------------------------------------------------ it is durable */
+
+describe("the runbook is somewhere a maintainer can actually read it", () => {
+  it("is tracked, not gitignored like the plan the reviews flagged", (t) => {
+    // The whole reason this file exists. Ask git rather than pattern-match `.gitignore`:
+    // the ignore file has several `docs/**` entries already, so a hand-rolled check would
+    // answer a different question than the one that matters — is *this file* visible.
+    const ignored = (rel) =>
+      spawnSync("git", ["check-ignore", "-q", rel], { cwd: repoRoot }).status === 0;
+    if (spawnSync("git", ["rev-parse", "--git-dir"], { cwd: repoRoot }).status !== 0) {
+      t.skip("not a git checkout");
+      return;
+    }
+    assert.ok(
+      ignored(".spec/release-readiness/execution-plan.md"),
+      "assumption changed: .spec/ is no longer ignored",
+    );
+    assert.ok(
+      !ignored("docs/release-verification.md"),
+      "the runbook is ignored — that is exactly the defect it was written to fix",
+    );
+    assert.ok(fs.existsSync(path.join(repoRoot, "docs/release-verification.md")));
+  });
+
+  it("is reachable from the policy document rather than duplicating it", () => {
+    const instructions = read(".github/copilot-instructions.md");
+    assert.match(
+      instructions,
+      /docs\/release-verification\.md/,
+      "copilot-instructions.md must link the runbook, or the steps are orphaned again",
+    );
+  });
+});
+
+/* ------------------------------------------------------- families derived from the README */
+
+describe("the artefact-families table is derived from the README, not asserted about it", () => {
+  it("names every family the shared library defines", () => {
+    for (const family of ARTIFACT_FAMILIES) {
+      assert.match(
+        runbook,
+        new RegExp(`\\*\\*${family.label}\\*\\*`),
+        `the runbook does not list the ${family.id} family`,
+      );
+    }
+  });
+
+  it("claims the same method count the README actually documents", () => {
+    // #107's review: "three install routes" undercounted the methods *and* overstated what
+    // three transcripts cover. The corrected claim is N methods delivering 3 byte streams —
+    // and N is read from the README so adding a seventh method fails here.
+    const methods = readmeInstallHeadings(read("README.md"));
+    const words = ["zero", "one", "two", "three", "four", "five", "six", "seven", "eight"];
+    assert.match(
+      runbook,
+      new RegExp(`\\*\\*${words[methods.length]}\\*\\* install methods`, "i"),
+      `the README documents ${methods.length} install methods; the runbook says otherwise`,
+    );
+    assert.match(
+      runbook,
+      new RegExp(`\\*\\*${words[ARTIFACT_FAMILIES.length]}\\*\\* distinct byte streams`, "i"),
+    );
+  });
+
+  it("covers every README method through some family", () => {
+    const documented = readmeInstallHeadings(read("README.md"));
+    const covered = coveredReadmeHeadings();
+    assert.deepEqual(
+      documented.filter((h) => !covered.includes(h)),
+      [],
+      "a README install method belongs to no artefact family",
+    );
+  });
+
+  it("cites the verifier for the family that had no reader", () => {
+    // The gap #107 opened with: the plugin archive was staged-and-checked, never *loaded*.
+    assert.match(runbook, /evals\/tools\/verify-plugin-archive\.mjs/);
+    assert.match(runbook, /evals\/tests\/plugin-archive-install\.test\.mjs/);
+  });
+});
+
+/* -------------------------------------------------- commands derived from the workflows */
+
+describe("the plugin-train commands match what create-release.yml does", () => {
+  it("pins the recovery dispatch to the tag, because the workflow checks out the ref", () => {
+    // Derived, not restated: the workflow's checkout has no `ref:`, so it takes the
+    // dispatched ref, and `gh workflow run` defaults to the default branch. If someone adds
+    // an explicit `ref:` to the workflow, this test tells them the runbook needs rewriting.
+    assert.match(createRelease, /actions\/checkout@v\d/, "workflow no longer checks out");
+    const checkoutBlock = createRelease.slice(createRelease.indexOf("actions/checkout@"));
+    const nextStep = checkoutBlock.indexOf("\n      - ");
+    assert.ok(
+      !/^\s+ref:/m.test(nextStep === -1 ? checkoutBlock : checkoutBlock.slice(0, nextStep)),
+      "create-release.yml now pins its own ref; the runbook's --ref rationale is stale",
+    );
+    assert.match(
+      runbook,
+      /gh workflow run create-release\.yml --ref vX\.Y -f version=X\.Y/,
+      "the recovery command must pin --ref or it packages main against a tag",
+    );
+    assert.match(runbook, /`--ref` is not optional/);
+  });
+
+  it("looks the run up by event, ref and commit rather than by --limit 1", () => {
+    // `--limit 1` races with any concurrent run, and the evidence then records a green run
+    // that is not the release run — which is unfalsifiable after the fact.
+    for (const filter of ["--event push", "--branch vX.Y", "--commit"]) {
+      assert.ok(runbook.includes(filter), `run lookup is missing ${filter}`);
+    }
+    assert.match(runbook, /gh run watch "\$RUN" --exit-status/);
+    assert.ok(
+      !/gh run list[^\n]*--limit 1 --json databaseId[^\n]*\n[^\n]*gh run watch\s*$/m.test(runbook),
+      "the runbook must record which run it watched",
+    );
+  });
+
+  it("names the tag the pipeline creates, not the manifest string", () => {
+    assert.match(runbook, /normalizes the version/);
+    assert.match(runbook, /2\.6\.0.*publishes at\s*\n?\*\*`v2\.6`\*\*/s);
+  });
+
+  it("verifies the downloaded asset, not the repository at that ref", () => {
+    assert.match(runbook, /gh release download vX\.Y -p 'problem-based-srs-\*\.zip'/);
+    assert.match(runbook, /npx skills add.*clones the repository; it never opens the release/s);
+  });
+
+  it("explains the link closure instead of the grep it replaced", () => {
+    assert.match(runbook, /replaces `grep -rn 'agents\/skills\/'`/);
+    assert.match(runbook, /link closure/);
+    assert.match(runbook, /Counts in its output are \*\*recorded, not gated\*\*/);
+  });
+});
+
+describe("the canvas-train commands match what release-canvas.yml does", () => {
+  it("does not tell anyone to push a canvas tag by hand", () => {
+    // The canvas train creates its tag as part of publishing (`gh release create --target`),
+    // which is what makes a failed publish unable to strand a tag. A runbook that said
+    // `git tag vX.Y.Z` would break that property.
+    assert.match(releaseCanvas, /workflow_dispatch/);
+    assert.ok(
+      !/git tag vX\.Y\.Z/.test(runbook),
+      "the canvas train must not be documented as hand-tagged",
+    );
+    assert.match(runbook, /gh workflow run release-canvas\.yml/);
+  });
+
+  it("orders the recovery delete-then-rerun, because bump-version skips existing tags", () => {
+    const deleteAt = runbook.indexOf("git push --delete origin vX.Y.Z");
+    const rerunAt = runbook.indexOf("gh workflow run release-canvas.yml", deleteAt);
+    assert.ok(deleteAt !== -1 && rerunAt > deleteAt, "delete must precede the re-run");
+    assert.match(runbook, /skips any version whose tag exists/);
+  });
+
+  it("warns against hand-bumping VERSION, which the workflow owns", () => {
+    assert.match(releaseCanvas, /bump-version\.mjs/);
+    assert.match(runbook, /Do not hand-bump `VERSION`/);
+  });
+});
+
+/* ------------------------------------------------- the /live claim, derived from the code */
+
+describe("the /live section separates the two installs it actually depends on", () => {
+  it("says the command ships with the skill, not the canvas archive", () => {
+    assert.ok(
+      fs.existsSync(path.join(repoRoot, "skills/problem-based-srs/reference/live.md")),
+      "the runbook cites reference/live.md as the source of /live",
+    );
+    assert.match(runbook, /skills\/problem-based-srs\/reference\/live\.md/);
+  });
+
+  it("is right that the canvas tool cannot dispatch live", () => {
+    // Derived from extension.mjs: if `live` were ever added to the action enum, installing
+    // only the canvas archive *would* be a fair test of `/live`, and this paragraph would be
+    // wrong. Read it rather than trust it.
+    const ext = read(".github/extensions/srs-navigator/extension.mjs");
+    const table = ext.match(/const ACTIONS = \[([\s\S]*?)\];/);
+    assert.ok(table, "could not find the ACTIONS table in extension.mjs");
+    const actions = [...table[1].matchAll(/action:\s*["']([a-z-]+)["']/g)].map((m) => m[1]);
+    assert.ok(actions.length >= 9, `only found ${actions.length} actions; parser is stale`);
+    assert.match(ext, /enum:\s*ACTIONS\.map/, "the tool's enum no longer comes from ACTIONS");
+    assert.ok(
+      !actions.includes("live"),
+      "extension.mjs now dispatches `live`; the runbook's command-source table is stale",
+    );
+    assert.match(runbook, /action enum does \*\*not\*\* include `live`/);
+  });
+
+  it("requires workspace isolation, not merely an empty extensions directory", () => {
+    // #105's correction. This repository's own workspace contributes the project extension,
+    // so "the extensions directory is empty" does not make the run a clean loader test.
+    assert.ok(
+      fs.existsSync(path.join(repoRoot, ".github/extensions/srs-navigator/extension.mjs")),
+      "the project extension is what makes this workspace non-neutral",
+    );
+    assert.match(runbook, /neutral workspace/);
+    assert.match(runbook, /registers the same\s*\n?\s*canvas id and tool name twice/);
+  });
+
+  it("forbids substituting the loopback capture for a failed load", () => {
+    assert.match(runbook, /A failed load is a result/);
+    assert.match(runbook, /cannot be substituted/);
+  });
+});
+
+/* ------------------------------------------------------------------- the evidence pack */
+
+describe("the evidence-pack section keeps derived and recorded apart", () => {
+  it("labels the skill file count as recorded and says why it cannot be derived", () => {
+    // #107's review: the 9-row dispatch table cannot produce the 12-file total, because the
+    // tree also carries SKILL.md and the example walkthroughs that no action dispatches.
+    assert.match(runbook, /\*recorded\* from the installed tree; never a gate/);
+    assert.match(runbook, /`SKILL\.md` and the `\*-example\.md` walkthroughs/);
+  });
+
+  it("labels the graph figures as derived and names the function that derives them", () => {
+    assert.match(runbook, /graph-metrics\.mjs/);
+    assert.match(runbook, /degree ≥ 4 graph property, not an array length/);
+    assert.ok(
+      fs.existsSync(path.join(repoRoot, ".github/extensions/srs-navigator/lib/graph-metrics.mjs")),
+      "the runbook cites a module that must exist",
+    );
+  });
+
+  it("reads a clean --strict run as zero errors, not as a readable surface", () => {
+    // check-distribution.mjs exits 0 on warnings and notices by design. A pack that reported
+    // "exit 0" as "everything verified" would be quoting the wrong property.
+    const checker = read("scripts/check-distribution.mjs");
+    assert.match(checker, /notice/, "severity model changed; re-read this claim");
+    assert.match(runbook, /zero \*\*\*error\*\* findings\*\*|zero \*error\* findings/);
+    assert.match(runbook, /every warning and notice explained/);
+  });
+
+  it("prescribes fixture canaries rather than mutating the tracked tree", () => {
+    assert.match(runbook, /\*\*fixture canaries\*\*/);
+    assert.match(runbook, /not by mutating the tracked tree/);
+  });
+});

--- a/evals/tests/tag-without-release.test.mjs
+++ b/evals/tests/tag-without-release.test.mjs
@@ -194,6 +194,26 @@ describe("the recovery each train actually needs", () => {
     assert.match(text, /-f version=2\.6/, "the dispatch input must carry the version");
   });
 
+  it("pins the dispatch to the tag, so the recovery packages the tagged commit", () => {
+    // #104's review: "Recovery must pin provenance: `gh workflow run create-release.yml
+    // --ref v2.6 -f version=2.6`; otherwise a later `main` can package bytes different
+    // from the tag." The failure this prevents is worse than the one it recovers from —
+    // the release exists, looks right, and does not match its own tag.
+    const text = pluginText();
+    assert.match(
+      text,
+      /gh workflow run create-release\.yml --ref v2\.6 -f version=2\.6/,
+      "without --ref, `gh workflow run` dispatches on the default branch and the workflow " +
+        "checks that out, so the asset is built from main rather than from v2.6",
+    );
+    assert.match(
+      text,
+      /--ref pins the provenance/i,
+      "the flag without its reason is the first thing dropped when someone retypes the " +
+        "command from memory",
+    );
+  });
+
   it("says why re-pushing the tag does nothing, instead of leaving it to be re-tried", () => {
     assert.match(
       pluginText(),
@@ -256,6 +276,20 @@ describe("the instructions are derived from the pipelines, not asserted about th
     assert.ok(
       !/^\s*(git tag|- run: git tag)/m.test(steps),
       "the plugin workflow must never create the tag itself — the tag is its trigger",
+    );
+  });
+
+  it("create-release.yml checks out the dispatched ref, which is why --ref is load-bearing", () => {
+    // The advice's reason, derived from the workflow rather than asserted about it. A
+    // `ref:` added to that checkout would make --ref decorative, and this test says so
+    // rather than letting the instruction quietly become superstition.
+    const wf = read(".github/workflows/create-release.yml");
+    const release = wf.slice(wf.indexOf("  release:"));
+    const checkout = release.slice(release.indexOf("actions/checkout@v4"));
+    assert.ok(
+      !/^\s+with:\s*\n\s+ref:/m.test(checkout.slice(0, 200)),
+      "the release job checks out with no explicit ref, so it packages whatever ref the run " +
+        "was dispatched on — that is the entire reason the recovery must pass --ref",
     );
   });
 

--- a/evals/tests/verify-plugin-archive.test.mjs
+++ b/evals/tests/verify-plugin-archive.test.mjs
@@ -1,0 +1,354 @@
+// `evals/tools/verify-plugin-archive.mjs` is the reader for the third artefact family —
+// the `problem-based-srs-vX.Y.zip` a plugin release attaches. It is a *tool*, meant to be
+// pointed at a downloaded archive during a release, so this suite proves two things a
+// release cannot afford to discover late:
+//
+//   1. it passes the archive this repository actually produces (built here, with the
+//      packager, not described);
+//   2. it *fails* each of the defects it exists to catch — every gate has a canary.
+//
+// The canaries are fixture trees. #107's review specifically asked for that rather than a
+// "deliberate, reverted addition" to the tracked tree: mutating `main` mid-release adds
+// risk to the release without improving the proof that ships.
+import { describe, it, before, after } from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { spawnSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
+
+import {
+  MANIFEST,
+  findPluginRoot,
+  formatReport,
+  parseArgs,
+  sha256,
+  verifyPluginArchive,
+} from "../tools/verify-plugin-archive.mjs";
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(here, "../..");
+
+let tmp = "";
+
+/* --------------------------------------------------------------------------- fixtures */
+
+const row = (action) => `| \`${action}\` | [\`reference/${action}.md\`](reference/${action}.md) |`;
+
+/** The smallest tree that is a valid plugin archive: manifest, skill, dispatch, links. */
+function healthyArchive(overrides = {}) {
+  return {
+    "problem-based-srs/.claude-plugin/plugin.json": JSON.stringify({
+      name: "problem-based-srs",
+      version: "9.9.9",
+    }),
+    "problem-based-srs/skills/problem-based-srs/SKILL.md": [
+      "| Action | File |",
+      "|---|---|",
+      row("problems"),
+      row("live"),
+    ].join("\n"),
+    "problem-based-srs/skills/problem-based-srs/reference/problems.md": "# problems\n",
+    "problem-based-srs/skills/problem-based-srs/reference/live.md": "# live\n",
+    "problem-based-srs/agents/problem-based-srs/AGENT.md":
+      "[skill](../../skills/problem-based-srs/SKILL.md)\n",
+    ...overrides,
+  };
+}
+
+function fixture(name, files) {
+  const root = path.join(tmp, name);
+  fs.rmSync(root, { recursive: true, force: true });
+  for (const [rel, body] of Object.entries(files)) {
+    const abs = path.join(root, rel);
+    fs.mkdirSync(path.dirname(abs), { recursive: true });
+    fs.writeFileSync(abs, body);
+  }
+  return root;
+}
+
+const failed = (record, id) => record.checks.find((c) => c.id === id && !c.ok);
+const passed = (record, id) => record.checks.find((c) => c.id === id && c.ok);
+
+before(() => {
+  tmp = fs.mkdtempSync(path.join(os.tmpdir(), "pbsrs-verify-tool-"));
+});
+
+after(() => {
+  if (tmp) fs.rmSync(tmp, { recursive: true, force: true });
+});
+
+/* -------------------------------------------------------------------- locating the root */
+
+describe("findPluginRoot accepts either thing a maintainer will point at", () => {
+  it("accepts the plugin root itself", () => {
+    const root = fixture("root-direct", healthyArchive());
+    assert.equal(
+      findPluginRoot(path.join(root, "problem-based-srs")),
+      path.join(root, "problem-based-srs"),
+    );
+  });
+
+  it("accepts the directory the archive was extracted into", () => {
+    // `unzip -d /tmp/x` gives /tmp/x/problem-based-srs, because the archive carries its own
+    // root. Requiring the caller to know which one is a guess they will get wrong once.
+    const root = fixture("root-nested", healthyArchive());
+    assert.equal(findPluginRoot(root), path.join(root, "problem-based-srs"));
+  });
+
+  it("refuses a directory with no manifest rather than reporting an empty archive", () => {
+    const root = fixture("root-none", { "readme.txt": "not a plugin" });
+    assert.throws(() => findPluginRoot(root), new RegExp(`no ${MANIFEST.replace(/[.]/g, "\\.")}`));
+  });
+
+  it("refuses to guess between two plugin roots", () => {
+    const root = fixture("root-two", {
+      ...healthyArchive(),
+      "other-plugin/.claude-plugin/plugin.json": '{"name":"other-plugin","version":"1.0.0"}',
+    });
+    assert.throws(() => findPluginRoot(root), /2 plugin roots/);
+  });
+
+  it("says so when the path does not exist at all", () => {
+    assert.throws(() => findPluginRoot(path.join(tmp, "nope")), /no such directory/);
+    assert.throws(() => findPluginRoot(""), /no directory given/);
+  });
+});
+
+/* ---------------------------------------------------------------- the healthy archive */
+
+describe("a well-formed archive passes every gate", () => {
+  let record;
+
+  before(() => {
+    record = verifyPluginArchive(fixture("healthy", healthyArchive()));
+  });
+
+  it("loads the manifest and identifies the plugin", () => {
+    assert.ok(passed(record, "manifest-parses"));
+    assert.ok(passed(record, "manifest-identifies-the-plugin"));
+    assert.equal(record.manifest.name, "problem-based-srs");
+    assert.equal(record.manifest.version, "9.9.9");
+    assert.match(record.manifest.sha256, /^[0-9a-f]{64}$/);
+  });
+
+  it("resolves the dispatch table against the files in the archive", () => {
+    assert.ok(passed(record, "skill-problem-based-srs-dispatch-resolves"));
+    assert.deepEqual(record.skills[0].dispatch.actions, ["live", "problems"]);
+  });
+
+  it("resolves every relative link inside the archive", () => {
+    assert.ok(passed(record, "relative-links-resolve-inside-the-archive"));
+    assert.deepEqual(record.links.broken, []);
+  });
+
+  it("is ok overall", () => {
+    assert.equal(record.ok, true);
+  });
+
+  it("records counts without gating on them", () => {
+    // The distinction #107 exists to enforce: `observed` is a transcript, `checks` is the
+    // contract. If a count ever became a check, a tenth action would fail a correct archive.
+    assert.ok(record.observed.files > 0);
+    assert.ok(record.observed.actions > 0);
+    const countGate = record.checks.find((c) => /\b\d+ (files|actions) exactly\b/.test(c.id));
+    assert.equal(countGate, undefined);
+    assert.match(record.observed.note, /recorded, not asserted/i);
+  });
+
+  it("stays green when an action is added to both sides", () => {
+    const grown = healthyArchive();
+    grown["problem-based-srs/skills/problem-based-srs/SKILL.md"] += `\n${row("needs")}`;
+    grown["problem-based-srs/skills/problem-based-srs/reference/needs.md"] = "# needs\n";
+    const after = verifyPluginArchive(fixture("healthy-grown", grown));
+    assert.equal(after.ok, true, "a routine addition must not turn a correct archive red");
+    assert.equal(after.observed.actions, record.observed.actions + 1);
+  });
+});
+
+/* --------------------------------------------------------------------------- canaries */
+
+describe("CANARIES — each gate rejects the defect it exists to catch", () => {
+  it("rejects a manifest that is not readable JSON", () => {
+    const record = verifyPluginArchive(
+      fixture("bad-json", {
+        ...healthyArchive(),
+        "problem-based-srs/.claude-plugin/plugin.json": "{ not json",
+      }),
+    );
+    assert.equal(record.ok, false);
+    assert.ok(failed(record, "manifest-parses"));
+  });
+
+  it("rejects a manifest missing a name or version", () => {
+    const record = verifyPluginArchive(
+      fixture("no-version", {
+        ...healthyArchive(),
+        "problem-based-srs/.claude-plugin/plugin.json": '{"name":"problem-based-srs"}',
+      }),
+    );
+    assert.equal(record.ok, false);
+    assert.ok(failed(record, "manifest-identifies-the-plugin"));
+  });
+
+  it("rejects an archive whose root does not match the name the manifest declares", () => {
+    // The README tells installers to extract into the directory *above* the plugin and then
+    // point at `<name>/`. A root that disagrees breaks that instruction silently.
+    const record = verifyPluginArchive(
+      fixture("wrong-root", {
+        "some-other-name/.claude-plugin/plugin.json": JSON.stringify({
+          name: "problem-based-srs",
+          version: "9.9.9",
+        }),
+      }),
+    );
+    assert.equal(record.ok, false);
+    assert.ok(failed(record, "archive-root-matches-the-manifest-name"));
+  });
+
+  it("rejects an archive that ships no skill at all", () => {
+    const record = verifyPluginArchive(
+      fixture("no-skills", {
+        "problem-based-srs/.claude-plugin/plugin.json": JSON.stringify({
+          name: "problem-based-srs",
+          version: "9.9.9",
+        }),
+      }),
+    );
+    assert.equal(record.ok, false);
+    assert.ok(failed(record, "ships-at-least-one-skill"));
+  });
+
+  it("rejects a dispatched action whose reference file was not packaged", () => {
+    const broken = healthyArchive();
+    delete broken["problem-based-srs/skills/problem-based-srs/reference/live.md"];
+    const record = verifyPluginArchive(fixture("missing-action", broken));
+    assert.equal(record.ok, false);
+    assert.match(failed(record, "skill-problem-based-srs-dispatch-resolves").detail, /live/);
+  });
+
+  it("rejects the link defect that actually shipped", () => {
+    // `../skills/…` from `agents/problem-based-srs/` lands in `agents/skills/`, which exists
+    // nowhere. This is the check that replaces `grep -rn 'agents/skills/'` — it catches the
+    // shape, not the string, so the next one of these is caught too.
+    const record = verifyPluginArchive(
+      fixture("dangling-link", {
+        ...healthyArchive(),
+        "problem-based-srs/agents/problem-based-srs/AGENT.md":
+          "[skill](../skills/problem-based-srs/SKILL.md)\n",
+      }),
+    );
+    assert.equal(record.ok, false);
+    const check = failed(record, "relative-links-resolve-inside-the-archive");
+    assert.match(check.detail, /AGENT\.md/);
+    assert.doesNotMatch(
+      check.detail,
+      /grep/,
+      "the check must describe the closure it ran, not the string it used to look for",
+    );
+  });
+
+  it("rejects an archive carrying development tooling", () => {
+    const record = verifyPluginArchive(
+      fixture("with-tooling", {
+        ...healthyArchive(),
+        "problem-based-srs/node_modules/left-pad/index.js": "module.exports = 1;",
+      }),
+    );
+    assert.equal(record.ok, false);
+    assert.ok(failed(record, "carries-no-development-tooling"));
+  });
+});
+
+/* ---------------------------------------------------------- the archive we really ship */
+
+describe("the archive this repository packages passes", () => {
+  it("verifies the real packaged zip, or skips if there is no interpreter", (t) => {
+    // Layer B of the same split `plugin-archive-install.test.mjs` uses: only the fidelity
+    // cross-check needs Python, and only it may skip. Probing for the interpreter separately
+    // keeps a broken packager from being reported as a missing interpreter.
+    const python = ["python3", "python"].find(
+      (exe) => spawnSync(exe, ["--version"], { encoding: "utf8" }).status === 0,
+    );
+    if (!python) {
+      t.skip("no python interpreter available to package the archive");
+      return;
+    }
+    const out = path.join(tmp, "real-zip");
+    fs.mkdirSync(out, { recursive: true });
+    const res = spawnSync(
+      python,
+      ["-B", path.join(repoRoot, "scripts/build-plugin.py"), "package", "--out-dir", out],
+      { encoding: "utf8", cwd: repoRoot, env: { ...process.env, PYTHONDONTWRITEBYTECODE: "1" } },
+    );
+    assert.equal(res.status, 0, `packaging failed:\n${res.stdout ?? ""}${res.stderr ?? ""}`);
+
+    const zip = fs.readdirSync(out).find((f) => f.endsWith(".zip"));
+    assert.ok(zip, "package() must emit an archive");
+    const extracted = path.join(out, "extracted");
+    fs.mkdirSync(extracted, { recursive: true });
+    const unzip =
+      process.platform === "win32"
+        ? spawnSync(
+            "powershell",
+            [
+              "-NoProfile",
+              "-Command",
+              `Expand-Archive -Force -LiteralPath '${path.join(out, zip)}' -DestinationPath '${extracted}'`,
+            ],
+            { encoding: "utf8" },
+          )
+        : spawnSync("unzip", ["-q", path.join(out, zip), "-d", extracted], { encoding: "utf8" });
+    assert.equal(unzip.status, 0, `could not extract the archive: ${unzip.stderr}`);
+
+    const record = verifyPluginArchive(extracted);
+    assert.equal(
+      record.ok,
+      true,
+      `the archive this repository ships fails its own verifier:\n${formatReport(record)}`,
+    );
+    assert.equal(record.manifest.name, "problem-based-srs");
+    assert.ok(record.observed.actions >= 9, "the methodology's dispatch table shrank");
+  });
+});
+
+/* -------------------------------------------------------------------------- the CLI */
+
+describe("the CLI surface", () => {
+  it("parses the options the runbook uses", () => {
+    assert.deepEqual(parseArgs(["/tmp/x", "--json", "e.json", "--quiet"]), {
+      dir: "/tmp/x",
+      json: "e.json",
+      quiet: true,
+      help: false,
+    });
+  });
+
+  it("refuses unknown options and stray arguments rather than ignoring them", () => {
+    assert.throws(() => parseArgs(["--nope"]), /unknown option/);
+    assert.throws(() => parseArgs(["a", "b"]), /unexpected argument/);
+  });
+
+  it("renders a transcript that separates gates from recorded values", () => {
+    const text = formatReport(verifyPluginArchive(fixture("report", healthyArchive())));
+    assert.match(text, /checks \(derived — these gate the exit code\)/);
+    assert.match(text, /observed \(recorded — these gate nothing\)/);
+    assert.match(text, /RESULT: every gate passed/);
+  });
+
+  it("names the failing gate in the transcript, so the record is self-explaining", () => {
+    const broken = healthyArchive();
+    delete broken["problem-based-srs/skills/problem-based-srs/reference/live.md"];
+    const text = formatReport(verifyPluginArchive(fixture("report-bad", broken)));
+    assert.match(text, /FAIL {2}skill-problem-based-srs-dispatch-resolves/);
+    assert.match(text, /RESULT: at least one gate failed/);
+  });
+
+  it("hashes what it read, so the record names the bytes", () => {
+    const root = fixture("hash", healthyArchive());
+    const file = path.join(root, "problem-based-srs", MANIFEST);
+    assert.equal(sha256(file), sha256(file));
+    assert.match(sha256(file), /^[0-9a-f]{64}$/);
+  });
+});

--- a/evals/tools/open-archive-canvas.mjs
+++ b/evals/tools/open-archive-canvas.mjs
@@ -21,15 +21,25 @@
 // Usage:
 //   node evals/tools/open-archive-canvas.mjs <extracted-archive-dir> [options]
 //
-//   --spec <file>      render this specification JSON instead of the archive's demo
-//   --instance <id>    canvas instance id (default: open-archive-canvas)
-//   --landing          keep the extension's "no spec found" landing overlay
+//   --spec <file>        render this specification JSON instead of the archive's demo
+//   --instance <id>      canvas instance id (default: open-archive-canvas)
+//   --landing            keep the extension's "no spec found" landing overlay
+//   --provenance <file>  write the capture-source record (see below) as JSON
 //
 // The URL is the only thing written to stdout, so this composes:
 //   CANVAS_URL=$(node evals/tools/open-archive-canvas.mjs /tmp/ext/srs-navigator)
+//
+// `--provenance` exists because of #105's first acceptance criterion: *"the evidence
+// records the source of the capture — extracted archive path and loopback URL — so it
+// cannot be confused with a checkout capture."* A PNG carries no provenance of its own, and
+// `live-dotted-notation.png` looks identical whether the pixels came from the published
+// archive or from `lib/`. `assertExtractedArchive()` stops the wrong tree being *booted*;
+// this records which tree was booted, by path, version and content hash, so the record
+// survives being copied into an issue.
 
 import fs from "node:fs";
 import path from "node:path";
+import crypto from "node:crypto";
 import { pathToFileURL } from "node:url";
 
 /** The single bare specifier the Copilot app injects; everything else must be in the archive. */
@@ -232,15 +242,85 @@ export async function openArchiveCanvas(dir, options = {}) {
   };
 }
 
+/* ------------------------------------------------------------------------ provenance */
+
+/**
+ * What the Copilot app supplies and what the archive supplies are different sources, and
+ * `/live` needs both. The canvas archive registers the `srs-navigator` canvas and the
+ * `problem_based_srs` tool; that tool's action enum does **not** contain `live`, because
+ * `/live` is a *skill* action backed by `reference/live.md`, which travels in the plugin /
+ * skills install. Recorded here so an evidence pack naming "`/live` opened the graph"
+ * states which install supplied the command and which supplied the panel — #105's review:
+ * *"record the separately installed skill that supplies `/live`."*
+ */
+export const LIVE_COMMAND_SOURCES = Object.freeze({
+  command: Object.freeze({
+    source: "skills install (plugin archive or `npx skills add`)",
+    evidence: "skills/problem-based-srs/reference/live.md",
+    note: "the canvas archive's tool action enum excludes `live` — it is not the command's source",
+  }),
+  panel: Object.freeze({
+    source: "canvas archive install",
+    evidence: "srs-navigator/extension.mjs registers the `srs-navigator` canvas",
+    note: "extract into the directory above the extension, e.g. ~/.copilot/extensions/",
+  }),
+});
+
+/**
+ * A record naming the bytes a capture came from.
+ *
+ * `extension.mjs`'s hash is the load-bearing field: a path can be re-pointed and a version
+ * string can be stale, but two runs quoting the same digest read the same code.
+ *
+ * @param {{extensionDir:string, url:string, instanceId?:string, specName?:string|null}} opened
+ * @returns {object}
+ */
+export function captureProvenance(opened) {
+  const { extensionDir, url, instanceId = null, specName = null } = opened;
+  const entry = path.join(extensionDir, "extension.mjs");
+  let version = null;
+  try {
+    version = JSON.parse(fs.readFileSync(path.join(extensionDir, "package.json"), "utf8")).version;
+  } catch {
+    version = null;
+  }
+  return {
+    tool: "open-archive-canvas",
+    capturedAt: new Date().toISOString(),
+    source: "extracted release archive",
+    extensionDir,
+    realPath: fs.existsSync(extensionDir) ? fs.realpathSync(extensionDir) : extensionDir,
+    archiveVersion: version,
+    extensionSha256: fs.existsSync(entry)
+      ? crypto.createHash("sha256").update(fs.readFileSync(entry)).digest("hex")
+      : null,
+    url,
+    instanceId,
+    specName,
+    liveCommandSources: LIVE_COMMAND_SOURCES,
+    note:
+      "This proves the published archive's runtime rendered the capture. It does not prove " +
+      "the Copilot app's own extension loader accepted it — that is a separate witness, " +
+      "taken in a clean profile with every project copy of the extension disabled.",
+  };
+}
+
 /* --------------------------------------------------------------------------------- CLI */
 
 function parseArgs(argv) {
-  const out = { dir: null, specPath: null, instanceId: undefined, landing: false };
+  const out = {
+    dir: null,
+    specPath: null,
+    instanceId: undefined,
+    landing: false,
+    provenance: null,
+  };
   for (let i = 0; i < argv.length; i++) {
     const arg = argv[i];
     if (arg === "--spec") out.specPath = argv[++i];
     else if (arg === "--instance") out.instanceId = argv[++i];
     else if (arg === "--landing") out.landing = true;
+    else if (arg === "--provenance") out.provenance = argv[++i];
     else if (arg === "--help" || arg === "-h") out.help = true;
     else if (arg.startsWith("-")) throw new Error(`open-archive-canvas: unknown option ${arg}`);
     else if (!out.dir) out.dir = arg;
@@ -251,9 +331,10 @@ function parseArgs(argv) {
 
 const USAGE = `Usage: node evals/tools/open-archive-canvas.mjs <extracted-archive-dir> [options]
 
-  --spec <file>     render this specification JSON instead of the archive's demo
-  --instance <id>   canvas instance id (default: open-archive-canvas)
-  --landing         keep the extension's "no spec found" landing overlay
+  --spec <file>        render this specification JSON instead of the archive's demo
+  --instance <id>      canvas instance id (default: open-archive-canvas)
+  --landing            keep the extension's "no spec found" landing overlay
+  --provenance <file>  write the capture-source record as JSON ("-" for stderr)
 
 Prints the loopback URL on stdout and keeps serving until interrupted, so:
   CANVAS_URL=$(node evals/tools/open-archive-canvas.mjs /tmp/ext/srs-navigator)`;
@@ -277,6 +358,12 @@ async function main() {
     `SRS Navigator canvas serving ${opened.specName ?? "the archive's first-run view"} ` +
       `from ${opened.extensionDir}\nPress Ctrl+C to stop.\n`,
   );
+
+  if (opts.provenance) {
+    const record = `${JSON.stringify(captureProvenance(opened), null, 2)}\n`;
+    if (opts.provenance === "-") process.stderr.write(record);
+    else fs.writeFileSync(opts.provenance, record);
+  }
 
   let closing = false;
   const shutdown = async () => {

--- a/evals/tools/verify-plugin-archive.mjs
+++ b/evals/tools/verify-plugin-archive.mjs
@@ -1,0 +1,324 @@
+#!/usr/bin/env node
+// Load the **published** plugin release archive as an installer would, and print what it
+// found. The third artefact family, and the one nothing had ever opened.
+//
+// Why this exists (issues #104, #107). `npx skills add` clones the repository; the canvas
+// tooling opens the canvas archive. `problem-based-srs-vX.Y.zip` — the only asset attached
+// to a methodology release — had no reader at all, and it shipped broken: two links that
+// resolved to `agents/skills/`, a directory that exists nowhere.
+// `evals/tests/plugin-archive-install.test.mjs` closed half of that by reading what the
+// *packager stages*. This reads what the *release serves*, which is a different tree the
+// moment a workflow packages a ref that is not the one under test.
+//
+// Two review notes shape what it does, and both are about not proving the wrong thing:
+//
+//   #104 — "`grep agents/skills/` checks one known defect, not link closure. Run the
+//           existing full relative-link validator against the downloaded zip."
+//   #107 — "replace archive download/listing with an actual plugin load."
+//
+// So this does not list entries and match a string. It resolves the manifest, resolves
+// every skill the tree ships, parses each orchestrator's dispatch table, and requires
+// every action to land on a file **in the extracted tree** — then resolves every relative
+// link in every shipped markdown file against that same tree.
+//
+// Counts are recorded, never gated. A file total is a snapshot of one release; gating on
+// it makes the next routine addition fail a correct archive, and the number then gets
+// edited to match reality — which is how an acceptance criterion becomes a formality. The
+// gates are closure properties, which stay true as the tree grows.
+//
+// Usage:
+//   node evals/tools/verify-plugin-archive.mjs <extracted-dir> [--json <file>] [--quiet]
+//
+//   <extracted-dir>  the archive's own `problem-based-srs/` root, or the directory it was
+//                    extracted into (the root is found either way)
+//   --json <file>    write the machine-readable evidence record here ("-" for stdout)
+//   --quiet          suppress the human transcript on stderr
+//
+// Exit code is 0 only when every derived gate passed, so it composes into a release gate:
+//   gh release download v2.6 -p 'problem-based-srs-*.zip' -D /tmp/pbsrs
+//   unzip -q /tmp/pbsrs/problem-based-srs-v2.6.zip -d /tmp/pbsrs/extracted
+//   node evals/tools/verify-plugin-archive.mjs /tmp/pbsrs/extracted --json evidence.json
+
+import fs from "node:fs";
+import path from "node:path";
+import crypto from "node:crypto";
+import { pathToFileURL } from "node:url";
+
+import {
+  ARTIFACT_FAMILIES,
+  dispatchClosure,
+  linkClosure,
+  readInstalledSkill,
+  walkTree,
+} from "../lib/distribution-artifacts.mjs";
+
+/** The manifest that makes an extracted directory a plugin rather than a folder of files. */
+export const MANIFEST = ".claude-plugin/plugin.json";
+
+/**
+ * Find the plugin root: the directory containing the manifest.
+ *
+ * The archive carries its own `problem-based-srs/` root, so `unzip -d /tmp/x` gives
+ * `/tmp/x/problem-based-srs`. Accepting either saves the caller a guess, and refusing
+ * anything with no manifest keeps "I extracted it somewhere else" from reading as "the
+ * archive is empty".
+ *
+ * @param {string} dir
+ * @returns {string} absolute path to the plugin root
+ */
+export function findPluginRoot(dir) {
+  if (!dir) throw new Error("verify-plugin-archive: no directory given");
+  const resolved = path.resolve(dir);
+  if (!fs.existsSync(resolved)) {
+    throw new Error(`verify-plugin-archive: no such directory: ${resolved}`);
+  }
+  if (!fs.statSync(resolved).isDirectory()) {
+    throw new Error(`verify-plugin-archive: not a directory: ${resolved}`);
+  }
+  if (fs.existsSync(path.join(resolved, MANIFEST))) return resolved;
+
+  const nested = fs
+    .readdirSync(resolved, { withFileTypes: true })
+    .filter((e) => e.isDirectory())
+    .map((e) => path.join(resolved, e.name))
+    .filter((d) => fs.existsSync(path.join(d, MANIFEST)));
+
+  if (nested.length === 1) return nested[0];
+  if (nested.length > 1) {
+    throw new Error(
+      `verify-plugin-archive: ${resolved} contains ${nested.length} plugin roots ` +
+        `(${nested.map((d) => path.basename(d)).join(", ")}); point at one of them`,
+    );
+  }
+  throw new Error(
+    `verify-plugin-archive: no ${MANIFEST} under ${resolved}\n` +
+      "The archive carries its own root directory, so extracting it to /tmp/x gives you " +
+      "/tmp/x/<plugin-name> — point at either.",
+  );
+}
+
+/** SHA-256 of a file, so an evidence record names the bytes it read. */
+export function sha256(file) {
+  return crypto.createHash("sha256").update(fs.readFileSync(file)).digest("hex");
+}
+
+/**
+ * Load the plugin out of an extracted archive and check the properties an installer
+ * depends on. Returns the evidence record; never throws for a *failed check*, only for a
+ * tree it cannot read at all — a caller wants the failing record, not an exception.
+ *
+ * @param {string} dir
+ * @returns {object} evidence record
+ */
+export function verifyPluginArchive(dir) {
+  const root = findPluginRoot(dir);
+  const files = walkTree(root);
+  const checks = [];
+  const record = {
+    tool: "verify-plugin-archive",
+    family: ARTIFACT_FAMILIES.find((f) => f.id === "plugin-archive"),
+    root,
+    verifiedAt: new Date().toISOString(),
+    observed: {},
+    checks,
+    ok: false,
+  };
+
+  const check = (id, ok, detail) => {
+    checks.push({ id, ok: Boolean(ok), detail });
+    return Boolean(ok);
+  };
+
+  /* ---------------------------------------------------------------- the manifest loads */
+
+  const manifestPath = path.join(root, MANIFEST);
+  let manifest = null;
+  try {
+    manifest = JSON.parse(fs.readFileSync(manifestPath, "utf8"));
+  } catch (error) {
+    check("manifest-parses", false, `${MANIFEST} is not readable JSON: ${error.message}`);
+    record.observed.files = files.length;
+    return record;
+  }
+  check("manifest-parses", true, `${MANIFEST} parsed`);
+  check(
+    "manifest-identifies-the-plugin",
+    Boolean(manifest.name) && Boolean(manifest.version),
+    `name=${manifest.name ?? "(none)"} version=${manifest.version ?? "(none)"}`,
+  );
+  check(
+    "archive-root-matches-the-manifest-name",
+    path.basename(root) === manifest.name,
+    `extracted root is ${path.basename(root)}; the manifest declares ${manifest.name}`,
+  );
+
+  record.manifest = {
+    name: manifest.name ?? null,
+    version: manifest.version ?? null,
+    sha256: sha256(manifestPath),
+  };
+
+  /* ------------------------------------------------------------- the skills are loaded */
+
+  const skillsDir = path.join(root, "skills");
+  const slugs = fs.existsSync(skillsDir)
+    ? fs
+        .readdirSync(skillsDir, { withFileTypes: true })
+        .filter((e) => e.isDirectory())
+        .map((e) => e.name)
+        .sort()
+    : [];
+
+  check("ships-at-least-one-skill", slugs.length > 0, `skills/: ${slugs.join(", ") || "(none)"}`);
+
+  record.skills = slugs.map((slug) => {
+    const skill = readInstalledSkill(path.join(skillsDir, slug));
+    const closure = dispatchClosure(skill);
+
+    check(
+      `skill-${slug}-has-an-orchestrator`,
+      skill.skillMd !== null,
+      `skills/${slug}/SKILL.md ${skill.skillMd === null ? "is missing" : "loaded"}`,
+    );
+    check(
+      `skill-${slug}-dispatch-resolves`,
+      closure.ok,
+      closure.ok
+        ? `all ${closure.actions.length} actions resolve to a reference file in the archive`
+        : [
+            closure.unresolved.length
+              ? `dispatched but not shipped: ${closure.unresolved.join(", ")}`
+              : null,
+            closure.undispatched.length
+              ? `shipped but unreachable: ${closure.undispatched.join(", ")}`
+              : null,
+            closure.actions.length === 0 ? "the dispatch table parsed as empty" : null,
+            closure.shipped.length === 0 ? "no reference files shipped" : null,
+          ]
+            .filter(Boolean)
+            .join("; "),
+    );
+
+    return {
+      slug,
+      files: skill.files.length,
+      actions: closure.actions,
+      referenceFiles: skill.referenceFiles.length,
+      exampleFiles: skill.exampleFiles.length,
+      dispatch: closure,
+    };
+  });
+
+  /* --------------------------------------------------------- every link stays inside it */
+
+  const links = linkClosure(root, { files });
+  check(
+    "relative-links-resolve-inside-the-archive",
+    links.broken.length === 0,
+    links.broken.length === 0
+      ? `${links.links} relative links across ${links.checked} markdown files all resolve`
+      : links.broken.map((b) => `${b.file} -> ${b.target} (${b.reason})`).join("; "),
+  );
+  record.links = links;
+
+  /* ---------------------------------------------------- nothing developmental shipped */
+
+  const unwanted = files.filter(
+    (f) =>
+      /(^|\/)(node_modules|evals|tests|scripts|dist|build)\//.test(f) ||
+      /(^|\/)(package-lock\.json|\.gitignore)$/.test(f),
+  );
+  check(
+    "carries-no-development-tooling",
+    unwanted.length === 0,
+    unwanted.length === 0 ? "no node_modules, tests, scripts or lockfiles" : unwanted.join(", "),
+  );
+
+  /* ------------------------------------------------------- recorded, deliberately ungated */
+
+  record.observed = {
+    files: files.length,
+    markdownFiles: files.filter((f) => f.endsWith(".md")).length,
+    skills: slugs.length,
+    actions: record.skills.reduce((n, s) => n + s.actions.length, 0),
+    relativeLinks: links.links,
+    note:
+      "Observed values are recorded, not asserted. The gates above are closure properties, " +
+      "which survive a tenth action; a count would not.",
+  };
+
+  record.ok = checks.every((c) => c.ok);
+  return record;
+}
+
+/* --------------------------------------------------------------------------------- CLI */
+
+export function parseArgs(argv) {
+  const out = { dir: null, json: null, quiet: false, help: false };
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i];
+    if (arg === "--json") out.json = argv[++i];
+    else if (arg === "--quiet") out.quiet = true;
+    else if (arg === "--help" || arg === "-h") out.help = true;
+    else if (arg.startsWith("-")) throw new Error(`verify-plugin-archive: unknown option ${arg}`);
+    else if (!out.dir) out.dir = arg;
+    else throw new Error(`verify-plugin-archive: unexpected argument ${arg}`);
+  }
+  return out;
+}
+
+export const USAGE = `Usage: node evals/tools/verify-plugin-archive.mjs <extracted-dir> [options]
+
+  --json <file>   write the machine-readable evidence record ("-" for stdout)
+  --quiet         suppress the human transcript on stderr
+
+Exits 0 only when every derived gate passed.`;
+
+/** Render the evidence record as the transcript an issue can carry. */
+export function formatReport(record) {
+  const lines = [
+    `plugin archive: ${record.root}`,
+    record.manifest
+      ? `manifest: ${record.manifest.name} ${record.manifest.version} (sha256 ${record.manifest.sha256.slice(0, 12)}…)`
+      : "manifest: unreadable",
+    `artifact family: ${record.family.label} — ${record.family.artifact}`,
+    "",
+    "checks (derived — these gate the exit code):",
+    ...record.checks.map((c) => `  ${c.ok ? "PASS" : "FAIL"}  ${c.id}: ${c.detail}`),
+    "",
+    "observed (recorded — these gate nothing):",
+    ...Object.entries(record.observed)
+      .filter(([k]) => k !== "note")
+      .map(([k, v]) => `  ${k}: ${v}`),
+    `  ${record.observed.note ?? ""}`,
+    "",
+    record.ok ? "RESULT: every gate passed" : "RESULT: at least one gate failed",
+  ];
+  return lines.join("\n");
+}
+
+async function main() {
+  const opts = parseArgs(process.argv.slice(2));
+  if (opts.help || !opts.dir) {
+    process.stderr.write(`${USAGE}\n`);
+    process.exit(opts.help ? 0 : 1);
+  }
+
+  const record = verifyPluginArchive(opts.dir);
+
+  if (!opts.quiet) process.stderr.write(`${formatReport(record)}\n`);
+  if (opts.json === "-") process.stdout.write(`${JSON.stringify(record, null, 2)}\n`);
+  else if (opts.json) fs.writeFileSync(opts.json, `${JSON.stringify(record, null, 2)}\n`);
+
+  process.exit(record.ok ? 0 : 1);
+}
+
+const invokedDirectly =
+  process.argv[1] && pathToFileURL(path.resolve(process.argv[1])).href === import.meta.url;
+
+if (invokedDirectly) {
+  main().catch((error) => {
+    process.stderr.write(`${error.message}\n`);
+    process.exit(1);
+  });
+}

--- a/scripts/check-distribution.mjs
+++ b/scripts/check-distribution.mjs
@@ -547,6 +547,13 @@ export function tagsWithoutRelease({
  * because `bump-version.mjs` keeps bumping past any version whose tag exists, so leaving the
  * tag makes the stranded version unreachable forever — its tag has to go first.
  *
+ * The plugin dispatch carries `--ref <tag>` and that is not decoration. `create-release.yml`
+ * checks out with `actions/checkout@v4` and no `ref:`, so it packages whatever the dispatched
+ * ref holds — and `gh workflow run` defaults to the repository's default branch. Recovering
+ * without `--ref` therefore attaches bytes built from `main` as it is *now* to a tag that
+ * names a different commit, which is a worse outcome than the failed run being recovered
+ * from: the release exists, looks correct, and does not match its own tag.
+ *
  * @param {{tag:string, train:string, advertised:string|null}} entry
  * @returns {string[]}
  */
@@ -557,7 +564,10 @@ export function republishInstruction({ tag, train, advertised } = {}) {
   if (train === "plugin") {
     const version = (pluginReleaseTag(advertised) ?? tag).replace(/^v/i, "");
     return [
-      `Re-publish by dispatch: \`gh workflow run create-release.yml -f version=${version}\`.`,
+      "Re-publish by dispatch: " +
+        `\`gh workflow run create-release.yml --ref ${tag} -f version=${version}\`.`,
+      `--ref pins the provenance: the workflow checks out the dispatched ref, and without it ` +
+        `the run packages main as it stands now and attaches that to ${tag}.`,
       noEvent,
     ];
   }


### PR DESCRIPTION
Implements the repo-side half of every open issue's plan — #69, #89–#92, #102–#108 — following each issue's `plan-review-2026-08-02` comment, which overrides several of the bodies.

## The defect this is shaped around

Three artefact families ship from this repository, and **only two had a reader**. `plugin-archive-install.test.mjs` checks what the packager *stages*; nothing ever opened the published `problem-based-srs-vX.Y.zip`. So `AGENT.md`'s links to `agents/skills/` — a directory that exists in neither the repository nor the archive — were wrong in **every published zip**, six releases running, with a green suite the whole time.

The evidence plan had the same shape one level up: it asked a human to run `grep -rn 'agents/skills/'`, which tests the one defect we already knew about.

## What landed

| Area | Change |
|---|---|
| **Archive is loaded, not staged** | `evals/tools/verify-plugin-archive.mjs` extracts and loads a downloaded archive: resolves the manifest, resolves every skill, requires every dispatched action to land on a file in the tree, and resolves every relative link *against that tree*. Emits JSON evidence naming the SHA-256 of the bytes it read. |
| **One definition of what we ship** | `evals/lib/distribution-artifacts.mjs` — the three artefact families, the README methods each covers, and the tree/link/dispatch readers the suites and the verifier share. The README's method list is **read**, not restated. |
| **Metrics leave the browser** | `lib/graph-metrics.mjs` extracts the health-bar computation out of the renderer's template literal and injects it back verbatim. "29 nodes, 5 need clusters, 100% traceability" is now *derivable* from a spec instead of read off a screenshot. |
| **Evidence attribution** | `tests/evidence-attribution.test.mjs` derives which capture each suite writes, so a claim and its screenshot can't come from different suites. |
| **Tracked runbook** | `docs/release-verification.md` replaces the runbook that lived in gitignored `.spec/release-readiness/`. |
| **Recovery is pinned** | `check-distribution.mjs` now emits `gh workflow run create-release.yml --ref <tag>`, so a re-publish builds the tagged tree rather than whatever `main` has become. |

### Two design rules held throughout

**Gates are closure properties; counts are recorded but never asserted.** The reviews on #107 objected to "9 actions / 12 files" thresholds — a snapshot presented as a gate turns a correct product red on its next routine addition, which is how an acceptance criterion quietly becomes a formality. `record.observed` carries the counts; nothing gates on them.

**Every guard was negative-tested.** Including this one, which failed on its first run against my *own* incomplete table — it found two captures the runbook hadn't attributed:

```
✖ landing-health-link.png is written by site.test.mjs but the runbook's
  attribution table does not list it
```

and, when a capture was deliberately misattributed:

```
✖ the runbook credits skills-health-dashboard.png to visual.test.mjs, but it is
  written by site.test.mjs. This is the #92 defect exactly.
```

## Issue-by-issue

| Issue | Disposition |
|---|---|
| **#102** | **Closed** — digest superseded by its execution issues. |
| **#103** | **Closed** — Dependabot alert #2 dismissed `tolerable_risk` with rationale on the alert and the issue. Per its review: no standing exception added to `copilot-instructions.md`. `ai` is `scope: development`, excluded from the packaged archive, and the only consumer sends text-only messages. |
| **#106** | **Closed** — its deliverable *was* #91's corrected body, plus the description-axis guard (both landed). |
| **#104 #105 #107** | Bodies corrected per review; tooling landed. Execution blocked on the release cuts. |
| **#89 #90 #92** | Gates amended: #104 made a mandatory pre-flight; the tag cut from a **recorded SHA**, not the stale "merge commit of #86"; every downloaded artefact tied to its asset id/digest and a local hash taken *before* extraction; an explicit install-route equivalence matrix. |
| **#108** | Rewritten as an exhaustive **checkbox → evidence → fix → guard** ledger. Its own baseline was stale: #69 has **9 boxes, 8 unticked**, not "8 and 7". Its documentation-gap criterion listed two of the **seven** gaps actually fixed; all seven are now tabulated with their guards. |
| **#69** | Body corrected — it asked for a listing reflecting **`v2.5.0`**, a version bumped over and folded into `[2.6.0]` by #86. Now `v2.6`. Every open box names its evidence and its blocking issue. **Nothing ticked** that isn't done. |

Three factual errors found in the issues while doing this, each corrected in place: the `v2.5.0` target, #108's box count, and #92's screenshot attribution.

## Verification

```
node --test evals/tests/*.test.mjs        680/680   (baseline 601)
cd .github/extensions/srs-navigator
  npm test                                295/295   (baseline 265)
  npm run test:e2e                         41/41
python scripts/build-plugin.py validate   success
```

The e2e run is the one that matters for the renderer refactor — `visual.test.mjs:256`, *"the health bar reports 29 nodes, 5 need clusters and 100% traceability"*, passes against a page whose metrics now come from the extracted module.

## Not in this PR — and why

`check-distribution.mjs` still reports exactly three errors. All three are **maintainer-only actions that cannot live in a PR**:

1. **Cut `v2.6`** (#89) — a tag push is irreversible and cannot be reviewed.
2. **Cut `v1.1.1`** (#90) — same, and `bump-version.mjs` skips versions whose tag exists, so a mistake here strands `1.1.1` permanently.
3. **Re-submit at skills.sh** (#91) — a third-party web form.

Consequently #92's evidence pack and #69's closure stay blocked, and #105's clean-profile `/live` capture needs a real Copilot app on a machine with no prior checkout. The reviews sequence the gate work *before* the cuts, which is what this PR is.

**Do not merge yet** — opened for review, as asked.