### PR TITLE
Add Thursday release cadence

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -455,6 +455,8 @@ single build script. Releases publish a validated, packaged plugin artifact to t
 | **CI workflow** | `.github/workflows/ci.yml` | On every push/PR to `main`: validates the plugin and uploads the packaged zip as a build artifact. |
 | **Release workflow** | `.github/workflows/create-release.yml` | Builds, validates, packages, and publishes a GitHub Release with the zip attached. |
 | **Canvas release workflow** | `.github/workflows/release-canvas.yml` | Independent pipeline for the SRS Navigator canvas app: runs `npm test`, refreshes bundled skills, bumps the extension version (`scripts/bump-version.mjs`), confirms the bumped tag is this train's (`scripts/release-train.mjs --expect canvas`), packages archives (`scripts/package-extension.mjs`), verifies the archive contract (`evals/tests/from-archive-install.test.mjs`), and publishes a `vX.Y.Z` GitHub Release that creates its own tag. |
+| **Thursday report** | `.github/workflows/thursday-release-report.yml` | At 12:00 BRT on Thursdays, opens or refreshes the weekly release report issue with the unreleased commits and files for both trains. |
+| **Thursday dispatch** | `.github/workflows/thursday-release.yml` | At 16:00 BRT on Thursdays, dispatches the trains that are ready; the report is advisory, not a gate. |
 | **Distribution monitor** | `.github/workflows/distribution-drift.yml` → `scripts/check-distribution.mjs` | Weekly (and on demand): compares the surfaces this repository does **not** own — the skills.sh listing and GitHub Releases — against what the repository actually ships. Deliberately outside the PR gate. |
 
 > **Two release pipelines, two tag schemes.** The **plugin** release uses `vX.Y` tags
@@ -462,18 +464,17 @@ single build script. Releases publish a validated, packaged plugin artifact to t
 > tags (driven by `VERSION` + `bump-version.mjs`). Keep them distinct so tags never
 > collide. "Make a release" of the methodology means the plugin pipeline below.
 >
-> They still share one tag namespace, and `create-release.yml` triggers on `v*`, so it sees
-> the canvas train's tags too — and the trains cannot be told apart by shape (`v2.4.1` is a
-> plugin release, `v1.1.0` a canvas one). Publishing the canvas app therefore used to fail
-> `Create Release` on a version mismatch it could do nothing about (run `28527065984`, tag
-> `v1.1.0`). `scripts/release-train.mjs` now attributes the pushed tag first — plugin if its
-> normalized version matches `plugin.json` (the same comparison `build-plugin.py` makes),
-> canvas if it matches `VERSION` / the extension `package.json` verbatim (the tag
-> `bump-version.mjs` pushes) — and the publishing job runs only for the plugin train. A tag
-> matching neither, or both, **fails the run** rather than releasing something arbitrary.
+> They still share one tag namespace, and the trains still cannot be told apart by tag shape
+> (`v2.4.1` is a plugin release, `v1.1.0` a canvas one). Publishing the canvas app used to
+> fire `Create Release` on a version mismatch it could do nothing about (run `28527065984`,
+> tag `v1.1.0`). The plugin workflow is now dispatch-only, and the canvas workflow calls
+> `scripts/release-train.mjs` before it creates its tag — plugin if its normalized version
+> matches `plugin.json` (the same comparison `build-plugin.py` makes), canvas if it matches
+> `VERSION` / the extension `package.json` verbatim (the tag `bump-version.mjs` pushes). A
+> tag matching neither, or both, **fails the run** rather than releasing something arbitrary.
 > Guarded by `evals/tests/release-trains.test.mjs`.
 >
-> **Both trains check the shared tag namespace, and they act on the answer differently — on purpose.** `create-release.yml` fires on every `v*` tag, most of which are not its business, so it *skips* when `release-train.mjs` says the tag belongs to the canvas train. `release-canvas.yml` is dispatched deliberately and is about to publish, so it runs `release-train.mjs --tag <bumped tag> --expect canvas` after `bump-version.mjs` and before anything leaves the runner; if the verdict is not `canvas`, it *fails*. The one state neither may publish is a tag **both trains claim**; either one would put its artifacts on the other's release.
+> **The plugin train is dispatched on purpose; the canvas train proves ownership before tagging.** `create-release.yml` no longer auto-runs on tag pushes, so the Thursday dispatcher (or an explicit manual recovery) decides when the plugin release happens. `release-canvas.yml` is still about to create a shared-namespace tag, so it runs `release-train.mjs --tag <bumped tag> --expect canvas` after `bump-version.mjs` and before anything leaves the runner; if the verdict is not `canvas`, it *fails*. The one state neither may publish is a tag **both trains claim**; either one would put its artifacts on the other's release.
 
 > **`VERSION` is owned by `release-canvas.yml`.** Do not bump it in a feature branch:
 > `bump-version.mjs` *increments* from the version it finds, so a hand-bumped number is never
@@ -483,14 +484,12 @@ single build script. Releases publish a validated, packaged plugin artifact to t
 > advertising canvas `1.1.0`, `v1.1.0` is `canvas` and `v1.1.1` is `unknown` until the release
 > workflow bumps it.
 
-> **The canvas train never pushes a tag by hand; the plugin train always does.** This is a
-> real difference, not an inconsistency. `release-canvas.yml` is dispatch-only, so it
-> publishes with `gh release create <tag> --target <sha>` and GitHub creates the tag *as part
-> of* the release — no tag can outlive a failed publish. `create-release.yml` is triggered
-> **by** a tag push, so its tag already exists when it runs and `--target` is ignored there;
-> that train is tagged by hand on purpose (`git tag v2.6 && git push origin v2.6`), which is
-> why a failed plugin release can leave a tag behind and the canvas one cannot. Adding a
-> `push: tags` trigger to `release-canvas.yml` would silently turn `--target` into a no-op.
+> **Neither train should be hand-tagged during the normal Thursday flow.** Both release
+> workflows are dispatch-only now. `release-canvas.yml` publishes with `gh release create
+> <tag> --target <sha>` and GitHub creates the tag *as part of* the release; `create-release.yml`
+> does the same for the plugin train when Thursday dispatches it (or when a maintainer runs a
+> recovery by hand). Adding a `push: tags` trigger back to either train would reintroduce an
+> out-of-cadence path and, on the canvas side, would silently turn `--target` into a no-op.
 >
 > The canvas rule is therefore: **nothing leaves the runner until the artifact has been built
 > and read**, and a failed or cancelled publish reverts the version bump so a re-run
@@ -550,18 +549,12 @@ git push origin main
 
 #### 2. Publish the Release
 
-Pick **one** of the two methods:
+The standard path is the Thursday cadence: `thursday-release-report.yml` opens the review
+issue at **12:00 BRT**, and `thursday-release.yml` dispatches the release at **16:00 BRT**
+when `plugin.json` and `CHANGELOG.md` already advertise an unpublished version.
 
-**Method A — Tag push (recommended).** Pushing a `vX.Y` tag triggers the release
-workflow, which derives the version from the tag and the notes from `CHANGELOG.md`:
-
-```bash
-git tag vX.Y
-git push origin vX.Y
-```
-
-**Method B — Manual dispatch.** GitHub → **Actions** → **Create Release** →
-**Run workflow**. All inputs are optional:
+For an exception or recovery, use **manual dispatch**: GitHub → **Actions** →
+**Create Release** → **Run workflow**. All inputs are optional:
 
 | Field | Description | Default |
 |-------|-------------|---------|
@@ -571,7 +564,8 @@ git push origin vX.Y
 
 The workflow validates the plugin, packages `problem-based-srs-vX.Y.zip`, and creates
 (or updates) the `vX.Y` release with that zip attached. The `v` prefix and trailing
-`.0` normalization are handled automatically.
+`.0` normalization are handled automatically, and the tag is created by the workflow's
+`gh release create --target` step rather than by a separate git push.
 
 #### 3. Verify the Release
 
@@ -598,10 +592,10 @@ is a notification, not a broken build: it is out of the PR gate on purpose.
 |---------|----------|---------------|-----------|
 | `registry-listing-drift` | error | The [skills.sh listing](https://www.skills.sh/rafaelgorski/problem-based-srs) advertises skills the repository no longer ships. It is a cached index, so consolidations (like #50, which took nine skills to one) do not propagate. | Re-submit the repository at [skills.sh](https://www.skills.sh) so the listing is re-crawled, then re-run the checker. |
 | `registry-skill-stale` | error | The listing's page for a skill the repository *does* ship publishes an older copy of it — a description that has moved on, or `##` sections the page never renders. Captured 2026-07-31, the `problem-based-srs` page was missing **Identifier Notation (CANONICAL)** and still taught `FR-001`, the notation the methodology replaced. Names agreeing is the cheap half; this is the half a re-submission is actually for. | Re-submit at [skills.sh](https://www.skills.sh) and re-run. This is the finding that tells you whether the re-crawl worked — `registry-listing-drift` clearing only means the *names* line up. |
-| `dangling-release-links` | error | A `releases/tag/…` link in `README.md`/`CHANGELOG.md` names a **well-formed** tag with no release behind it **and no tag on origin** — normally a manifest bump whose tag never got pushed. When the tag does exist, the link moves to `release-tag-without-release` instead. | Cut the missing release (above). The link is already correct and will resolve when the tag exists. |
+| `dangling-release-links` | error | A `releases/tag/…` link in `README.md`/`CHANGELOG.md` names a **well-formed** tag with no release behind it **and no tag on origin** — normally a manifest bump that has not been dispatched yet. When the tag does exist, the link moves to `release-tag-without-release` instead. | Cut the missing release (above). The link is already correct and will resolve when the workflow creates the tag. |
 | `unpublishable-release-link` | error | A reference definition **in `CHANGELOG.md`** (the file `build-plugin.py` reads for release notes, so its labels are plugin-train claims) names a tag **no pipeline creates for that version**. `create-release.yml` tags `v${VERSION}` where `VERSION` is `build-plugin.py`'s *normalized* version, so `2.6.0` publishes at `v2.6` — and GitHub serves `/releases/tag/<tag>` by exact name. Links outside that file stay under `dangling-release-links`, because the canvas train tags `v${VERSION}` verbatim and does not strip the `.0`. | Correct the link to the tag named in the finding. Cutting a release will **not** clear this one. |
 | `stranded-release-link` | error | A reference definition **in `CHANGELOG.md`** names a version the manifest has **already moved past**. `create-release.yml` runs `build-plugin.py build --version <tag>`, which validates the tag against `plugin.json` — so `v2.5` fails on `version mismatch: plugin.json has 2.6.0` and is no longer publishable from `main`. Not impossible, and the finding says so: `checkout@v4` restores the *tagged commit*, so tagging the older commit that still read `2.5.0` would build — but it would publish a tree and notes that predate what the section documents now, and `extract_notes()` publishes exactly one section, so those notes reach no release from `main` either. Deeper than `unpublishable-release-link`, so it wins when a link is both. | **Do not cut it from `main`** — that fails the workflow, and a historical tag ships the wrong notes. Fold the section into `## [<manifest version>]`, the release that will actually deliver those changes, and delete the link definition. Guarded offline by `evals/tests/release-hygiene.test.mjs`, which requires every changelog section below the manifest version to name a tag present in `git tag --list`, and by `evals/tests/stranded-release-claim.test.mjs`, which holds the wording to what the repository's history supports. |
-| `plugin-release-missing` / `canvas-release-missing` | error | The version a surface advertises has no release behind it, **and no tag for it exists** — the tag was never pushed. Each finding names the newest release **on its own train**; the trains are told apart by the title their workflow writes (`🎉 Version …` / `srs-navigator …`). When a train has no releases at all it says so, rather than quoting the other train's newest. | Cut it on the matching train — `vX.Y` for the plugin, `vX.Y.Z` for the canvas. |
+| `plugin-release-missing` / `canvas-release-missing` | error | The version a surface advertises has no release behind it, **and no tag for it exists** — the release has not been run yet. Each finding names the newest release **on its own train**; the trains are told apart by the title their workflow writes (`🎉 Version …` / `srs-navigator …`). When a train has no releases at all it says so, rather than quoting the other train's newest. | Cut it on the matching train — dispatch `create-release.yml` for the plugin, or run `release-canvas.yml` for the canvas. |
 | `release-tag-without-release` | error | A tag **is** on origin but no release was published for it — a publish run that failed after the tag existed (`Create Release` run `28527065984` is the precedent). This supersedes the `*-release-missing` finding for that train and takes the link out of `dangling-release-links`, because in this state both of those advise a re-push, and **re-pushing an existing tag emits no `push` event**, so nothing re-runs. | Plugin train: `gh workflow run create-release.yml --ref vX.Y -f version=X.Y` — `gh release create` attaches to the tag that already exists, and `--ref` makes the run package the tagged commit rather than whatever `main` holds now. Canvas train: `git push --delete origin vX.Y.Z` **first**, then re-run `release-canvas.yml`; `bump-version.mjs` skips any version whose tag exists, so leaving the tag skips that version forever. |
 | `surface-unreachable` | warning | A registry or the releases API could not be reached at all. | A fetch failure, **not** proof of drift. Re-run; if it persists, check the surface by hand. |
 | `registry-listing-unreadable` | warning | The listing responded but carried no JSON-LD `CollectionPage`. | Its markup probably changed. Check the page by hand and update `parseRegistryListing` — until then a clean run proves nothing. |
@@ -637,10 +631,10 @@ and the monitor keeps reporting it under advice that no longer applies. Guarded 
 `evals/tests/release-hygiene.test.mjs`, which derives the expected tag by executing
 `build-plugin.py`'s own `normalize_version` rather than restating the rule.
 
-**Never bump the manifest over a release that was never cut.** The tag push in
+**Never bump the manifest over a release that was never cut.** The release dispatch in
 [step 2](#2-publish-the-release) is the *only* thing that publishes a version, and the
 manifest version is the only version `main` can publish — `create-release.yml` validates
-the tag against `plugin.json`, so once the manifest reads `2.6.0`, `v2.5` is no longer
+the dispatched version against `plugin.json`, so once the manifest reads `2.6.0`, `v2.5` is no longer
 reachable from `main`. `2.4.1 → 2.5.0 → 2.6.0` shipped that way: a 76-line `## [2.5.0]`
 section whose link had no release behind it and whose notes no release cut from `main` would
 carry, because `extract_notes()` extracts exactly one section. State that precisely: tagging
@@ -685,12 +679,12 @@ check repo Settings → Actions → General → Workflow permissions.
 
 **Tag already exists / re-release:** the workflow updates an existing `vX.Y` release in
 place (notes + asset). To start clean: `git push --delete origin vX.Y` and delete the
-release from the GitHub UI, then re-tag.
+release from the GitHub UI, then re-dispatch `create-release.yml`.
 
-**The tag pushed but the run failed (no release exists):** do **not** try to push the tag
-again. Git sends nothing for a ref that is already up to date, so no `push` event fires and
-`create-release.yml` never re-runs — the same reason `git tag vX.Y` aborts on the collision.
-Fix the cause, then re-publish onto the tag that is already there:
+**The workflow created the tag but the run failed (no release exists):** do **not** try to
+push the tag again. Git sends nothing for a ref that is already up to date, and
+`create-release.yml` is dispatch-only anyway. Fix the cause, then re-publish onto the tag
+that is already there:
 
 ```bash
 gh workflow run create-release.yml --ref vX.Y -f version=X.Y   # attaches to the existing tag

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -3,24 +3,12 @@ name: Create Release
 # Build & release pipeline: validates the plugin, packages a distributable
 # artifact, and publishes a GitHub Release with the artifact attached.
 #
-# Two ways to release:
-#   1. Push a tag matching v*  (e.g. `git tag v1.3 && git push origin v1.3`)
-#      -> version is derived from the tag, notes from CHANGELOG.md.
-#   2. Run manually (workflow_dispatch). All inputs are optional:
-#        - version: defaults to the version in .claude-plugin/plugin.json
-#        - release_name: optional display suffix
-#        - release_body: optional override; defaults to the CHANGELOG.md section
-#
-# The `v*` trigger below is deliberately broad, and it therefore also matches the *other*
-# release train: release-canvas.yml publishes the srs-navigator canvas app at vX.Y.Z. The two
-# trains cannot be told apart by tag shape (v2.4.1 is a plugin release; v1.1.0 is a canvas
-# one), so this workflow used to run against canvas tags and fail on a version mismatch it
-# could do nothing about — run 28527065984, tag v1.1.0, four seconds after the canvas release.
-# The `train` job below attributes the tag first, and publishing runs only for this train.
+# The normal path is the Thursday dispatcher (`thursday-release.yml`), which calls this
+# workflow on the default branch after the report window. Manual dispatch remains available
+# for rehearsals, recoveries, and exceptional releases. The release tag is created by
+# `gh release create --target`, not by a pushed git tag, so this workflow no longer has any
+# release path that fires automatically outside the Thursday cadence.
 on:
-  push:
-    tags:
-      - "v*"
   workflow_dispatch:
     inputs:
       version:
@@ -40,34 +28,19 @@ permissions:
   contents: write
 
 jobs:
-  train:
-    name: Which release train is this tag?
-    runs-on: ubuntu-latest
-    outputs:
-      train: ${{ steps.classify.outputs.train || 'plugin' }}
-      reason: ${{ steps.classify.outputs.reason }}
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Set up Node
-        uses: actions/setup-node@v4
-        with:
-          node-version: "20"
-
-      # A tag push may belong to either train. A manual dispatch carries no tag, and was asked
-      # for on this workflow by hand, so it is the plugin train by definition.
-      - name: Classify the pushed tag
-        id: classify
-        if: github.event_name == 'push'
-        run: node scripts/release-train.mjs --tag "$GITHUB_REF_NAME"
-
   release:
     name: Build, package & publish release
-    needs: train
-    if: needs.train.outputs.train == 'plugin'
     runs-on: ubuntu-latest
+    defaults:
+      run:
+        shell: bash
     steps:
+      - name: Refuse to release from anywhere but the default branch
+        if: github.ref_name != github.event.repository.default_branch
+        run: |
+          echo "::error::create-release.yml must run on ${{ github.event.repository.default_branch }}; got ${{ github.ref_name }}"
+          exit 1
+
       - name: Checkout
         uses: actions/checkout@v4
 
@@ -79,9 +52,7 @@ jobs:
       - name: Resolve raw version
         id: raw
         run: |
-          if [ "${{ github.event_name }}" = "push" ]; then
-            VERSION="${GITHUB_REF_NAME#v}"
-          elif [ -n "${{ inputs.version }}" ]; then
+          if [ -n "${{ inputs.version }}" ]; then
             VERSION="${{ inputs.version }}"
           else
             VERSION="$(python -c "import json;print(json.load(open('.claude-plugin/plugin.json'))['version'])")"

--- a/.github/workflows/release-canvas.yml
+++ b/.github/workflows/release-canvas.yml
@@ -25,10 +25,8 @@ name: Release Canvas Extension
 # Nothing now leaves this runner until the artifact has been built and read, and the tag
 # is created *by* `gh release create --target`, so no tag can outlive a failed publish.
 # That is possible here because this workflow is dispatch-only: the tag never exists
-# beforehand. It is **not** true of create-release.yml, whose `push: tags` trigger means
-# the tag already exists when it runs and `--target` is ignored — that train is tagged by
-# hand on purpose, and adding a tag trigger here would silently turn `--target` into a
-# no-op. Guarded by evals/tests/release-canvas-ordering.test.mjs.
+# beforehand. Keep it that way — adding a `push: tags` trigger here would silently turn
+# `--target` into a no-op. Guarded by evals/tests/release-canvas-ordering.test.mjs.
 #
 # Residual window, stated rather than hidden: if the runner dies between pushing the bump
 # and recording that it pushed, no rollback step runs. Closing that needs a re-run to

--- a/.github/workflows/thursday-release-report.yml
+++ b/.github/workflows/thursday-release-report.yml
@@ -1,0 +1,63 @@
+name: Thursday release report
+
+on:
+  schedule:
+    # Thursday 12:00 BRT (15:00 UTC) — four hours before the scheduled release dispatch.
+    - cron: "0 15 * * 4"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  report:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        shell: bash
+    steps:
+      - name: Refuse to report from anywhere but the default branch
+        if: github.ref_name != github.event.repository.default_branch
+        run: |
+          echo "::error::thursday-release-report.yml must run on ${{ github.event.repository.default_branch }}; got ${{ github.ref_name }}"
+          exit 1
+
+      - name: Checkout (full history for release comparisons)
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          fetch-tags: true
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Build the weekly release report
+        id: report
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: node scripts/weekly-release-report.mjs --markdown-out release-report.md --json-out release-report.json
+
+      - name: Create or update the weekly release issue
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPORT_TITLE: ${{ steps.report.outputs.report_title }}
+        run: |
+          gh issue list --state open --limit 100 --json number,title > issues.json
+          NUMBER=$(node -e "const fs=require('fs'); const issues=JSON.parse(fs.readFileSync('issues.json','utf8')); const hit=issues.find((issue) => issue.title === process.env.REPORT_TITLE); process.stdout.write(hit ? String(hit.number) : '');")
+          rm issues.json
+          if [ -n "$NUMBER" ]; then
+            gh issue edit "$NUMBER" --title "$REPORT_TITLE" --body-file release-report.md
+          else
+            gh issue create --title "$REPORT_TITLE" --body-file release-report.md
+          fi
+
+      - name: Publish the report summary
+        run: cat release-report.md >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/thursday-release.yml
+++ b/.github/workflows/thursday-release.yml
@@ -1,0 +1,71 @@
+name: Thursday release dispatch
+
+on:
+  schedule:
+    # Thursday 16:00 BRT (19:00 UTC) — scheduled release, even when the report is not approved.
+    - cron: "0 19 * * 4"
+  workflow_dispatch:
+
+permissions:
+  actions: write
+  contents: read
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        shell: bash
+    steps:
+      - name: Refuse to release from anywhere but the default branch
+        if: github.ref_name != github.event.repository.default_branch
+        run: |
+          echo "::error::thursday-release.yml must run on ${{ github.event.repository.default_branch }}; got ${{ github.ref_name }}"
+          exit 1
+
+      - name: Checkout (full history for release comparisons)
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          fetch-tags: true
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Plan the Thursday release dispatch
+        id: report
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: node scripts/weekly-release-report.mjs --markdown-out release-report.md --json-out release-report.json
+
+      - name: Dispatch the scheduled plugin release
+        if: steps.report.outputs.plugin_ready == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PLUGIN_VERSION: ${{ steps.report.outputs.plugin_version }}
+        run: gh workflow run create-release.yml --ref "${GITHUB_REF_NAME}" -f version="${PLUGIN_VERSION}"
+
+      - name: Dispatch the scheduled canvas release
+        if: steps.report.outputs.canvas_ready == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: gh workflow run release-canvas.yml --ref "${GITHUB_REF_NAME}" -f part=patch
+
+      - name: Summarize the scheduled dispatch
+        run: |
+          cat release-report.md >> "$GITHUB_STEP_SUMMARY"
+          {
+            echo ""
+            echo "## Dispatch result"
+            echo ""
+            echo "- Plugin dispatched: ${{ steps.report.outputs.plugin_ready }}"
+            echo "- Canvas dispatched: ${{ steps.report.outputs.canvas_ready }}"
+            echo "- This schedule does not wait for approval; it fires at 16:00 BRT even if the report is still pending."
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/README.md
+++ b/README.md
@@ -408,6 +408,23 @@ directly, so the bundled copies only exist for standalone installs and packaging
 Maintainers edit a skill **once** in `skills/problem-based-srs/`, and both the agent plugin
 and the canvas app stay in sync.
 
+### Thursday release cadence
+
+The standard release cadence now runs on **Thursday**. Two GitHub Actions workflows handle it:
+
+1. [`.github/workflows/thursday-release-report.yml`](.github/workflows/thursday-release-report.yml)
+   opens or refreshes a weekly report issue at **12:00 BRT** with the commits and files waiting
+   for each release train.
+2. [`.github/workflows/thursday-release.yml`](.github/workflows/thursday-release.yml)
+   dispatches releases at **16:00 BRT**.
+
+The canvas train auto-releases when commits are waiting. The plugin train only auto-releases
+when `plugin.json` and `CHANGELOG.md` already advertise an unpublished version; otherwise the
+Thursday run reports the accumulated plugin changes and skips that train until the version is
+prepared. The report is for review, not gating — the 16:00 BRT dispatch still runs even if no
+approval arrives in time, and the plugin release workflow itself no longer auto-runs from a tag
+push outside that cadence.
+
 ## Research and standards
 
 Based on the methodology by Gorski & Stadzisz, published as peer-reviewed research.

--- a/docs/release-verification.md
+++ b/docs/release-verification.md
@@ -10,6 +10,7 @@ process lives here; `.github/copilot-instructions.md` keeps the *policy* (which 
 which tag, what the distribution monitor reports) and links back to this file for the steps.
 
 - [Distribution artefact families](#distribution-artefact-families)
+- [Thursday release cadence](#thursday-release-cadence)
 - [Plugin train — cutting `vX.Y`](#plugin-train--cutting-vxy)
 - [Canvas train — cutting `vX.Y.Z`](#canvas-train--cutting-vxyz)
 - [Proving `/live` in the app itself](#proving-live-in-the-app-itself)
@@ -36,42 +37,66 @@ install method cannot be added without either mapping it to a family or failing 
 
 ---
 
+## Thursday release cadence
+
+The normal release rhythm is now:
+
+- **12:00 BRT / 15:00 UTC** — `thursday-release-report.yml` creates or refreshes a weekly
+  report issue with the commits and files waiting for both release trains.
+- **16:00 BRT / 19:00 UTC** — `thursday-release.yml` dispatches the releases for the trains
+  that are ready.
+
+The report is informational, not a gate. If no approval arrives before 16:00 BRT, the
+scheduled dispatch still runs.
+
+The two trains differ on what "ready" means:
+
+- **Plugin train:** ready only when `plugin.json` and `CHANGELOG.md` already advertise an
+  unpublished plugin version. The Thursday report calls this out explicitly when the version
+  is not yet prepared.
+- **Canvas train:** ready whenever unreleased commits exist. The dispatch workflow triggers
+  `release-canvas.yml`, which bumps the patch version itself.
+
+This keeps the manual release paths available for exceptions and recovery, while making
+Thursday the default accumulation point for normal releases. The plugin workflow itself is
+dispatch-only now, so it no longer auto-runs from a tag push outside this cadence.
+
+---
+
 ## Plugin train — cutting `vX.Y`
 
-### Pre-flight, before any tag is pushed
+### Pre-flight, before the release is dispatched
 
-The tag is the point of no return: `create-release.yml` is triggered **by** the tag push, so
-a failed run leaves a tag behind, and re-pushing an existing ref emits no `push` event.
-Everything that can be checked from a clean `main` is checked first.
+The standard cut is a workflow dispatch on `main`, not a tag push. Everything that can be
+checked from a clean `main` is checked first.
 
 ```bash
 git checkout main && git pull --tags
 git rev-parse HEAD                                   # record this SHA in the release issue
 
 python scripts/build-plugin.py build --version X.Y   # validates + packages + prints notes
-node scripts/release-train.mjs --tag vX.Y            # must print exactly: plugin
 node --test evals/tests/*.test.mjs
 python scripts/build-plugin.py validate
 ( cd .github/extensions/srs-navigator && npm test )
 ```
 
 `build-plugin.py` normalizes the version, so a manifest reading `2.6.0` publishes at
-**`v2.6`** — and GitHub serves `/releases/tag/<tag>` by exact name. Push the tag the
-rehearsal named, not the manifest string.
+**`v2.6`** — and GitHub serves `/releases/tag/<tag>` by exact name. Dispatch the workflow
+with the normalized version, not the manifest string with its trailing `.0`.
 
 ### The cut, and watching the right run
 
 ```bash
-git tag vX.Y && git push origin vX.Y
+gh workflow run create-release.yml --ref main -f version=X.Y
 ```
 
 `gh run list --workflow 'Create Release' --limit 1` races: any concurrent run can be the one
 it returns, and the evidence then records a green run that is not the release run. Pin it to
-the event, the ref and the commit that was recorded above:
+the event, the branch and the commit that was recorded above:
 
 ```bash
 RUN=$(gh run list --workflow 'Create Release' \
-        --event push --branch vX.Y --commit "$SHA" \
+        --event workflow_dispatch --branch main --commit "$SHA" \
         --limit 1 --json databaseId --jq '.[0].databaseId')
 gh run watch "$RUN" --exit-status
 gh run view "$RUN" --json headSha,event,headBranch    # assert it is the run you meant
@@ -103,10 +128,10 @@ a grep for the symptom would not have found the next one.
 Counts in its output are **recorded, not gated**. The gates are closure properties, so a
 tenth action does not turn a correct archive red.
 
-### If the run fails with the tag already pushed
+### If the run fails after the workflow created the tag
 
-Do not re-push — git sends nothing for a ref that is up to date, so no `push` event fires.
-Re-publish by dispatch, **pinned to the tag**:
+Do not re-push — git sends nothing for a ref that is up to date, and `create-release.yml` is
+dispatch-only anyway. Re-publish by dispatch, **pinned to the tag**:
 
 ```bash
 gh workflow run create-release.yml --ref vX.Y -f version=X.Y

--- a/evals/tests/distribution-drift.test.mjs
+++ b/evals/tests/distribution-drift.test.mjs
@@ -312,7 +312,7 @@ describe("release links the repository publishes", () => {
   });
 
   it("every link to an already-shipped release resolves", () => {
-    // The pending-release link (v2.6) is a maintainer action — a tag push, not an edit. A link to a version *older* than the newest published release has no such
+    // The pending-release link (v2.6) is a maintainer action — a release dispatch, not an edit. A link to a version *older* than the newest published release has no such
     // excuse: it is a typo, and it is permanently broken. `[1.0]` pointed at v1.0 for the
     // project's entire life; the tag has always been v1.0.0, and
     //   /releases/tag/v1.0   → 404
@@ -512,7 +512,7 @@ describe("a dangling link that cutting the release would not fix", () => {
       canvasVersion: "1.1.0",
     });
 
-  it("is reported apart from a link that is merely waiting for a tag push", () => {
+  it("is reported apart from a link that is merely waiting for a release dispatch", () => {
     const summary = summaryFor(
       advertisedTagLinks([
         {
@@ -528,7 +528,7 @@ describe("a dangling link that cutting the release would not fix", () => {
     assert.ok(
       unpublishable,
       "v2.6.0 names a tag no pipeline in this repository creates. Reporting it beside a " +
-        "link that a tag push *would* fix hands the maintainer one instruction that works " +
+        "link that a release dispatch *would* fix hands the maintainer one instruction that works " +
         "and one that cannot, under a heading that says 'cut the release'.",
     );
     assert.ok(
@@ -561,7 +561,7 @@ describe("a dangling link that cutting the release would not fix", () => {
     assert.deepEqual(
       summary.findings.map((f) => f.id),
       [],
-      "after `git tag v2.6 && git push origin v2.6` the report must go quiet — that is " +
+      "after dispatching `create-release.yml` for 2.6 the report must go quiet — that is " +
         "the whole point of the last open box on #69",
     );
   });
@@ -689,7 +689,7 @@ describe("a dangling link the manifest has already moved past", () => {
     assert.ok(
       finding,
       "a link `main` can no longer publish is not the same job as one waiting for a " +
-        "tag push, and must not be filed under an instruction that cannot work",
+        "release dispatch, and must not be filed under an instruction that cannot work",
     );
     assert.equal(finding.severity, "error");
     assert.ok(

--- a/evals/tests/plugin-archive-install.test.mjs
+++ b/evals/tests/plugin-archive-install.test.mjs
@@ -1,5 +1,5 @@
 // The plugin release archive is the artifact every `vX.Y` release publishes — and the
-// artifact the release issue #69 keeps asking for (`git tag v2.6 && git push origin v2.6`)
+// artifact the release issue #69 keeps asking for (now produced by `create-release.yml`)
 // will publish. Nothing had ever opened it.
 //
 // Eight passes on #69 proved the two *other* install paths: #73 loaded the canvas archive

--- a/evals/tests/release-canvas-ordering.test.mjs
+++ b/evals/tests/release-canvas-ordering.test.mjs
@@ -13,9 +13,7 @@
 //   2. The tag is created by the release, not before it — which is only true while this
 //      workflow stays dispatch-only. `gh release create --target` creates the tag when the
 //      tag does not yet exist and is *ignored* when it does, so adding a `push: tags`
-//      trigger would silently turn the whole mechanism into a no-op. That is why
-//      create-release.yml is not the reference for it: its trigger *is* a tag push, so on
-//      that path the tag already exists and that train is tagged by hand on purpose.
+//      trigger would silently turn the whole mechanism into a no-op.
 //   3. A publish failure rolls the bump back, and a publish *success* never does.
 import { describe, it } from "node:test";
 import assert from "node:assert/strict";
@@ -240,13 +238,17 @@ describe("release-canvas.yml — the tag is created by the release, not before i
         "guards would silently stop happening.",
     );
     assert.match(triggers, /workflow_dispatch:/, "the canvas release is dispatched by hand");
-    // Stated as the contrast it is: the plugin train *is* tag-triggered, which is why it
-    // is not the reference for this mechanism.
+    // Keep the plugin workflow aligned with the cadence too: a tag trigger there would
+    // reintroduce an out-of-band release path.
     assert.match(
       PLUGIN_WF.slice(0, PLUGIN_WF.indexOf("\npermissions:")),
+      /workflow_dispatch:/,
+      `${PLUGIN_WF_PATH} must stay dispatch-only alongside the Thursday cadence`,
+    );
+    assert.doesNotMatch(
+      PLUGIN_WF.slice(0, PLUGIN_WF.indexOf("\npermissions:")),
       /tags:/,
-      `${PLUGIN_WF_PATH} is expected to be tag-triggered; if that changed, the comment in ` +
-        `${CANVAS_WF_PATH} explaining why the trains differ is now wrong`,
+      `${PLUGIN_WF_PATH} must not regain a tag trigger outside the Thursday cadence`,
     );
   });
 

--- a/evals/tests/release-trains.test.mjs
+++ b/evals/tests/release-trains.test.mjs
@@ -3,10 +3,9 @@
 //   plugin  — .claude-plugin/plugin.json, tagged vX.Y   by create-release.yml
 //   canvas  — VERSION / the extension package.json, tagged vX.Y.Z by release-canvas.yml
 //
-// `create-release.yml` triggers on `push: tags: ["v*"]`, and that glob matches both. The
-// trains cannot be told apart by tag shape either — v2.4.1 is a plugin release and v1.1.0 is
-// a canvas one. So publishing a canvas release fired the plugin pipeline against a tag that
-// does not match plugin.json, and it failed:
+// The trains cannot be told apart by tag shape either — v2.4.1 is a plugin release and
+// v1.1.0 is a canvas one. So publishing a canvas release used to fire the plugin pipeline
+// against a tag that did not match plugin.json, and it failed:
 //
 //   run 28527065984 · tag v1.1.0 · 2026-07-01T15:01:11Z · "Build, validate & package" failed
 //     ::error::validation failed: version mismatch: plugin.json has … but expected 1.1.1
@@ -15,8 +14,9 @@
 // that workflow's entire history, and it is structural: it recurs on every canvas release.
 //
 // This suite pins the classification that keeps the trains apart, and the wiring that makes
-// the release pipeline use it. Both rules are read from the pipelines themselves rather than
-// restated here — a test that hard-codes what a workflow hard-codes is a second copy of it.
+// the canvas release pipeline use it while the plugin train stays dispatch-only. Both rules
+// are read from the pipelines themselves rather than restated here — a test that hard-codes
+// what a workflow hard-codes is a second copy of it.
 import { describe, it } from "node:test";
 import assert from "node:assert/strict";
 import fs from "node:fs";
@@ -212,42 +212,28 @@ describe("release trains — the rules are read from the pipelines, not restated
     );
   });
 
-  it("create-release.yml still triggers on every v* tag", () => {
-    // Kept deliberately: the glob cannot express "tags whose version matches plugin.json", so
-    // the trigger is not where the trains get separated. Asserting it stays broad is what makes
-    // the gate below load-bearing rather than belt-and-braces.
-    assert.match(CREATE_RELEASE, /tags:\s*\n\s*-\s*"v\*"/, "the plugin workflow still sees both trains");
+  it("create-release.yml stays dispatch-only", () => {
+    assert.match(CREATE_RELEASE, /workflow_dispatch:/, "the plugin workflow must still be callable");
+    assert.doesNotMatch(
+      CREATE_RELEASE,
+      /push:\s*\n\s*tags:/,
+      "the plugin workflow must not auto-run from a tag push outside the Thursday cadence",
+    );
   });
 
-  it("create-release.yml classifies the tag before building anything", () => {
+  it("release-canvas.yml still classifies the tag before publishing anything", () => {
     assert.match(
-      CREATE_RELEASE,
+      RELEASE_CANVAS,
       /scripts\/release-train\.mjs/,
-      "the plugin release must ask which train the tag belongs to",
-    );
-  });
-
-  it("create-release.yml releases only when the answer is the plugin train", () => {
-    assert.match(
-      CREATE_RELEASE,
-      /needs\.train\.outputs\.train\s*==\s*'plugin'/,
-      "the publishing job must be gated on the classification, not merely informed by it",
-    );
-    assert.match(CREATE_RELEASE, /needs:\s*train/, "and it must depend on the job that produces it");
-    assert.match(
-      CREATE_RELEASE,
-      /outputs:\s*\n\s*train:/,
-      "the classify job has to publish its verdict for the gate to read",
+      "the canvas release must ask which train the tag belongs to",
     );
   });
 
   it("a manual dispatch still releases the plugin", () => {
-    // workflow_dispatch carries no tag, so classification has nothing to read. The run was
-    // asked for by hand on this workflow, which is the plugin train by definition.
     assert.match(
       CREATE_RELEASE,
-      /github\.event_name.*=.*.push./,
-      "the classifier must only be consulted for tag pushes",
+      /workflow_dispatch:/,
+      "the plugin workflow must still support Thursday dispatch and recovery dispatches",
     );
   });
 
@@ -257,7 +243,7 @@ describe("release trains — the rules are read from the pipelines, not restated
     assert.match(
       runbook,
       /release-train\.mjs/,
-      "the release process section must say the pushed tag is attributed to a train",
+      "the release process section must still say the canvas train checks the tag it is about to create",
     );
     assert.match(
       runbook,
@@ -325,12 +311,11 @@ describe("release trains — both pipelines enforce exclusive ownership", () => 
     );
   });
 
-  it("gates the two workflows differently, on purpose", () => {
-    assert.match(CREATE_RELEASE, /needs\.train\.outputs\.train\s*==\s*'plugin'/, "plugin: skip");
+  it("keeps the two workflows separate, on purpose", () => {
     assert.doesNotMatch(
       CREATE_RELEASE,
-      /--expect/,
-      "the plugin workflow must not hard-fail on the canvas train's tags",
+      /release-train\.mjs/,
+      "the plugin workflow no longer auto-sees foreign tags; the canvas workflow owns the classifier",
     );
     assert.doesNotMatch(
       RELEASE_CANVAS,
@@ -567,12 +552,17 @@ describe("bump-version — the rule is importable without running a release", ()
 
 describe("negative canaries", () => {
   it("an ungated workflow fails the gate assertion", () => {
-    const ungated = CREATE_RELEASE.replace(/^\s*if:\s*needs\.train\.outputs\.train.*$/m, "");
-    assert.notEqual(ungated, CREATE_RELEASE, "the mutation must actually remove the gate");
+    const ungated = CREATE_RELEASE.replace(/workflow_dispatch:\s*\n/, 'push:\n    tags:\n      - "v*"\n  workflow_dispatch:\n');
+    assert.notEqual(ungated, CREATE_RELEASE, "the mutation must actually add the out-of-band trigger");
     assert.doesNotMatch(
+      CREATE_RELEASE,
+      /push:\s*\n\s*tags:/,
+      "the tracked workflow must stay off tag-push automation",
+    );
+    assert.match(
       ungated,
-      /needs\.train\.outputs\.train\s*==\s*'plugin'/,
-      "removing the gate must be detectable — that was the live defect",
+      /push:\s*\n\s*tags:/,
+      "reintroducing the tag trigger must be detectable",
     );
   });
 

--- a/evals/tests/release-verification-runbook.test.mjs
+++ b/evals/tests/release-verification-runbook.test.mjs
@@ -139,10 +139,10 @@ describe("the plugin-train commands match what create-release.yml does", () => {
     assert.match(runbook, /`--ref` is not optional/);
   });
 
-  it("looks the run up by event, ref and commit rather than by --limit 1", () => {
+  it("looks the run up by event, branch and commit rather than by --limit 1", () => {
     // `--limit 1` races with any concurrent run, and the evidence then records a green run
     // that is not the release run — which is unfalsifiable after the fact.
-    for (const filter of ["--event push", "--branch vX.Y", "--commit"]) {
+    for (const filter of ["--event workflow_dispatch", "--branch main", "--commit"]) {
       assert.ok(runbook.includes(filter), `run lookup is missing ${filter}`);
     }
     assert.match(runbook, /gh run watch "\$RUN" --exit-status/);
@@ -166,6 +166,11 @@ describe("the plugin-train commands match what create-release.yml does", () => {
     assert.match(runbook, /replaces `grep -rn 'agents\/skills\/'`/);
     assert.match(runbook, /link closure/);
     assert.match(runbook, /Counts in its output are \*\*recorded, not gated\*\*/);
+  });
+
+  it("documents dispatching the release instead of pushing a tag", () => {
+    assert.match(runbook, /gh workflow run create-release\.yml --ref main -f version=X\.Y/);
+    assert.doesNotMatch(runbook, /git tag vX\.Y && git push origin vX\.Y/);
   });
 });
 

--- a/evals/tests/stranded-release-claim.test.mjs
+++ b/evals/tests/stranded-release-claim.test.mjs
@@ -6,8 +6,8 @@
 //
 //   * `git show 69dfe88:.claude-plugin/plugin.json` reads 2.5.0, and that tree ships the
 //     skill, so `validate --expected-version 2.5` passes on it;
-//   * `create-release.yml` checks out with no `ref:`, so a tag push builds *the tagged
-//     commit*, not `main`.
+//   * `create-release.yml` checks out with no `ref:`, so a dispatch pinned to a tag builds
+//     *the tagged commit*, not `main`.
 //
 // `git tag v2.5 <that commit> && git push` therefore publishes v2.5. "The tag can never be
 // created" and "a permanent 404" were overstatements, and a monitor that overstates its case

--- a/evals/tests/tag-without-release.test.mjs
+++ b/evals/tests/tag-without-release.test.mjs
@@ -4,13 +4,13 @@
 // releases** only: `publishedTags` is `fetchPublishedReleases().map(r => r.tag)`. It never
 // reads git refs, so it cannot tell these two states apart:
 //
-//   A. the tag was never pushed      -> `git tag v2.6 && git push origin v2.6` works
-//   B. the tag was pushed and the publish run failed -> the same command does nothing
+//   A. the release was never dispatched -> no tag exists yet
+//   B. the tag exists and the publish run failed -> recovery has to target that tag
 //
 // In state B `git tag` aborts with "tag already exists", and `git push origin v2.6` sends
 // nothing for a ref that is already up to date — so no `push` event fires and
 // create-release.yml cannot re-run. The maintainer follows the advice, observes no change,
-// and the run stays red. `Create Release` has already failed on a tag push in this
+// and the run stays red. `Create Release` has already failed with a stranded tag in this
 // repository (run 28527065984, tag v1.1.0), so this is not a hypothetical.
 //
 // The two trains do not even recover the same way: the plugin train re-publishes by
@@ -188,8 +188,8 @@ describe("the recovery each train actually needs", () => {
     assert.match(
       text,
       /gh workflow run create-release\.yml/,
-      "create-release.yml is triggered by a tag push and by workflow_dispatch; the tag is " +
-        "already there, so dispatch is what is left",
+      "create-release.yml is dispatch-only, and the stranded-tag recovery still has to target " +
+        "that existing tag",
     );
     assert.match(text, /-f version=2\.6/, "the dispatch input must carry the version");
   });
@@ -217,15 +217,14 @@ describe("the recovery each train actually needs", () => {
   it("says why re-pushing the tag does nothing, instead of leaving it to be re-tried", () => {
     assert.match(
       pluginText(),
-      /push event/i,
-      "without the reason, the next maintainer re-runs `git push origin v2.6`, sees " +
-        "'Everything up-to-date', and has no way to know that is the whole story",
+      /dispatch-only/i,
+      "without the reason, the next maintainer retries the wrong git push and has no way to know why nothing changes",
     );
   });
 
   it("never tells the plugin maintainer to push a tag that already exists", () => {
     assert.doesNotMatch(
-      pluginText().replace(/[^\n]*push event[^\n]*/gi, ""),
+      pluginText().replace(/[^\n]*dispatch-only[^\n]*/gi, ""),
       /git push origin v2\.6\b(?!.*cannot)/,
       "that is the instruction this finding exists to replace",
     );
@@ -248,7 +247,7 @@ describe("the recovery each train actually needs", () => {
       "\n",
     );
     assert.doesNotMatch(text, /create-release\.yml|release-canvas\.yml/);
-    assert.match(text, /push event/i);
+    assert.match(text, /re-publish/i);
   });
 });
 
@@ -275,7 +274,7 @@ describe("the instructions are derived from the pipelines, not asserted about th
     const steps = wf.slice(wf.indexOf("jobs:"));
     assert.ok(
       !/^\s*(git tag|- run: git tag)/m.test(steps),
-      "the plugin workflow must never create the tag itself — the tag is its trigger",
+      "the plugin workflow must never hand-create the tag itself; the release command owns it",
     );
   });
 
@@ -338,8 +337,8 @@ describe("summarize routes the stranded state to the instruction that works", ()
     assert.ok(!ids(summary).includes("release-tag-without-release"));
     assert.match(
       detailOf(summary, "plugin-release-missing"),
-      /git tag v2\.6 && git push origin v2\.6/,
-      "state A is the common case and its advice must not be collateral damage",
+      /Dispatch `create-release\.yml`|Dispatch \`create-release\.yml\`/,
+      "state A is the common case and its advice must still name the release path that exists",
     );
   });
 
@@ -586,7 +585,7 @@ describe("the maintainer's runbook says both halves out loud", () => {
 });
 
 describe("negative canaries", () => {
-  it("the plugin instruction fails this suite if it goes back to a tag push", () => {
+  it("the plugin instruction fails this suite if it goes back to a git-tag release path", () => {
     const regressed = "Cut it with `git tag v2.6 && git push origin v2.6`.";
     const real = republishInstruction({
       tag: "v2.6",

--- a/evals/tests/thursday-release-cadence.test.mjs
+++ b/evals/tests/thursday-release-cadence.test.mjs
@@ -1,0 +1,58 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import {
+  RELEASE_CRON_UTC,
+  REPORT_CRON_UTC,
+} from "../../scripts/weekly-release-report.mjs";
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(here, "../..");
+const read = (rel) => fs.readFileSync(path.join(repoRoot, rel), "utf8");
+
+const REPORT_WORKFLOW = read(".github/workflows/thursday-release-report.yml");
+const RELEASE_WORKFLOW = read(".github/workflows/thursday-release.yml");
+const CREATE_RELEASE_WORKFLOW = read(".github/workflows/create-release.yml");
+
+function firstCron(workflow) {
+  return workflow.match(/cron:\s*"([^"]+)"/)?.[1] ?? null;
+}
+
+describe("Thursday release cadence", () => {
+  it("schedules the report for Thursday noon BRT", () => {
+    assert.equal(firstCron(REPORT_WORKFLOW), REPORT_CRON_UTC);
+    assert.match(REPORT_WORKFLOW, /workflow_dispatch:/);
+  });
+
+  it("schedules the release for Thursday 16:00 BRT", () => {
+    assert.equal(firstCron(RELEASE_WORKFLOW), RELEASE_CRON_UTC);
+    assert.match(RELEASE_WORKFLOW, /workflow_dispatch:/);
+  });
+
+  it("keeps the report four hours ahead of the release", () => {
+    const [reportMinute, reportHour, , , reportDay] = REPORT_CRON_UTC.split(" ");
+    const [releaseMinute, releaseHour, , , releaseDay] = RELEASE_CRON_UTC.split(" ");
+    assert.equal(reportDay, "4");
+    assert.equal(releaseDay, "4");
+    assert.equal(reportMinute, releaseMinute);
+    assert.equal(Number(releaseHour) - Number(reportHour), 4);
+  });
+
+  it("dispatches both release trains from the Thursday workflow", () => {
+    assert.match(RELEASE_WORKFLOW, /gh workflow run create-release\.yml/);
+    assert.match(RELEASE_WORKFLOW, /gh workflow run release-canvas\.yml/);
+  });
+
+  it("keeps the plugin release workflow off tag-push automation", () => {
+    assert.match(CREATE_RELEASE_WORKFLOW, /workflow_dispatch:/);
+    assert.doesNotMatch(CREATE_RELEASE_WORKFLOW, /push:\s*\n\s*tags:/);
+  });
+
+  it("keeps both Thursday workflows on the default branch", () => {
+    assert.match(REPORT_WORKFLOW, /github\.ref_name != github\.event\.repository\.default_branch/);
+    assert.match(RELEASE_WORKFLOW, /github\.ref_name != github\.event\.repository\.default_branch/);
+  });
+});

--- a/evals/tests/weekly-release-report.test.mjs
+++ b/evals/tests/weekly-release-report.test.mjs
@@ -1,0 +1,80 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  assessCanvasRelease,
+  assessPluginRelease,
+  buildReportMarkdown,
+  CANVAS_RELEASE_PART,
+} from "../../scripts/weekly-release-report.mjs";
+
+describe("weekly-release-report", () => {
+  it("keeps the plugin train waiting until a new version is prepared", () => {
+    const status = assessPluginRelease({
+      currentVersion: "2.6.0",
+      latestReleaseTag: "v2.6",
+      hasUnreleasedChanges: true,
+      changelogReady: true,
+    });
+    assert.equal(status.ready, false);
+    assert.match(status.reason, /already the latest published plugin release/);
+  });
+
+  it("marks the plugin train ready only when the changelog is prepared", () => {
+    const status = assessPluginRelease({
+      currentVersion: "2.7.0",
+      latestReleaseTag: "v2.6",
+      hasUnreleasedChanges: true,
+      changelogReady: true,
+    });
+    assert.equal(status.ready, true);
+    assert.equal(status.targetTag, "v2.7");
+  });
+
+  it("blocks the plugin train when the changelog section is missing", () => {
+    const status = assessPluginRelease({
+      currentVersion: "2.7.0",
+      latestReleaseTag: "v2.6",
+      hasUnreleasedChanges: true,
+      changelogReady: false,
+    });
+    assert.equal(status.ready, false);
+    assert.match(status.reason, /CHANGELOG\.md does not yet contain/);
+  });
+
+  it("marks the canvas train ready when unreleased commits exist", () => {
+    const status = assessCanvasRelease({
+      currentVersion: "1.2.3",
+      nextPlannedVersion: "1.2.4",
+      hasUnreleasedChanges: true,
+    });
+    assert.equal(status.ready, true);
+    assert.equal(status.targetTag, "v1.2.4");
+    assert.match(status.reason, new RegExp(`release-canvas\\.yml \\(${CANVAS_RELEASE_PART}`));
+  });
+
+  it("states plainly that Thursday's release does not wait for approval", () => {
+    const markdown = buildReportMarkdown({
+      reportDate: "2026-08-06",
+      plugin: {
+        latestReleaseTag: "v2.6",
+        currentVersion: "2.7.0",
+        targetTag: "v2.7",
+        ready: true,
+        reason: "Ready.",
+        commits: [{ sha: "abc1234", subject: "Prepare plugin release" }],
+        files: ["CHANGELOG.md"],
+      },
+      canvas: {
+        latestReleaseTag: "v1.2.3",
+        currentVersion: "1.2.3",
+        targetTag: "v1.2.4",
+        ready: true,
+        reason: "Ready.",
+        commits: [{ sha: "def5678", subject: "Ship canvas change" }],
+        files: ["VERSION"],
+      },
+    });
+    assert.match(markdown, /scheduled release still runs at 16:00 BRT even if approval does not arrive in time/i);
+  });
+});

--- a/scripts/check-distribution.mjs
+++ b/scripts/check-distribution.mjs
@@ -483,13 +483,12 @@ export function danglingTagLinks(links = [], publishedTags = [], { repo = REPO }
  * nothing behind it is invisible — and two states that need opposite instructions get the
  * same one:
  *
- *   A. the tag was never pushed              -> `git tag vX.Y && git push origin vX.Y`
- *   B. the tag was pushed and the run failed -> that command does nothing at all
+ *   A. the release was never dispatched      -> no tag exists yet
+ *   B. the tag exists but the run failed     -> re-dispatching on the tag is the only fix
  *
- * In state B `git tag` aborts on the collision, and pushing a ref that is already up to
- * date sends nothing, so no `push` event fires and create-release.yml cannot re-run. The
- * maintainer follows the advice, sees "Everything up-to-date", and the run stays red.
- * `Create Release` has already failed on a tag push here (run 28527065984, tag v1.1.0).
+ * In state B the tag is already there, so the Thursday scheduler will not recreate it and a
+ * recovery run has to dispatch create-release.yml on that tag explicitly. `Create Release` has
+ * already failed with a tag stranded on origin here (run 28527065984, tag v1.1.0).
  *
  * The plugin train is matched through `pluginTag` so a hand-pushed `v2.6.0` counts as the
  * tag standing in 2.6.0's way; the canvas train tags `v${VERSION}` verbatim and is matched
@@ -560,7 +559,9 @@ export function tagsWithoutRelease({
 export function republishInstruction({ tag, train, advertised } = {}) {
   const noEvent =
     `Re-pushing ${tag} cannot re-trigger anything: git sends nothing for a ref that is ` +
-    "already up to date, so no push event fires.";
+    "already up to date.";
+  const pluginNoEvent = `${noEvent} create-release.yml is dispatch-only, so recovery has to use ` +
+    "workflow_dispatch.";
   if (train === "plugin") {
     const version = (pluginReleaseTag(advertised) ?? tag).replace(/^v/i, "");
     return [
@@ -568,7 +569,7 @@ export function republishInstruction({ tag, train, advertised } = {}) {
         `\`gh workflow run create-release.yml --ref ${tag} -f version=${version}\`.`,
       `--ref pins the provenance: the workflow checks out the dispatched ref, and without it ` +
         `the run packages main as it stands now and attaches that to ${tag}.`,
-      noEvent,
+      pluginNoEvent,
     ];
   }
   if (train === "canvas") {
@@ -892,7 +893,7 @@ export function summarize({
   }
 
   const dangling = danglingTagLinks(tagLinks, tags);
-  // Three jobs, not one. A link waiting for a tag push is cut; a link naming a tag no
+  // Three jobs, not one. A link waiting for a release dispatch is cut; a link naming a tag no
   // pipeline creates is edited; a link for a version the manifest has already passed is
   // *folded into the release that will carry it*. Reporting them together hands the
   // maintainer instructions that cannot all work: cutting v2.6 leaves a v2.6.0 link 404,
@@ -909,7 +910,7 @@ export function summarize({
   });
   const cuttable = dangling.filter((l) => !unpublishable.includes(l) && !stranded.includes(l));
 
-  // Of what is left, a link whose tag is already on origin is not waiting for a tag push:
+  // Of what is left, a link whose tag is already on origin is not waiting for a fresh dispatch:
   // its release run failed. Same evidence, opposite instruction.
   const strandedTags = tagsWithoutRelease({
     manifestVersion,
@@ -1007,8 +1008,8 @@ export function summarize({
       detail: [
         `.claude-plugin/plugin.json: ${manifestVersion}`,
         newestLine(releases.plugin, "plugin"),
-        `Cut it with \`git tag ${pluginReleaseTag(manifestVersion) ?? "vX.Y"} && git push ` +
-          `origin ${pluginReleaseTag(manifestVersion) ?? "vX.Y"}\` (create-release.yml).`,
+        `Dispatch \`create-release.yml\` for ${pluginReleaseTag(manifestVersion)?.replace(/^v/i, "") ?? "X.Y"} ` +
+          `or let the Thursday release cadence pick it up from \`main\`.`,
       ],
     });
   }

--- a/scripts/release-train.mjs
+++ b/scripts/release-train.mjs
@@ -1,17 +1,16 @@
 #!/usr/bin/env node
 /**
- * Which release train a pushed tag belongs to.
+ * Which release train a tag belongs to.
  *
  * The project publishes two products from one repository and one tag namespace:
  *
  *   plugin  — .claude-plugin/plugin.json, released by create-release.yml
  *   canvas  — the srs-navigator extension, released by release-canvas.yml
  *
- * `create-release.yml` triggers on `push: tags: ["v*"]`, which matches both, and the trains
- * cannot be told apart by tag shape: `v2.4.1` is a plugin release and `v1.1.0` is a canvas
- * one. So every canvas release fired the plugin pipeline against a tag that does not match
- * plugin.json — run 28527065984 on tag v1.1.0, the only failure in that workflow's history,
- * four seconds after the canvas release it belonged to succeeded.
+ * The two products still share one tag namespace, and the trains cannot be told apart by tag
+ * shape: `v2.4.1` is a plugin release and `v1.1.0` is a canvas one. The canvas workflow asks
+ * this module whether the tag it is about to create belongs to it before anything leaves the
+ * runner, so a canvas release can never publish over a plugin tag.
  *
  * The tag can only be attributed by asking each train whether it claims it, which is what
  * this module does. Both rules are the pipelines' own, not local restatements:
@@ -21,9 +20,6 @@
  *            same comparison is used here via pluginReleaseTag().
  *   canvas — bump-version.mjs tags `v${version}` verbatim, so the match is exact.
  *
- * Usage (create-release.yml):
- *   node scripts/release-train.mjs --tag v2.6
- *
  * Usage (release-canvas.yml), where the answer must be one particular train:
  *   node scripts/release-train.mjs --tag v1.1.1 --expect canvas
  *
@@ -32,14 +28,9 @@
  * stopping for, and one both trains claim would have the plugin pipeline publish onto a
  * release the canvas job is about to create.
  *
- * `--expect` is what makes the gate bilateral. Gating the plugin pipeline alone leaves the
- * collision unguarded at the end that causes it: release-canvas.yml bumps the version and then
- * creates the tag as part of `gh release create`, so by the time create-release.yml classifies
- * anything the tag already exists. The canvas job therefore asserts the verdict is its own
- * train before anything leaves the runner. The two pipelines act on the verdict differently on
- * purpose: create-release.yml fires on every `v*` tag, most of which are not its business, so
- * it *skips*; release-canvas.yml was dispatched deliberately and is about to publish, so it
- * *fails*.
+ * `--expect` is what makes the gate load-bearing. release-canvas.yml bumps the version and then
+ * creates the tag as part of `gh release create`, so the canvas job has to assert the verdict
+ * is its own train before anything leaves the runner.
  */
 
 import fs from "node:fs";

--- a/scripts/weekly-release-report.mjs
+++ b/scripts/weekly-release-report.mjs
@@ -1,0 +1,334 @@
+#!/usr/bin/env node
+/**
+ * Build the Thursday release report and the dispatch decisions that go with it.
+ *
+ * The repository has two release trains with different rules:
+ *   - plugin: only releasable when plugin.json + CHANGELOG.md already advertise
+ *             an unpublished version
+ *   - canvas: releasable whenever there are unreleased commits; the workflow
+ *             bumps the patch version itself
+ *
+ * This script keeps that decision logic in one place so the report workflow and
+ * the release-dispatch workflow cannot drift apart.
+ */
+
+import fs from "node:fs";
+import path from "node:path";
+import { execFileSync } from "node:child_process";
+import { fileURLToPath, pathToFileURL } from "node:url";
+
+import {
+  fetchPublishedReleases,
+  pluginReleaseTag,
+  releaseTrain,
+} from "./check-distribution.mjs";
+import { nextVersion } from "./bump-version.mjs";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+export const REPO_ROOT = path.resolve(__dirname, "..");
+const BUILD_PLUGIN = path.join(REPO_ROOT, "scripts", "build-plugin.py");
+
+export const REPORT_TIME_BRT = "12:00 BRT";
+export const RELEASE_TIME_BRT = "16:00 BRT";
+export const REPORT_CRON_UTC = "0 15 * * 4";
+export const RELEASE_CRON_UTC = "0 19 * * 4";
+export const REPORT_TIMEZONE = "America/Sao_Paulo";
+export const CANVAS_RELEASE_PART = "patch";
+
+function parseArgs(argv) {
+  const out = { markdownOut: null, jsonOut: null, repo: process.env.GITHUB_REPOSITORY ?? undefined };
+  for (let i = 0; i < argv.length; i++) {
+    if (argv[i] === "--markdown-out") out.markdownOut = argv[++i];
+    else if (argv[i] === "--json-out") out.jsonOut = argv[++i];
+    else if (argv[i] === "--repo") out.repo = argv[++i];
+    else throw new Error(`Unknown argument "${argv[i]}".`);
+  }
+  return out;
+}
+
+function readJson(file) {
+  return JSON.parse(fs.readFileSync(file, "utf8"));
+}
+
+export function readPluginVersion(root = REPO_ROOT) {
+  return readJson(path.join(root, ".claude-plugin", "plugin.json")).version;
+}
+
+export function readCanvasVersion(root = REPO_ROOT) {
+  return fs.readFileSync(path.join(root, "VERSION"), "utf8").trim();
+}
+
+export function existingTags(root = REPO_ROOT) {
+  return gitLines(["tag", "--list"], { root });
+}
+
+function gitLines(args, { root = REPO_ROOT } = {}) {
+  const output = execFileSync("git", args, { cwd: root, encoding: "utf8" });
+  return output
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter(Boolean);
+}
+
+function gitCommitsSince(tag, { root = REPO_ROOT } = {}) {
+  const args = ["log", "--format=%h%x09%s"];
+  if (tag) args.push(`${tag}..HEAD`);
+  return gitLines(args, { root }).map((line) => {
+    const [sha, subject] = line.split("\t");
+    return { sha, subject };
+  });
+}
+
+function gitFilesSince(tag, { root = REPO_ROOT } = {}) {
+  if (!tag) return gitLines(["ls-files"], { root });
+  return gitLines(["diff", "--name-only", `${tag}..HEAD`], { root });
+}
+
+function hasChangelogSection(version, { root = REPO_ROOT, python = process.env.PYTHON ?? "python" } = {}) {
+  try {
+    execFileSync(python, [BUILD_PLUGIN, "notes", "--version", version], {
+      cwd: root,
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function formatDateInZone(date, timeZone = REPORT_TIMEZONE) {
+  const parts = new Intl.DateTimeFormat("en-CA", {
+    timeZone,
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+  }).formatToParts(date);
+  const map = Object.fromEntries(parts.map((part) => [part.type, part.value]));
+  return `${map.year}-${map.month}-${map.day}`;
+}
+
+function newestRelease(releases, train) {
+  return releases.find((release) => releaseTrain(release) === train) ?? null;
+}
+
+export function assessPluginRelease({
+  currentVersion,
+  latestReleaseTag = null,
+  hasUnreleasedChanges,
+  changelogReady,
+}) {
+  const targetTag = pluginReleaseTag(currentVersion);
+  if (!hasUnreleasedChanges) {
+    return {
+      train: "plugin",
+      ready: false,
+      targetVersion: currentVersion,
+      targetTag,
+      reason: "No commits are waiting for the plugin train.",
+    };
+  }
+  if (!targetTag) {
+    return {
+      train: "plugin",
+      ready: false,
+      targetVersion: currentVersion,
+      targetTag: null,
+      reason: "plugin.json does not contain a publishable dotted version.",
+    };
+  }
+  if (targetTag === latestReleaseTag) {
+    return {
+      train: "plugin",
+      ready: false,
+      targetVersion: currentVersion,
+      targetTag,
+      reason:
+        `${targetTag} is already the latest published plugin release. ` +
+        "The scheduled run will skip until plugin.json and CHANGELOG.md are prepared for a new version.",
+    };
+  }
+  if (!changelogReady) {
+    return {
+      train: "plugin",
+      ready: false,
+      targetVersion: currentVersion,
+      targetTag,
+      reason: `CHANGELOG.md does not yet contain the release notes for ${currentVersion}.`,
+    };
+  }
+  return {
+    train: "plugin",
+    ready: true,
+    targetVersion: currentVersion,
+    targetTag,
+    reason: `Ready to dispatch create-release.yml for ${targetTag}.`,
+  };
+}
+
+export function assessCanvasRelease({
+  currentVersion,
+  nextPlannedVersion,
+  hasUnreleasedChanges,
+}) {
+  const targetTag = `v${nextPlannedVersion}`;
+  if (!hasUnreleasedChanges) {
+    return {
+      train: "canvas",
+      ready: false,
+      currentVersion,
+      targetVersion: nextPlannedVersion,
+      targetTag,
+      reason: "No commits are waiting for the canvas train.",
+    };
+  }
+  return {
+    train: "canvas",
+    ready: true,
+    currentVersion,
+    targetVersion: nextPlannedVersion,
+    targetTag,
+    reason: `Ready to dispatch release-canvas.yml (${CANVAS_RELEASE_PART} -> ${nextPlannedVersion}).`,
+  };
+}
+
+function markdownLinesForCommits(commits) {
+  if (commits.length === 0) return ["_No unreleased commits._"];
+  return commits.map((commit) => `- \`${commit.sha}\` ${commit.subject}`);
+}
+
+function markdownLinesForFiles(files) {
+  if (files.length === 0) return ["_No changed files._"];
+  return files.map((file) => `- \`${file}\``);
+}
+
+export function buildReportMarkdown({ reportDate, plugin, canvas }) {
+  const lines = [
+    `# Weekly release report — ${reportDate}`,
+    "",
+    `Review this before ${RELEASE_TIME_BRT} if you want to adjust today's release. ` +
+      `The scheduled release still runs at ${RELEASE_TIME_BRT} even if approval does not arrive in time.`,
+    "",
+    "| Train | Latest published | Planned Thursday target | Ready now? | Status |",
+    "| --- | --- | --- | --- | --- |",
+    `| Plugin | ${plugin.latestReleaseTag ?? "none"} | ${plugin.targetTag ?? "n/a"} | ${plugin.ready ? "Yes" : "No"} | ${plugin.reason} |`,
+    `| Canvas | ${canvas.latestReleaseTag ?? "none"} | ${canvas.targetTag} | ${canvas.ready ? "Yes" : "No"} | ${canvas.reason} |`,
+    "",
+    "## Plugin train",
+    "",
+    `- **Latest published release:** ${plugin.latestReleaseTag ?? "none"}`,
+    `- **Current advertised version:** ${plugin.currentVersion}`,
+    `- **Planned scheduled target:** ${plugin.targetTag ?? "n/a"}`,
+    `- **Commits waiting:** ${plugin.commits.length}`,
+    `- **Files changed:** ${plugin.files.length}`,
+    "",
+    "### Commits",
+    "",
+    ...markdownLinesForCommits(plugin.commits),
+    "",
+    "### Files",
+    "",
+    ...markdownLinesForFiles(plugin.files),
+    "",
+    "## Canvas train",
+    "",
+    `- **Latest published release:** ${canvas.latestReleaseTag ?? "none"}`,
+    `- **Current version on main:** ${canvas.currentVersion}`,
+    `- **Planned scheduled target:** ${canvas.targetTag}`,
+    `- **Commits waiting:** ${canvas.commits.length}`,
+    `- **Files changed:** ${canvas.files.length}`,
+    "",
+    "### Commits",
+    "",
+    ...markdownLinesForCommits(canvas.commits),
+    "",
+    "### Files",
+    "",
+    ...markdownLinesForFiles(canvas.files),
+    "",
+  ];
+  return lines.join("\n");
+}
+
+export async function collectWeeklyReleaseReport({
+  root = REPO_ROOT,
+  repo = process.env.GITHUB_REPOSITORY,
+  token = process.env.GITHUB_TOKEN ?? process.env.GH_TOKEN,
+  now = new Date(),
+} = {}) {
+  const releases = repo ? await fetchPublishedReleases({ repo, token }) : [];
+  const latestPlugin = newestRelease(releases, "plugin");
+  const latestCanvas = newestRelease(releases, "canvas");
+  const tags = existingTags(root);
+
+  const pluginVersion = readPluginVersion(root);
+  const pluginCommits = gitCommitsSince(latestPlugin?.tag ?? null, { root });
+  const pluginFiles = gitFilesSince(latestPlugin?.tag ?? null, { root });
+  const pluginStatus = assessPluginRelease({
+    currentVersion: pluginVersion,
+    latestReleaseTag: latestPlugin?.tag ?? null,
+    hasUnreleasedChanges: pluginCommits.length > 0,
+    changelogReady: hasChangelogSection(pluginVersion, { root }),
+  });
+
+  const canvasVersion = readCanvasVersion(root);
+  const canvasCommits = gitCommitsSince(latestCanvas?.tag ?? null, { root });
+  const canvasFiles = gitFilesSince(latestCanvas?.tag ?? null, { root });
+  const canvasStatus = assessCanvasRelease({
+    currentVersion: canvasVersion,
+    nextPlannedVersion: nextVersion(canvasVersion, CANVAS_RELEASE_PART, tags),
+    hasUnreleasedChanges: canvasCommits.length > 0,
+  });
+
+  const reportDate = formatDateInZone(now, REPORT_TIMEZONE);
+  const payload = {
+    generatedAt: now.toISOString(),
+    reportDate,
+    reportTitle: `Weekly release report for ${reportDate}`,
+    plugin: {
+      ...pluginStatus,
+      currentVersion: pluginVersion,
+      latestReleaseTag: latestPlugin?.tag ?? null,
+      commits: pluginCommits,
+      files: pluginFiles,
+    },
+    canvas: {
+      ...canvasStatus,
+      latestReleaseTag: latestCanvas?.tag ?? null,
+      commits: canvasCommits,
+      files: canvasFiles,
+    },
+  };
+  payload.markdown = buildReportMarkdown(payload);
+  return payload;
+}
+
+function emitOutputs(report) {
+  const out = process.env.GITHUB_OUTPUT;
+  if (!out) return;
+  fs.appendFileSync(out, `report_title=${report.reportTitle}\n`);
+  fs.appendFileSync(out, `plugin_ready=${report.plugin.ready}\n`);
+  fs.appendFileSync(out, `plugin_version=${report.plugin.targetVersion}\n`);
+  fs.appendFileSync(out, `plugin_tag=${report.plugin.targetTag ?? ""}\n`);
+  fs.appendFileSync(out, `canvas_ready=${report.canvas.ready}\n`);
+  fs.appendFileSync(out, `canvas_version=${report.canvas.targetVersion}\n`);
+  fs.appendFileSync(out, `canvas_tag=${report.canvas.targetTag}\n`);
+}
+
+async function main(argv) {
+  const args = parseArgs(argv);
+  const report = await collectWeeklyReleaseReport({ repo: args.repo });
+  if (args.markdownOut) fs.writeFileSync(args.markdownOut, `${report.markdown}\n`, "utf8");
+  if (args.jsonOut) fs.writeFileSync(args.jsonOut, `${JSON.stringify(report, null, 2)}\n`, "utf8");
+  emitOutputs(report);
+  if (!args.markdownOut && !args.jsonOut) process.stdout.write(`${report.markdown}\n`);
+}
+
+const invokedDirectly =
+  process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href;
+
+if (invokedDirectly) {
+  main(process.argv.slice(2)).catch((error) => {
+    console.error(`::error::${error.message}`);
+    process.exit(1);
+  });
+}


### PR DESCRIPTION
This moves releases onto a weekly Thursday cadence so changes can accumulate until a predictable review window, while still allowing the release to proceed on time if no approval arrives before the cutoff.

## Why

The repository had multiple release paths and docs that still treated plugin releases as tag-push driven. That left room for out-of-band releases and made the new Thursday cadence incomplete.

## What changed

- Add a Thursday report workflow at 12:00 BRT and a Thursday dispatch workflow at 16:00 BRT.
- Add `scripts/weekly-release-report.mjs` to decide which trains are ready and to generate the review report.
- Make `create-release.yml` dispatch-only so plugin releases no longer auto-run from `v*` tag pushes outside the cadence.
- Keep the canvas release guarded by `release-train.mjs` before it creates a shared-namespace tag.
- Update release docs, Copilot instructions, and drift/recovery logic to describe dispatch-based releases instead of tag-push-based ones.
- Add and update deterministic tests so the cadence, runbook, recovery guidance, and workflow assumptions fail loudly if they drift.

## Notes for review

The main behavioral change is that the plugin train's normal automatic path is now the Thursday dispatcher, not a tag push. Manual dispatch remains available for exceptions and recovery.

The plugin train still only auto-releases when `plugin.json` and `CHANGELOG.md` already advertise an unpublished version; otherwise the Thursday report surfaces the accumulated changes and skips that train for the cycle.