### PR TITLE
Make the release verification runbook executable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,46 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **The release procedure is now executable, not only documented.** `docs/release-verification.md`
+  described a pre-flight, a `/live` proof and an evidence pack in prose; nothing ran any of
+  them, so each was performed slightly differently every time and the numbers in a pack were
+  hand-copied snapshots. Three tools close that gap, each addressing a stated problem in the
+  issue it comes from:
+  - **`evals/tools/release-preflight.mjs`** (#104 — "no rehearsal exists"). Nine gates run
+    before the tag exists, which is the last moment anything can be fixed cheaply: the tag push
+    triggers `create-release.yml`, so a failed run strands a tag and re-pushing emits no `push`
+    event. The gate the old pre-flight lacked is `packaged-archive-loads` — it extracts the
+    archive `build-plugin.py build` just wrote and puts `verifyPluginArchive` through it. The
+    packager only ever *packaged*, and the verifier only ever ran *after* publication, so the
+    defect class #104 exists for — `agents/skills/` links that were broken in **every**
+    published zip — could reach the release page unopposed. The train is decided by importing
+    `tagTrain()` from `scripts/release-train.mjs` rather than re-deriving it, and a `vX.Y.Z`
+    canvas tag is refused rather than guessed at: that train creates its tag *as part of*
+    publishing, so it has no "before the tag" moment. Release notes are read from the
+    `$GITHUB_OUTPUT` payload the build writes, which is the only place it emits them.
+  - **`evals/tools/live-profile.mjs`** (#105, problems 3 and 4). Workspace isolation and
+    command source were prose conditions nothing checked, so a capture could be — and was —
+    produced from a profile where this repository's own `.github/extensions/srs-navigator`
+    registers the same canvas id and tool name a second time. It reads the archive's `ACTIONS`
+    table rather than restating that `live` is absent from it, so adding `live` to the
+    extension changes the verdict instead of leaving the runbook wrong. `--loaded`, `--log`
+    and `--note` record the manual half and gate nothing: the tool cannot observe the app and
+    must not appear to.
+  - **`evals/tools/evidence-pack.mjs`** (#107 / #92). The pack's parts existed —
+    `graph-metrics.mjs`, `distribution-artifacts.mjs`, `verify-plugin-archive.mjs` — but
+    nothing composed them. It derives every figure it can and labels the rest recorded, and a
+    family whose artefact was not supplied **fails** rather than being skipped, because a pack
+    that silently omits the family it could not prove reads exactly like one that proved it.
+    It also sharpens the need-cluster definition the runbook carried: `computeHotspots`
+    classifies with an if/else chain, so a hub is "degree ≥ 4 **excluding** nodes already
+    classified as an orphaned problem or an unmet need", and an array that happens to have the
+    same length is a coincidence, not a derivation.
+
+  All three are covered by `evals/tests/{release-preflight,live-profile,evidence-pack}.test.mjs`
+  — 166 tests at 100 % line and function coverage, with a canary per gate — and
+  `evals/tests/release-verification-runbook.test.mjs` now requires the runbook to name each
+  executable and runs every documented command line through the tool's **own** `parseArgs`, so
+  a renamed option fails here instead of during a release.
 - **The release artefact a user downloads is now *loaded*, not just staged.** Three install
   families ship from this repository, and only two had a reader. `plugin-archive-install`
   checked what the packager *stages*; nothing opened the published

--- a/docs/release-verification.md
+++ b/docs/release-verification.md
@@ -15,6 +15,15 @@ which tag, what the distribution monitor reports) and links back to this file fo
 - [Proving `/live` in the app itself](#proving-live-in-the-app-itself)
 - [Deriving an evidence pack](#deriving-an-evidence-pack)
 
+Three steps below are also **executable**, because a procedure only prose describes is a
+procedure that gets performed differently each time:
+
+| Step | Command |
+|---|---|
+| Pre-flight, before any tag is pushed | `evals/tools/release-preflight.mjs` |
+| The `/live` preconditions | `evals/tools/live-profile.mjs` |
+| The evidence pack | `evals/tools/evidence-pack.mjs` |
+
 ---
 
 ## Distribution artefact families
@@ -45,6 +54,13 @@ a failed run leaves a tag behind, and re-pushing an existing ref emits no `push`
 Everything that can be checked from a clean `main` is checked first.
 
 ```bash
+node evals/tools/release-preflight.mjs --tag vX.Y --json preflight.json
+```
+
+That single command runs the whole rehearsal and exits non-zero if any gate fails. It is the
+executable form of the steps below, which it runs itself:
+
+```bash
 git checkout main && git pull --tags
 git rev-parse HEAD                                   # record this SHA in the release issue
 
@@ -54,6 +70,22 @@ node --test evals/tests/*.test.mjs
 python scripts/build-plugin.py validate
 ( cd .github/extensions/srs-navigator && npm test )
 ```
+
+It adds the one step that list never had: it **opens** what the packager just wrote.
+`build-plugin.py build` packages an archive and stops; `verify-plugin-archive.mjs` has only
+ever run *after* publication, against the download. So the defect class #104 exists for —
+`agents/skills/` links that were broken in every published zip because nothing opened one —
+could sail past the tag and be found on the release page. `packaged-archive-loads` extracts
+the fresh archive to a temporary directory and puts `verifyPluginArchive` through it, on this
+side of the push. Pass `--no-suites` to skip the two test-suite gates when they have just run,
+`--against HEAD` to waive the "HEAD is what will be tagged" comparison visibly rather than
+silently, and `--keep` to leave the packaged archive and the extracted tree on disk for
+inspection.
+
+Its gates are closure properties and its counts are recorded, never gated — the same contract
+`verify-plugin-archive.mjs` follows, so a tenth action does not turn a correct rehearsal red.
+It refuses a `vX.Y.Z` canvas tag rather than guessing: the canvas train creates its tag *as
+part of* publishing, so it has no "before the tag" moment to rehearse.
 
 `build-plugin.py` normalizes the version, so a manifest reading `2.6.0` publishes at
 **`v2.6`** — and GitHub serves `/releases/tag/<tag>` by exact name. Push the tag the
@@ -190,18 +222,63 @@ Procedure:
 ls ~/.copilot/extensions/                      # must not already contain srs-navigator
 unzip -q srs-navigator-X.Y.Z.zip -d ~/.copilot/extensions/
 cd /some/neutral/workspace                     # NOT this repository
+
+node <repo>/evals/tools/live-profile.mjs \
+  --workspace "$PWD" \
+  --archive ~/.copilot/extensions/srs-navigator \
+  --skills ~/.copilot/skills/problem-based-srs \
+  --json live-preconditions.json
 ```
+
+`live-profile.mjs` checks both conditions above before the app is opened, so a capture cannot
+be filed from a double-registered profile. It reads the archive's own `ACTIONS` table rather
+than restating that `live` is absent from it, so adding `live` to the extension changes the
+verdict instead of leaving this document wrong.
 
 Then, in the Copilot app: reload extensions → confirm `srs-navigator` is listed as **loaded**
 (not `failed`) → run `/live` → capture the panel, and record the extension log path from the
-extension inspector.
+extension inspector. Fold that observation back in:
 
-If the host refuses to load it, record the refusal verbatim. A failed load is a result; the
-loopback capture answers a different question and cannot be substituted for it.
+```bash
+node <repo>/evals/tools/live-profile.mjs --workspace "$PWD" \
+  --archive ~/.copilot/extensions/srs-navigator \
+  --loaded loaded --log <extension-log-path> --note "panel rendered"
+```
+
+`--loaded`, `--log` and `--note` are **recorded and never gate the exit code**, because the
+tool cannot observe the app and must not appear to.
+
+If the host refuses to load it, record the refusal verbatim (`--loaded failed`).
+A failed load is a result; the loopback capture answers a different question and
+cannot be substituted for it.
 
 ---
 
 ## Deriving an evidence pack
+
+```bash
+node scripts/check-distribution.mjs --json > distribution.json
+
+node evals/tools/evidence-pack.mjs \
+  --plugin-archive /tmp/pbsrs-asset/extracted \
+  --canvas-archive /tmp/ext/srs-navigator \
+  --provenance /tmp/canvas-archive/provenance.json \
+  --distribution distribution.json \
+  --markdown pack.md --json pack.json
+```
+
+The parts have existed for a while — `graph-metrics.mjs`, `distribution-artifacts.mjs`,
+`verify-plugin-archive.mjs` — but nothing composed them, so the pack was assembled by hand
+from snapshots and its numbers aged silently. `evidence-pack.mjs` composes them and labels
+every figure derived or recorded. A family whose artefact was not supplied **fails** and is
+**never skipped**, because a pack that quietly omits the family it could not prove reads
+exactly like one that proved it.
+
+`--markdown` writes the pack a human reads and `--json` writes the record a later run can
+diff; either takes `-` for stdout. `--distribution` folds in a `check-distribution.mjs --json`
+payload rather than re-fetching the third-party surfaces, so the pack quotes the run that was
+actually observed. `--provenance` ties the canvas capture to the `extension.mjs` that served
+it, and `--spec` points the derived figures at a specification other than the shipped demo.
 
 Every number in a pack is either **derived** or **recorded**, and the two are labelled:
 
@@ -210,7 +287,7 @@ Every number in a pack is either **derived** or **recorded**, and the two are la
 | every action resolves | `verify-plugin-archive.mjs` — dispatch closure over the extracted tree, both directions |
 | no link escapes the tree | `verify-plugin-archive.mjs` — full relative-link closure |
 | skill file count | *recorded* from the installed tree; never a gate. The dispatch table cannot supply it — the tree also carries `SKILL.md` and the `*-example.md` walkthroughs, which no action dispatches |
-| node / need-cluster / traceability figures | *derived* from the loaded specification with `healthMetrics()` in `.github/extensions/srs-navigator/lib/graph-metrics.mjs` — the same function the page runs. "Need clusters" is a degree ≥ 4 graph property, not an array length |
+| node / need-cluster / traceability figures | *derived* from the loaded specification with `healthMetrics()` in `.github/extensions/srs-navigator/lib/graph-metrics.mjs` — the same function the page runs. "Need clusters" is a degree ≥ 4 graph property, not an array length: nodes whose total degree reaches 4, **excluding** any already classified as an orphaned problem or an unmet need, because the classification is an if/else chain and those two win over hub. Where some array happens to have the same length, that is a coincidence and not a derivation |
 | `check-distribution.mjs --strict` exits 0 | **zero *error* findings**. Warnings and notices exit 0 by design, so the pack says "zero errors; every warning and notice explained" rather than treating exit 0 as a fully readable third-party surface |
 
 Thresholds are re-checked with **fixture canaries** — small purpose-built trees in the test

--- a/evals/tests/evidence-pack.test.mjs
+++ b/evals/tests/evidence-pack.test.mjs
@@ -1,0 +1,804 @@
+// `evals/tools/evidence-pack.mjs` composes the pack #92 asked for and #107 refined. Its whole
+// value is that the numbers in it are **derived** rather than copied off a screenshot: #92
+// attached the landing page's dashboard to a claim about the graph health bar, and no reader
+// could tell, because a screenshot cannot say which page rendered it.
+//
+// So this suite pins the two things that make the pack worth attaching:
+//
+//   1. a family with no artefact supplied **fails**, and never skips. A pack that quietly
+//      omits the plugin-archive family is the pack that shipped the broken zip;
+//   2. the figures come out of the same `healthMetrics()` the page runs, over the same
+//      `buildGraphData()`, so the pack and the screenshot cannot disagree — and `needClusters`
+//      is checked to be a *graph property*, not the length of any array in the spec.
+//
+// Everything except the last describe block runs on fixtures, so the gates are exercised in
+// both directions without needing a published artefact.
+import { describe, it, before, after } from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { spawnSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
+
+import {
+  CANVAS_TESTS,
+  DEFAULT_SPEC,
+  NEED_CLUSTER_DEFINITION,
+  REPO_ROOT,
+  USAGE,
+  buildEvidencePack,
+  canvasArchiveEvidence,
+  captureAttribution,
+  cli,
+  distributionEvidence,
+  familyCoverage,
+  formatMarkdown,
+  formatReport,
+  graphFigures,
+  parseArgs,
+  pluginArchiveEvidence,
+  skillsEvidence,
+} from "../tools/evidence-pack.mjs";
+import { ARTIFACT_FAMILIES } from "../lib/distribution-artifacts.mjs";
+import { buildGraphData } from "../../.github/extensions/srs-navigator/lib/parser.mjs";
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(here, "../..");
+
+let tmp = "";
+
+before(() => {
+  tmp = fs.mkdtempSync(path.join(os.tmpdir(), "pbsrs-evidence-pack-"));
+});
+
+after(() => {
+  if (tmp) fs.rmSync(tmp, { recursive: true, force: true });
+});
+
+/* --------------------------------------------------------------------------- fixtures */
+
+function tree(name, files = {}) {
+  const root = path.join(tmp, name);
+  fs.rmSync(root, { recursive: true, force: true });
+  fs.mkdirSync(root, { recursive: true });
+  for (const [rel, body] of Object.entries(files)) {
+    const abs = path.join(root, rel);
+    fs.mkdirSync(path.dirname(abs), { recursive: true });
+    fs.writeFileSync(abs, typeof body === "string" ? body : JSON.stringify(body));
+  }
+  return root;
+}
+
+const ALL_HEADINGS = ARTIFACT_FAMILIES.flatMap((f) => [...f.readmeHeadings]);
+
+/** A README whose Installation section documents exactly `headings`. */
+const readmeWith = (headings) =>
+  ["# Project", "", "## Installation", "", ...headings.flatMap((h) => [h, "", "steps", ""]), "## Later", ""].join("\n");
+
+const row = (action) => `| \`${action}\` | [\`reference/${action}.md\`](reference/${action}.md) |`;
+
+/** A skills install whose dispatch closes and whose links stay inside it. */
+function skillTree(name, { actions = ["problems", "live"], omit = [], extra = {} } = {}) {
+  const shipped = actions.filter((a) => !omit.includes(a));
+  const files = {
+    "SKILL.md": ["| Action | File |", "|---|---|", ...actions.map(row)].join("\n"),
+    ...Object.fromEntries(shipped.map((a) => [`reference/${a}.md`, `# ${a}\n`])),
+    ...extra,
+  };
+  return tree(name, files);
+}
+
+/** A plugin archive `verifyPluginArchive` accepts. */
+function pluginArchiveTree(name, overrides = {}) {
+  return tree(name, {
+    "problem-based-srs/.claude-plugin/plugin.json": { name: "problem-based-srs", version: "9.9.9" },
+    "problem-based-srs/skills/problem-based-srs/SKILL.md": [
+      "| Action | File |",
+      "|---|---|",
+      row("problems"),
+    ].join("\n"),
+    "problem-based-srs/skills/problem-based-srs/reference/problems.md": "# problems\n",
+    ...overrides,
+  });
+}
+
+const gate = (pack, id) => pack.checks.find((c) => c.id === id);
+
+/* ---------------------------------------------------------------- family coverage */
+
+describe("familyCoverage checks the mapping instead of asserting it", () => {
+  it("accepts a README whose install methods the families cover exactly once", () => {
+    const coverage = familyCoverage(readmeWith(ALL_HEADINGS));
+    assert.equal(coverage.ok, true);
+    assert.deepEqual(coverage.uncovered, []);
+    assert.deepEqual(coverage.duplicated, []);
+    assert.deepEqual(coverage.phantom, []);
+    assert.equal(coverage.documented.length, ALL_HEADINGS.length);
+  });
+
+  it("reports an install method no family claims", () => {
+    const coverage = familyCoverage(readmeWith([...ALL_HEADINGS, "### Homebrew tap"]));
+    assert.equal(coverage.ok, false);
+    assert.deepEqual(coverage.uncovered, ["### Homebrew tap"]);
+  });
+
+  it("reports a family claim the README does not document", () => {
+    const coverage = familyCoverage(readmeWith(ALL_HEADINGS.slice(1)));
+    assert.equal(coverage.ok, false);
+    assert.deepEqual(coverage.phantom, [ALL_HEADINGS[0]]);
+  });
+
+  it("reports a README with no Installation section as covering nothing", () => {
+    const coverage = familyCoverage("# Project\n\nNo install section here.\n");
+    assert.equal(coverage.ok, false);
+    assert.deepEqual(coverage.documented, []);
+  });
+
+  it("reports a heading two families both claim", () => {
+    // The shipped table has no duplicate, which is exactly why the family list is a parameter:
+    // "each exactly once" is only a check if something can fail it.
+    const families = [
+      { readmeHeadings: ["### Manual"] },
+      { readmeHeadings: ["### Manual", "### Plugin release archive"] },
+    ];
+    const coverage = familyCoverage(
+      readmeWith(["### Manual", "### Plugin release archive"]),
+      families,
+    );
+    assert.equal(coverage.ok, false);
+    assert.deepEqual(coverage.duplicated, ["### Manual"]);
+  });
+});
+
+/* ------------------------------------------------------------- the three families */
+
+describe("family 1 — the repository clone", () => {
+  it("reads the dispatch and link closure of an installed skill", () => {
+    const evidence = skillsEvidence(skillTree("skills-good"));
+    assert.equal(evidence.supplied, true);
+    assert.equal(evidence.exists, true);
+    assert.equal(evidence.dispatch.ok, true);
+    assert.equal(evidence.links.broken.length, 0);
+    assert.match(evidence.recorded.why, /recorded, not derived/);
+  });
+
+  it("says which family goes unproven when no install is given", () => {
+    const evidence = skillsEvidence(null);
+    assert.equal(evidence.supplied, false);
+    assert.match(evidence.reason, /four README install methods deliver/);
+  });
+
+  it("reports a directory that is not there", () => {
+    const evidence = skillsEvidence(path.join(tmp, "no-such-skill"));
+    assert.equal(evidence.exists, false);
+    assert.match(evidence.reason, /does not exist/);
+  });
+});
+
+describe("family 2 — the plugin archive", () => {
+  it("delegates to the reader the post-publication step already uses", () => {
+    const evidence = pluginArchiveEvidence(pluginArchiveTree("plugin-good"));
+    assert.equal(evidence.supplied, true);
+    assert.equal(evidence.verification.ok, true);
+  });
+
+  it("keeps a reader failure as a result instead of throwing out of the pack", () => {
+    const evidence = pluginArchiveEvidence(path.join(tmp, "no-such-archive"));
+    assert.equal(evidence.supplied, true);
+    assert.ok(evidence.error, "an unreadable archive must be reported, not raised");
+  });
+
+  it("names the defect history when the family is missing", () => {
+    assert.match(pluginArchiveEvidence(null).reason, /defect in every published zip/);
+  });
+});
+
+describe("family 3 — the canvas archive", () => {
+  it("accepts an extracted archive and folds in a capture's provenance", () => {
+    const evidence = canvasArchiveEvidence(
+      tree("canvas-good", { "extension.mjs": "export default {};" }),
+      { extensionSha256: "abcdef0123456789" },
+    );
+    assert.deepEqual(evidence.problems, []);
+    assert.equal(evidence.recorded.files, 1);
+    assert.equal(evidence.provenance.extensionSha256, "abcdef0123456789");
+  });
+
+  it("rejects a tree with no extension.mjs", () => {
+    const evidence = canvasArchiveEvidence(tree("canvas-empty", { "README.md": "x" }));
+    assert.equal(evidence.problems.length, 1);
+    assert.match(evidence.problems[0], /is not the archive's/);
+  });
+
+  it("rejects a tree an install step re-created", () => {
+    const evidence = canvasArchiveEvidence(
+      tree("canvas-installed", {
+        "extension.mjs": "export default {};",
+        "node_modules/x/index.js": "0",
+      }),
+    );
+    assert.ok(evidence.problems.some((p) => /node_modules is present/.test(p)));
+  });
+
+  it("rejects the checkout masquerading as the release", () => {
+    // `.github` in the path is the exact condition extension.mjs uses to decide it is an
+    // in-repo install and resolve skills from the repository instead of its own bundle.
+    const evidence = canvasArchiveEvidence(
+      path.join(repoRoot, ".github", "extensions", "srs-navigator"),
+    );
+    assert.ok(evidence.problems.some((p) => /this is the checkout, not the release/.test(p)));
+  });
+
+  it("reports a directory that is not there", () => {
+    const evidence = canvasArchiveEvidence(path.join(tmp, "no-canvas"));
+    assert.match(evidence.problems[0], /does not exist/);
+    assert.equal(evidence.recorded, null);
+  });
+
+  it("says which family goes unproven when none is given", () => {
+    const evidence = canvasArchiveEvidence(null);
+    assert.equal(evidence.supplied, false);
+    assert.equal(evidence.provenance, null);
+  });
+});
+
+/* ------------------------------------------------------------- the monitor's verdict */
+
+describe("distributionEvidence reads the monitor's own summary", () => {
+  it("separates errors from warnings and notices, because only errors fail the run", () => {
+    const evidence = distributionEvidence({
+      findings: [
+        { id: "registry-listing-drift", severity: "error" },
+        { id: "surface-unreachable", severity: "warning" },
+        { title: "untitled finding", severity: "error" },
+      ],
+      unverified: [{ id: "registry-skill-version-unverifiable" }],
+    });
+    assert.deepEqual(evidence.errors, ["registry-listing-drift", "untitled finding"]);
+    assert.deepEqual(evidence.warnings, ["surface-unreachable"]);
+    assert.deepEqual(evidence.unverified, ["registry-skill-version-unverifiable"]);
+    assert.match(evidence.reading, /Warnings and notices exit 0 by design/);
+  });
+
+  it("names an unnamed finding rather than dropping it", () => {
+    const evidence = distributionEvidence({ findings: [{ severity: "error" }] });
+    assert.deepEqual(evidence.errors, ["(unnamed)"]);
+  });
+
+  it("falls back to a finding's title on every channel, not just the error one", () => {
+    const evidence = distributionEvidence({
+      findings: [
+        { title: "a warning with no id", severity: "warning" },
+        { severity: "warning" },
+      ],
+      unverified: [{ title: "a notice with no id" }, {}],
+    });
+    assert.deepEqual(evidence.warnings, ["a warning with no id", "(unnamed)"]);
+    assert.deepEqual(evidence.unverified, ["a notice with no id", "(unnamed)"]);
+  });
+
+  it("tolerates a summary with no arrays at all", () => {
+    const evidence = distributionEvidence({});
+    assert.deepEqual(evidence.errors, []);
+    assert.deepEqual(evidence.unverified, []);
+  });
+
+  it("tells the reader how to produce the summary when it is missing", () => {
+    const evidence = distributionEvidence(null);
+    assert.equal(evidence.supplied, false);
+    assert.match(evidence.reason, /check-distribution\.mjs --json/);
+  });
+});
+
+/* ------------------------------------------------------------------ derived figures */
+
+describe("the figures are derived, not transcribed", () => {
+  it("runs the page's own metric function over the page's own graph builder", () => {
+    const spec = JSON.parse(fs.readFileSync(path.join(repoRoot, DEFAULT_SPEC), "utf8"));
+    const figures = graphFigures(spec);
+    assert.match(figures.derivedBy, /graph-metrics\.mjs healthMetrics\(\)/);
+    assert.ok(figures.metrics.nodes > 0);
+    assert.ok(figures.metrics.links > 0);
+    assert.equal(typeof figures.metrics.traceability, "number");
+  });
+
+  it("says need clusters is a graph property, and re-derives it from the links", () => {
+    const spec = JSON.parse(fs.readFileSync(path.join(repoRoot, DEFAULT_SPEC), "utf8"));
+    const figures = graphFigures(spec);
+    assert.equal(figures.needClusters, NEED_CLUSTER_DEFINITION);
+    assert.match(NEED_CLUSTER_DEFINITION, /total degree \(in \+ out\) reaches 4/);
+
+    // The definition, re-implemented here from its own words and compared. This is what makes
+    // it a definition rather than a caption: if `computeHotspots` changes what a hub is, or if
+    // the prose drifts from the code, these two numbers stop agreeing.
+    const graph = buildGraphData(spec);
+    const inDegree = new Map();
+    const outDegree = new Map();
+    for (const node of graph.nodes) {
+      inDegree.set(node.id, 0);
+      outDegree.set(node.id, 0);
+    }
+    const id = (end) => (typeof end === "object" ? end.id : end);
+    for (const link of graph.links) {
+      outDegree.set(id(link.source), (outDegree.get(id(link.source)) ?? 0) + 1);
+      inDegree.set(id(link.target), (inDegree.get(id(link.target)) ?? 0) + 1);
+    }
+    const expected = graph.nodes.filter((n) => {
+      const out = outDegree.get(n.id) ?? 0;
+      if (n.type === "problem" && out === 0) return false;
+      if (n.type === "need" && out === 0) return false;
+      return (inDegree.get(n.id) ?? 0) + out >= 4;
+    }).length;
+    assert.equal(figures.metrics.needClusters, expected);
+
+    // And the claim the definition actually makes about arrays: counting the needs does not
+    // produce it. Another array coinciding is exactly why the definition says "coincidence".
+    assert.notEqual(spec.needs.length, figures.metrics.needClusters);
+    assert.match(NEED_CLUSTER_DEFINITION, /coincidence rather than a derivation/);
+  });
+
+  it("reports zero rather than throwing when there is no specification", () => {
+    const figures = graphFigures(null);
+    assert.equal(figures.metrics.nodes, 0);
+  });
+});
+
+/* -------------------------------------------------------------- capture attribution */
+
+describe("captureAttribution answers which suite wrote which screenshot", () => {
+  it("reads the capture names out of the suites", () => {
+    const dir = tree("suites", {
+      "b.test.mjs": "await page.screenshot({ path: shot('graph-health.png') });\n",
+      "a.test.mjs": [
+        "// a comment",
+        `await page.screenshot({ path: shot("landing-dashboard.png") });`,
+      ].join("\n"),
+      "not-a-suite.mjs": "shot('ignored.png')",
+    });
+    assert.deepEqual(captureAttribution(dir), [
+      { capture: "graph-health.png", writtenBy: "b.test.mjs", line: 1 },
+      { capture: "landing-dashboard.png", writtenBy: "a.test.mjs", line: 2 },
+    ]);
+  });
+
+  it("treats a missing suite directory as no captures", () => {
+    assert.deepEqual(captureAttribution(path.join(tmp, "no-suites")), []);
+  });
+
+  it("attributes the captures this repository actually writes", () => {
+    const captures = captureAttribution(path.join(repoRoot, CANVAS_TESTS));
+    assert.ok(captures.length > 0, "the canvas suites must write captures to attribute");
+    assert.ok(captures.every((c) => c.writtenBy.endsWith(".test.mjs") && c.line > 0));
+  });
+});
+
+/* ---------------------------------------------------------------------- the whole pack */
+
+describe("CANARIES — a family with no artefact fails, and never skips", () => {
+  const world = (overrides = {}) =>
+    buildEvidencePack({
+      root: repoRoot,
+      skillsDir: skillTree("pack-skills"),
+      pluginArchiveDir: pluginArchiveTree("pack-plugin"),
+      canvasArchiveDir: tree("pack-canvas", { "extension.mjs": "export default {};" }),
+      distributionFile: tree("pack-dist", { "d.json": { findings: [], unverified: [] } }) + "/d.json",
+      ...overrides,
+    });
+
+  it("passes every gate when all three families are supplied and clean", () => {
+    const pack = world();
+    assert.equal(pack.ok, true, formatReport(pack));
+    assert.deepEqual(
+      pack.checks.map((c) => c.id),
+      [
+        "every-install-method-belongs-to-a-family",
+        "repository-clone-family-is-proven",
+        "plugin-archive-family-is-proven",
+        "canvas-archive-family-is-proven",
+        "specification-loads",
+        "distribution-monitor-reports-zero-errors",
+      ],
+    );
+  });
+
+  it("fails the clone family when no skills install is supplied", () => {
+    const pack = world({ skillsDir: null });
+    assert.equal(gate(pack, "repository-clone-family-is-proven").ok, false);
+    assert.equal(pack.ok, false);
+  });
+
+  it("fails the clone family when the install is missing", () => {
+    const pack = world({ skillsDir: path.join(tmp, "gone") });
+    assert.match(gate(pack, "repository-clone-family-is-proven").detail, /does not exist/);
+  });
+
+  it("fails the clone family when the dispatch table does not close", () => {
+    const pack = world({
+      skillsDir: skillTree("skills-open-dispatch", {
+        actions: ["problems", "ghost"],
+        omit: ["ghost"],
+      }),
+    });
+    assert.match(
+      gate(pack, "repository-clone-family-is-proven").detail,
+      /dispatch does not close/,
+    );
+  });
+
+  it("fails the clone family when a link escapes the install", () => {
+    const pack = world({
+      skillsDir: skillTree("skills-escaping-link", {
+        extra: { "reference/problems.md": "[out](../../../elsewhere.md)\n" },
+      }),
+    });
+    assert.match(gate(pack, "repository-clone-family-is-proven").detail, /links do not close/);
+  });
+
+  it("fails the plugin-archive family when it is missing, rather than omitting it", () => {
+    const pack = world({ pluginArchiveDir: null });
+    const g = gate(pack, "plugin-archive-family-is-proven");
+    assert.equal(g.ok, false);
+    assert.match(g.detail, /proves two of three/);
+  });
+
+  it("fails the plugin-archive family when the reader rejects it", () => {
+    const pack = world({
+      pluginArchiveDir: pluginArchiveTree("plugin-bad", {
+        "problem-based-srs/agents/a/AGENT.md": "[escape](../../../elsewhere.md)\n",
+      }),
+    });
+    const g = gate(pack, "plugin-archive-family-is-proven");
+    assert.equal(g.ok, false);
+    assert.match(g.detail, /verify-plugin-archive rejected it/);
+  });
+
+  it("fails the plugin-archive family when the reader could not read it at all", () => {
+    const pack = world({ pluginArchiveDir: path.join(tmp, "not-an-archive") });
+    assert.equal(gate(pack, "plugin-archive-family-is-proven").ok, false);
+  });
+
+  it("fails the canvas family when it is missing, and when it is the checkout", () => {
+    assert.equal(gate(world({ canvasArchiveDir: null }), "canvas-archive-family-is-proven").ok, false);
+    const checkout = world({
+      canvasArchiveDir: path.join(repoRoot, ".github", "extensions", "srs-navigator"),
+    });
+    assert.match(
+      gate(checkout, "canvas-archive-family-is-proven").detail,
+      /this is the checkout, not the release/,
+    );
+  });
+
+  it("says when no capture is tied to the canvas bytes, and when one is", () => {
+    const loose = world();
+    assert.match(
+      gate(loose, "canvas-archive-family-is-proven").detail,
+      /no capture is tied to these bytes/,
+    );
+
+    const provenance = tree("prov", {
+      "p.json": { extensionSha256: "0123456789abcdef0123456789abcdef" },
+    });
+    const tied = world({ provenanceFile: path.join(provenance, "p.json") });
+    assert.match(
+      gate(tied, "canvas-archive-family-is-proven").detail,
+      /names extension\.mjs 0123456789ab…/,
+    );
+  });
+
+  it("fails specification-loads when the spec is not there", () => {
+    const pack = world({ specFile: "no-such-spec.json" });
+    const g = gate(pack, "specification-loads");
+    assert.equal(g.ok, false);
+    assert.match(g.detail, /no graph figure in this pack is derived/);
+  });
+
+  it("fails the monitor gate on an error finding, and passes with warnings present", () => {
+    const dir = tree("dist-variants", {
+      "red.json": { findings: [{ id: "registry-listing-drift", severity: "error" }] },
+      "amber.json": {
+        findings: [{ id: "surface-unreachable", severity: "warning" }],
+        unverified: [{ id: "registry-skill-version-unverifiable" }],
+      },
+    });
+    const red = world({ distributionFile: path.join(dir, "red.json") });
+    assert.equal(gate(red, "distribution-monitor-reports-zero-errors").ok, false);
+    assert.match(
+      gate(red, "distribution-monitor-reports-zero-errors").detail,
+      /registry-listing-drift/,
+    );
+
+    const amber = world({ distributionFile: path.join(dir, "amber.json") });
+    const g = gate(amber, "distribution-monitor-reports-zero-errors");
+    assert.equal(g.ok, true, "warnings exit 0 by design; the pack must not invent a failure");
+    assert.match(g.detail, /1 warning\(s\) and 1 notice\(s\) remain/);
+  });
+
+  it("fails the family-coverage gate when the README documents an unclaimed method", () => {
+    const root = tree("root-extra-method", {
+      "README.md": readmeWith([...ALL_HEADINGS, "### Homebrew tap"]),
+      [DEFAULT_SPEC.split(path.sep).join("/")]: fs.readFileSync(
+        path.join(repoRoot, DEFAULT_SPEC),
+        "utf8",
+      ),
+    });
+    const pack = buildEvidencePack({ root });
+    const g = gate(pack, "every-install-method-belongs-to-a-family");
+    assert.equal(g.ok, false);
+    assert.match(g.detail, /uncovered: ### Homebrew tap/);
+  });
+
+  it("fails the family-coverage gate when there is no README to read", () => {
+    const pack = buildEvidencePack({ root: tree("root-no-readme") });
+    assert.match(
+      gate(pack, "every-install-method-belongs-to-a-family").detail,
+      /the README documents no install methods/,
+    );
+    assert.deepEqual(pack.captures, []);
+  });
+
+  it("fails the family-coverage gate when two families claim the same method", () => {
+    const root = tree("root-duplicate-claim", {
+      "README.md": readmeWith(["### Manual"]),
+    });
+    const pack = buildEvidencePack({
+      root,
+      families: [{ readmeHeadings: ["### Manual"] }, { readmeHeadings: ["### Manual"] }],
+    });
+    assert.match(
+      gate(pack, "every-install-method-belongs-to-a-family").detail,
+      /claimed twice: ### Manual/,
+    );
+  });
+});
+
+/* ------------------------------------------------------------------------- rendering */
+
+describe("rendering", () => {
+  const pack = () =>
+    buildEvidencePack({
+      root: repoRoot,
+      skillsDir: skillTree("render-skills"),
+      pluginArchiveDir: pluginArchiveTree("render-plugin"),
+      canvasArchiveDir: tree("render-canvas", { "extension.mjs": "export default {};" }),
+      distributionFile:
+        tree("render-dist", { "d.json": { findings: [], unverified: [] } }) + "/d.json",
+    });
+
+  it("renders a transcript that separates gates from figures", () => {
+    const text = formatReport(pack());
+    assert.match(text, /gates \(derived — these gate the exit code\)/);
+    assert.match(text, /derived figures:/);
+    assert.match(text, /needClusters is a graph property/);
+    assert.match(text, /RESULT: every gate passed/);
+  });
+
+  it("renders the failure verdict when a gate failed", () => {
+    const red = buildEvidencePack({ root: repoRoot });
+    assert.match(formatReport(red), /RESULT: at least one gate failed/);
+  });
+
+  it("renders the markdown an issue can carry", () => {
+    const md = formatMarkdown(pack());
+    assert.match(md, /^# Evidence pack$/m);
+    assert.match(md, /## Gates — derived, closure properties only/);
+    assert.match(md, /## Distribution artefact families/);
+    assert.match(md, /## Derived figures/);
+    assert.match(md, /## Capture attribution — derived from the suites/);
+    for (const family of ARTIFACT_FAMILIES) {
+      assert.ok(md.includes(family.label), `markdown omits the ${family.id} family`);
+    }
+    assert.match(md, /- installed skill tree: \d+ files/);
+    assert.match(md, /- plugin archive: \d+ files, \d+ actions/);
+  });
+
+  it("omits the recorded rows it has no evidence for rather than printing blanks", () => {
+    const md = formatMarkdown(buildEvidencePack({ root: repoRoot }));
+    assert.equal(md.includes("- installed skill tree:"), false);
+    assert.equal(md.includes("- plugin archive:"), false);
+  });
+});
+
+/* ---------------------------------------------------------------------- the CLI surface */
+
+describe("the CLI surface", () => {
+  it("parses every option the runbook uses", () => {
+    const opts = parseArgs([
+      "--root", repoRoot,
+      "--skills", "/s",
+      "--plugin-archive", "/p",
+      "--canvas-archive", "/c",
+      "--provenance", "/prov.json",
+      "--distribution", "/dist.json",
+      "--spec", "/spec.json",
+      "--json", "-",
+      "--markdown", "pack.md",
+      "--quiet",
+    ]);
+    assert.equal(opts.root, repoRoot);
+    assert.equal(opts.skillsDir, "/s");
+    assert.equal(opts.pluginArchiveDir, "/p");
+    assert.equal(opts.canvasArchiveDir, "/c");
+    assert.equal(opts.provenanceFile, "/prov.json");
+    assert.equal(opts.distributionFile, "/dist.json");
+    assert.equal(opts.specFile, "/spec.json");
+    assert.equal(opts.json, "-");
+    assert.equal(opts.markdown, "pack.md");
+    assert.equal(opts.quiet, true);
+  });
+
+  it("defaults to this repository", () => {
+    assert.equal(parseArgs([]).root, REPO_ROOT);
+    assert.equal(REPO_ROOT, repoRoot);
+  });
+
+  it("asks for help", () => {
+    assert.equal(parseArgs(["--help"]).help, true);
+    assert.equal(parseArgs(["-h"]).help, true);
+  });
+
+  it("refuses unknown options, missing values and stray arguments", () => {
+    assert.throws(() => parseArgs(["--nope"]), /unknown option --nope/);
+    assert.throws(() => parseArgs(["--spec"]), /--spec needs a value/);
+    assert.throws(() => parseArgs(["stray"]), /unexpected argument stray/);
+  });
+
+  it("documents every option, and states the no-skip rule", () => {
+    for (const flag of [
+      "--skills",
+      "--plugin-archive",
+      "--canvas-archive",
+      "--provenance",
+      "--distribution",
+      "--spec",
+      "--root",
+      "--json",
+      "--markdown",
+      "--quiet",
+    ]) {
+      assert.ok(USAGE.includes(flag), `USAGE does not mention ${flag}`);
+    }
+    assert.match(USAGE, /A family with no artefact supplied FAILS its gate/);
+  });
+});
+
+/* ---------------------------------------------------------------------- the entry point */
+
+describe("the entry point", () => {
+  const streams = () => {
+    const out = [];
+    const err = [];
+    return {
+      out,
+      err,
+      io: { stdout: { write: (s) => out.push(s) }, stderr: { write: (s) => err.push(s) } },
+    };
+  };
+
+  it("exits 0 and writes both renderings when every family is proven", () => {
+    const s = streams();
+    const jsonFile = path.join(tmp, "cli-pack.json");
+    const mdFile = path.join(tmp, "cli-pack.md");
+    const dist = tree("cli-dist", { "d.json": { findings: [], unverified: [] } });
+    const code = cli(
+      [
+        "--root", repoRoot,
+        "--skills", skillTree("cli-skills"),
+        "--plugin-archive", pluginArchiveTree("cli-plugin"),
+        "--canvas-archive", tree("cli-canvas", { "extension.mjs": "export default {};" }),
+        "--distribution", path.join(dist, "d.json"),
+        "--json", jsonFile,
+        "--markdown", mdFile,
+      ],
+      s.io,
+    );
+    assert.equal(code, 0, s.err.join(""));
+    assert.equal(JSON.parse(fs.readFileSync(jsonFile, "utf8")).ok, true);
+    assert.match(fs.readFileSync(mdFile, "utf8"), /^# Evidence pack$/m);
+    assert.match(s.err.join(""), /RESULT: every gate passed/);
+  });
+
+  it("exits 1 when a family is unproven, and can put both renderings on stdout", () => {
+    const s = streams();
+    const code = cli(["--root", repoRoot, "--json", "-", "--markdown", "-", "--quiet"], s.io);
+    assert.equal(code, 1);
+    assert.equal(s.err.join(""), "", "--quiet must suppress the transcript");
+    const written = s.out.join("");
+    assert.match(written, /"tool": "evidence-pack"/);
+    assert.match(written, /# Evidence pack/);
+  });
+
+  it("prints usage for --help and exits 0", () => {
+    const s = streams();
+    assert.equal(cli(["--help"], s.io), 0);
+    assert.match(s.err.join(""), /Usage: node evals\/tools\/evidence-pack\.mjs/);
+  });
+
+  it("reports a bad option as a message and an exit code, not a stack trace", () => {
+    const s = streams();
+    assert.equal(cli(["--nope"], s.io), 1);
+    assert.match(s.err.join(""), /unknown option --nope/);
+  });
+
+  it("reports an unreadable input file the same way", () => {
+    const s = streams();
+    assert.equal(cli(["--root", repoRoot, "--distribution", "no-such-file.json"], s.io), 1);
+    assert.ok(s.err.join("").length > 0);
+  });
+
+  it("defaults its argv to the process, so the bootstrap needs no arguments", () => {
+    const argv = process.argv;
+    try {
+      process.argv = [argv[0], argv[1], "--help"];
+      const s = streams();
+      assert.equal(cli(undefined, s.io), 0);
+      assert.match(s.err.join(""), /Usage:/);
+    } finally {
+      process.argv = argv;
+    }
+  });
+
+  it("defaults its streams to the process, so the bootstrap needs no io either", () => {
+    const write = process.stderr.write;
+    const captured = [];
+    process.stderr.write = (chunk) => {
+      captured.push(String(chunk));
+      return true;
+    };
+    try {
+      assert.equal(cli(["--help"]), 0);
+    } finally {
+      process.stderr.write = write;
+    }
+    assert.match(captured.join(""), /Usage: node evals\/tools\/evidence-pack\.mjs/);
+  });
+});
+
+/* ------------------------------------------------------------------ as a real command */
+
+describe("as a real command", () => {
+  // The bootstrap that turns `cli`'s return value into an exit code cannot run in-process —
+  // it would end the test run — so it is covered the only way it can be: by being run.
+  const tool = path.join(repoRoot, "evals", "tools", "evidence-pack.mjs");
+  const invoke = (args) =>
+    spawnSync(process.execPath, [tool, ...args], { encoding: "utf8", cwd: repoRoot });
+
+  it("exits 0 for --help", () => {
+    const result = invoke(["--help"]);
+    assert.equal(result.status, 0);
+    assert.match(result.stderr, /Usage: node evals\/tools\/evidence-pack\.mjs/);
+  });
+
+  it("exits 1 with a message when an option is unknown", () => {
+    const result = invoke(["--nope"]);
+    assert.equal(result.status, 1);
+    assert.match(result.stderr, /unknown option --nope/);
+  });
+
+  it("exits 1 against this repository, where the release artefacts do not exist yet", () => {
+    const result = invoke(["--root", repoRoot, "--quiet", "--json", "-"]);
+    assert.equal(result.status, 1);
+    assert.match(result.stdout, /"tool": "evidence-pack"/);
+  });
+});
+
+/* -------------------------------------------------------- the repository it ships with */
+
+describe("against this repository", () => {
+  it("proves the clone family from the canonical skill, and derives the figures", () => {
+    const pack = buildEvidencePack({
+      root: repoRoot,
+      skillsDir: path.join(repoRoot, "skills", "problem-based-srs"),
+    });
+    assert.equal(gate(pack, "every-install-method-belongs-to-a-family").ok, true);
+    assert.equal(gate(pack, "repository-clone-family-is-proven").ok, true);
+    assert.equal(gate(pack, "specification-loads").ok, true);
+    assert.ok(pack.figures.metrics.nodes > 0);
+    assert.ok(pack.captures.length > 0);
+    assert.equal(
+      pack.ok,
+      false,
+      "the two release families have no artefact here, and that must fail rather than skip",
+    );
+  });
+});

--- a/evals/tests/live-profile.test.mjs
+++ b/evals/tests/live-profile.test.mjs
@@ -1,0 +1,569 @@
+// `evals/tools/live-profile.mjs` checks the preconditions #105 states in prose and nothing
+// enforced: that the profile has no prior install, that the workspace contributes no project
+// copy of the same extension, that the extracted archive is still the published tree, and
+// that the run can say which install supplies `/live` and which supplies the panel.
+//
+// The reason a *tool* rather than a checklist item: all four conditions are invisible at the
+// moment they matter. A maintainer with `srs-navigator` already in `~/.copilot/extensions`,
+// running from a clone of this repository, sees a working `/live` and a correct-looking
+// screenshot — and has proven nothing about the published archive, because the panel came
+// from a double registration of the repository's own project extension. That is not
+// hypothetical: it is the state of the machine this suite was written on, and it is what the
+// "against this repository" case below pins.
+//
+// One thing is deliberately **not** a gate: whether the app loaded the archive. A refusal to
+// load is a result — arguably the most valuable one — so it is recorded and never asserted.
+import { describe, it, before, after } from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { spawnSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
+
+import {
+  GATE_IDS,
+  LIVE_ACTION,
+  LIVE_REFERENCE,
+  LOAD_VERDICTS,
+  USAGE,
+  canvasActions,
+  checkLiveProfile,
+  cli,
+  defaultExtensionsDir,
+  formatReport,
+  installedExtensions,
+  parseArgs,
+  projectExtensions,
+} from "../tools/live-profile.mjs";
+import { CANVAS_ID } from "../tools/open-archive-canvas.mjs";
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(here, "../..");
+
+let tmp = "";
+
+before(() => {
+  tmp = fs.mkdtempSync(path.join(os.tmpdir(), "pbsrs-live-profile-"));
+});
+
+after(() => {
+  if (tmp) fs.rmSync(tmp, { recursive: true, force: true });
+});
+
+/* --------------------------------------------------------------------------- fixtures */
+
+function tree(name, files = {}) {
+  const root = path.join(tmp, name);
+  fs.rmSync(root, { recursive: true, force: true });
+  fs.mkdirSync(root, { recursive: true });
+  for (const [rel, body] of Object.entries(files)) {
+    const abs = path.join(root, rel);
+    fs.mkdirSync(path.dirname(abs), { recursive: true });
+    fs.writeFileSync(abs, body);
+  }
+  return root;
+}
+
+/** An `extension.mjs` whose ACTIONS table dispatches exactly `actions`. */
+const extensionSource = (actions) =>
+  [
+    `const CANVAS_ID = "${CANVAS_ID}";`,
+    "const ACTIONS = [",
+    ...actions.map((a) => `  { action: "${a}", file: "${a}.md" },`),
+    "];",
+    "export default {};",
+  ].join("\n");
+
+const SHIPPED_ACTIONS = [
+  "business-context",
+  "problems",
+  "software-glance",
+  "needs",
+  "software-vision",
+  "functional-requirements",
+  "validate",
+  "complexity",
+];
+
+/** A canvas archive as published: the extension, no node_modules. */
+const archive = (name, actions = SHIPPED_ACTIONS, extra = {}) =>
+  tree(name, { "extension.mjs": extensionSource(actions), ...extra });
+
+/** A skills install that ships the reference `/live` comes from. */
+const skills = (name, files = { [LIVE_REFERENCE.split(path.sep).join("/")]: "# live\n" }) =>
+  tree(name, { "SKILL.md": "# skill\n", ...files });
+
+const gate = (record, id) => record.checks.find((c) => c.id === id);
+
+/** The smallest world in which every gate passes. Defaults are built only when not given. */
+function healthy(name, overrides = {}) {
+  const base = {};
+  if (!("extensionsDir" in overrides)) base.extensionsDir = tree(`${name}-profile`);
+  if (!("workspace" in overrides)) base.workspace = tree(`${name}-workspace`);
+  if (!("archiveDir" in overrides)) base.archiveDir = archive(`${name}-archive`);
+  if (!("skillsDir" in overrides)) base.skillsDir = skills(`${name}-skills`);
+  return checkLiveProfile({ ...base, ...overrides });
+}
+
+/* ------------------------------------------------------------------------ pure pieces */
+
+describe("the readers", () => {
+  it("names the profile the app discovers user-scope extensions from", () => {
+    assert.equal(
+      defaultExtensionsDir("/home/someone"),
+      path.join("/home/someone", ".copilot", "extensions"),
+    );
+    assert.equal(defaultExtensionsDir(), path.join(os.homedir(), ".copilot", "extensions"));
+  });
+
+  it("reads the action enum out of the extension rather than restating it", () => {
+    assert.deepEqual(canvasActions(extensionSource(["problems", "validate"])), [
+      "problems",
+      "validate",
+    ]);
+    assert.deepEqual(canvasActions("const ACTIONS = [];"), []);
+  });
+
+  it("returns null when there is no table to read, which is not the same as an empty one", () => {
+    assert.equal(canvasActions("export default {};"), null);
+    assert.equal(canvasActions(null), null);
+  });
+
+  it("treats a profile with no directory as nothing installed", () => {
+    assert.deepEqual(installedExtensions(path.join(tmp, "never-existed")), []);
+    assert.deepEqual(installedExtensions(""), []);
+    assert.deepEqual(installedExtensions(null), []);
+  });
+
+  it("lists installed extensions, ignoring loose files", () => {
+    const dir = tree("profile-with-installs", {
+      "srs-navigator/extension.mjs": "x",
+      "other-ext/extension.mjs": "x",
+      "notes.txt": "x",
+    });
+    assert.deepEqual(installedExtensions(dir), ["other-ext", "srs-navigator"]);
+  });
+
+  it("judges a project extension by what it registers, not by its directory name", () => {
+    const workspace = tree("workspace-renamed", {
+      ".github/extensions/renamed-thing/extension.mjs": extensionSource(["problems"]),
+      ".github/extensions/unrelated/extension.mjs": "export default {};",
+      ".github/extensions/no-entry/README.md": "no extension.mjs here",
+    });
+    assert.deepEqual(projectExtensions(workspace).map((p) => [p.name, p.registersCanvas]), [
+      ["no-entry", false],
+      ["renamed-thing", true],
+      ["unrelated", false],
+    ]);
+  });
+
+  it("treats a workspace with no .github/extensions as contributing nothing", () => {
+    assert.deepEqual(projectExtensions(tree("workspace-bare")), []);
+  });
+});
+
+/* -------------------------------------------------------------------------- the record */
+
+describe("a profile that is actually clean", () => {
+  it("passes every precondition and names both install sources", () => {
+    const record = healthy("clean");
+    assert.equal(record.ok, true, formatReport(record));
+    assert.deepEqual(
+      record.checks.map((c) => c.id),
+      [...GATE_IDS],
+    );
+    assert.equal(record.commandSources.command.evidence, `skills/problem-based-srs/${LIVE_REFERENCE.split(path.sep).join("/")}`);
+    assert.equal(record.manual.loaded, "not-run");
+    assert.deepEqual(record.unverified, []);
+  });
+
+  it("records the app's verdict without letting it decide the exit code", () => {
+    const refused = healthy("refused", { loaded: "no", note: "extension failed to start" });
+    assert.equal(refused.ok, true, "a refusal is a result, not a failed precondition");
+    assert.equal(refused.manual.loaded, "no");
+    assert.match(formatReport(refused), /REFUSED to load the archive — recorded as a result/);
+
+    const loaded = healthy("loaded", { loaded: "yes", log: "C:/logs/ext.log" });
+    assert.match(formatReport(loaded), /loaded: yes — the app loaded the archive/);
+    assert.equal(loaded.manual.log, "C:/logs/ext.log");
+  });
+
+  it("refuses a verdict it does not understand rather than recording a typo", () => {
+    assert.throws(() => checkLiveProfile({ loaded: "probably" }), /must be one of/);
+    assert.deepEqual([...LOAD_VERDICTS], ["yes", "no", "not-run"]);
+  });
+});
+
+/* ------------------------------------------------------------------------- canaries */
+
+describe("CANARIES — each precondition fails on the state it exists to catch", () => {
+  it("profile-has-no-prior-install rejects a profile that already has the extension", () => {
+    const record = healthy("prior", {
+      extensionsDir: tree("prior-profile", { [`${CANVAS_ID}/extension.mjs`]: "x" }),
+    });
+    const g = gate(record, "profile-has-no-prior-install");
+    assert.equal(g.ok, false);
+    assert.match(g.detail, /would load a previous install rather than the archive under test/);
+    assert.equal(record.ok, false);
+  });
+
+  it("profile-has-no-prior-install passes with unrelated extensions present", () => {
+    const record = healthy("unrelated", {
+      extensionsDir: tree("unrelated-profile", { "some-other/extension.mjs": "x" }),
+    });
+    assert.equal(gate(record, "profile-has-no-prior-install").ok, true);
+    assert.deepEqual(record.observed.profileExtensions, ["some-other"]);
+  });
+
+  it("workspace-contributes-no-project-extension rejects the double-registration trap", () => {
+    const record = healthy("double", {
+      workspace: tree("double-workspace", {
+        [`.github/extensions/${CANVAS_ID}/extension.mjs`]: extensionSource(SHIPPED_ACTIONS),
+      }),
+    });
+    const g = gate(record, "workspace-contributes-no-project-extension");
+    assert.equal(g.ok, false);
+    assert.match(g.detail, /registers the same canvas id and tool name twice/);
+    assert.match(g.detail, /Use a neutral workspace/);
+  });
+
+  it("archive-carries-no-node-modules fails when no archive was named at all", () => {
+    const record = healthy("no-archive", { archiveDir: null });
+    const g = gate(record, "archive-carries-no-node-modules");
+    assert.equal(g.ok, false);
+    assert.match(g.detail, /no --archive given/);
+    assert.equal(record.archiveDir, null);
+  });
+
+  it("archive-carries-no-node-modules fails when the named tree is not there", () => {
+    const record = healthy("ghost-archive", {
+      archiveDir: path.join(tmp, "no-such-archive"),
+    });
+    assert.match(gate(record, "archive-carries-no-node-modules").detail, /does not exist/);
+    assert.deepEqual(record.observed.archiveEntries, []);
+  });
+
+  it("archive-carries-no-node-modules rejects a tree an install step re-created", () => {
+    const record = healthy("installed-into", {
+      archiveDir: archive("installed-archive", SHIPPED_ACTIONS, {
+        "node_modules/left-pad/index.js": "module.exports = 0;",
+      }),
+    });
+    const g = gate(record, "archive-carries-no-node-modules");
+    assert.equal(g.ok, false);
+    assert.match(g.detail, /no longer the published archive/);
+    assert.ok(record.observed.archiveEntries.includes("node_modules"));
+  });
+
+  it("command-source-is-established fails when the skills install ships no live reference", () => {
+    const record = healthy("no-live-ref", {
+      skillsDir: skills("skills-without-live", { "reference/problems.md": "# problems\n" }),
+    });
+    const g = gate(record, "command-source-is-established");
+    assert.equal(g.ok, false);
+    assert.match(g.detail, /does not ship/);
+  });
+
+  it("command-source-is-established fails when no skills install was named", () => {
+    const record = healthy("no-skills", { skillsDir: null });
+    assert.match(
+      gate(record, "command-source-is-established").detail,
+      new RegExp(`no --skills given, so nothing established where /${LIVE_ACTION} comes from`),
+    );
+  });
+
+  it("command-source-is-established fails when the archive's enum could not be read", () => {
+    const record = healthy("no-enum", {
+      archiveDir: tree("archive-without-table", { "extension.mjs": "export default {};" }),
+    });
+    const g = gate(record, "command-source-is-established");
+    assert.equal(g.ok, false);
+    assert.match(g.detail, /ACTIONS table could not be read/);
+    assert.equal(record.observed.canvasActions, null);
+  });
+
+  it("command-source-is-established fails when no archive was named to read", () => {
+    const record = healthy("enum-unread", { archiveDir: null });
+    assert.match(
+      gate(record, "command-source-is-established").detail,
+      /the canvas archive's action enum was never read/,
+    );
+  });
+
+  it("command-source-is-established fails once the archive starts dispatching `live`", () => {
+    // The claim it guards — "/live comes from the skill, the panel from the canvas" — is only
+    // true while `live` is absent from the enum. If the extension ever adds it, evidence
+    // built on the old claim is wrong, and this must go red rather than keep passing.
+    const record = healthy("live-in-enum", {
+      archiveDir: archive("archive-with-live", [...SHIPPED_ACTIONS, LIVE_ACTION]),
+    });
+    const g = gate(record, "command-source-is-established");
+    assert.equal(g.ok, false);
+    assert.match(g.detail, /the two-install claim in the runbook is stale/);
+    assert.ok(record.observed.canvasActions.includes(LIVE_ACTION));
+  });
+
+  it("--profile-only reports the claim as unestablished instead of quietly passing it", () => {
+    const record = healthy("profile-only", { profileOnly: true });
+    assert.equal(
+      record.checks.some((c) => c.id === "command-source-is-established"),
+      false,
+    );
+    assert.equal(record.unverified.length, 1);
+    assert.equal(record.unverified[0].id, "command-source-not-established");
+    assert.match(formatReport(record), /not established this run:/);
+    assert.equal(record.ok, true, "an unestablished claim is reported, not failed");
+  });
+});
+
+/* ---------------------------------------------------------------------- the CLI surface */
+
+describe("the CLI surface", () => {
+  it("parses every option the runbook uses", () => {
+    const opts = parseArgs([
+      "--extensions-dir", "/p",
+      "--workspace", "/w",
+      "--archive", "/a",
+      "--skills", "/s",
+      "--profile-only",
+      "--loaded", "no",
+      "--log", "/l.log",
+      "--note", "it refused",
+      "--json", "-",
+      "--quiet",
+    ]);
+    assert.deepEqual(opts, {
+      extensionsDir: "/p",
+      workspace: "/w",
+      archiveDir: "/a",
+      skillsDir: "/s",
+      profileOnly: true,
+      loaded: "no",
+      log: "/l.log",
+      note: "it refused",
+      json: "-",
+      quiet: true,
+      help: false,
+    });
+  });
+
+  it("defaults to the real profile and the current directory", () => {
+    const opts = parseArgs([]);
+    assert.equal(opts.extensionsDir, defaultExtensionsDir());
+    assert.equal(opts.workspace, process.cwd());
+    assert.equal(opts.loaded, "not-run");
+  });
+
+  it("asks for help", () => {
+    assert.equal(parseArgs(["--help"]).help, true);
+    assert.equal(parseArgs(["-h"]).help, true);
+  });
+
+  it("refuses unknown options, missing values and stray arguments", () => {
+    assert.throws(() => parseArgs(["--nope"]), /unknown option --nope/);
+    assert.throws(() => parseArgs(["--loaded"]), /--loaded needs a value/);
+    assert.throws(() => parseArgs(["stray"]), /unexpected argument stray/);
+  });
+
+  it("documents every option it accepts", () => {
+    for (const flag of [
+      "--extensions-dir",
+      "--workspace",
+      "--archive",
+      "--skills",
+      "--profile-only",
+      "--loaded",
+      "--log",
+      "--note",
+      "--json",
+      "--quiet",
+    ]) {
+      assert.ok(USAGE.includes(flag), `USAGE does not mention ${flag}`);
+    }
+  });
+
+  it("renders a transcript that separates preconditions from the manual observation", () => {
+    const text = formatReport(healthy("transcript"));
+    assert.match(text, /preconditions \(derived — these gate the exit code\)/);
+    assert.match(text, /manual observation \(recorded — this gates nothing\)/);
+    assert.match(text, /RESULT: every precondition passed/);
+    assert.match(text, /loaded: not-run — the app has not been run yet/);
+    assert.match(text, /log: {4}\(none\)/);
+  });
+
+  it("says a capture taken now would prove nothing when a precondition failed", () => {
+    const text = formatReport(healthy("transcript-red", { archiveDir: null, skillsDir: null }));
+    assert.match(text, /FAIL {2}archive-carries-no-node-modules/);
+    assert.match(text, /a capture taken now would not prove what it claims/);
+    assert.match(text, /archive: {3}\(not given\)/);
+    assert.match(text, /skills: {4}\(not given\)/);
+    assert.equal(text.includes("undefined"), false);
+  });
+});
+
+/* ---------------------------------------------------------------------- the entry point */
+
+describe("the entry point", () => {
+  const streams = () => {
+    const out = [];
+    const err = [];
+    return {
+      out,
+      err,
+      io: { stdout: { write: (s) => out.push(s) }, stderr: { write: (s) => err.push(s) } },
+    };
+  };
+
+  it("exits 0 and writes the record when every precondition passed", () => {
+    const s = streams();
+    const jsonFile = path.join(tmp, "cli-live.json");
+    const code = cli(
+      [
+        "--extensions-dir", tree("cli-profile"),
+        "--workspace", tree("cli-workspace"),
+        "--archive", archive("cli-archive"),
+        "--skills", skills("cli-skills"),
+        "--loaded", "no",
+        "--note", "the app refused to start it",
+        "--json", jsonFile,
+      ],
+      s.io,
+    );
+    assert.equal(code, 0, "a refusal to load is a result, not a failed precondition");
+    assert.match(s.err.join(""), /RESULT: every precondition passed/);
+    const written = JSON.parse(fs.readFileSync(jsonFile, "utf8"));
+    assert.equal(written.manual.loaded, "no");
+    assert.equal(written.manual.note, "the app refused to start it");
+  });
+
+  it("exits 1 when a precondition failed, and can put the record on stdout", () => {
+    const s = streams();
+    const code = cli(
+      ["--extensions-dir", tree("cli-dirty", { [`${CANVAS_ID}/extension.mjs`]: "x" }),
+        "--workspace", tree("cli-workspace-2"),
+        "--json", "-",
+        "--quiet"],
+      s.io,
+    );
+    assert.equal(code, 1);
+    assert.equal(s.err.join(""), "", "--quiet must suppress the transcript");
+    assert.equal(JSON.parse(s.out.join("")).ok, false);
+  });
+
+  it("prints usage for --help and exits 0", () => {
+    const s = streams();
+    assert.equal(cli(["--help"], s.io), 0);
+    assert.match(s.err.join(""), /Usage: node evals\/tools\/live-profile\.mjs/);
+  });
+
+  it("reports a bad option as a message and an exit code, not a stack trace", () => {
+    const s = streams();
+    assert.equal(cli(["--nope"], s.io), 1);
+    assert.match(s.err.join(""), /unknown option --nope/);
+  });
+
+  it("reports an unusable load verdict the same way", () => {
+    const s = streams();
+    assert.equal(cli(["--loaded", "maybe"], s.io), 1);
+    assert.match(s.err.join(""), /--loaded must be one of/);
+  });
+
+  it("defaults its argv to the process, so the bootstrap needs no arguments", () => {
+    const argv = process.argv;
+    try {
+      process.argv = [argv[0], argv[1], "--help"];
+      const s = streams();
+      assert.equal(cli(undefined, s.io), 0);
+      assert.match(s.err.join(""), /Usage:/);
+    } finally {
+      process.argv = argv;
+    }
+  });
+
+  it("defaults its streams to the process, so the bootstrap needs no io either", () => {
+    const write = process.stderr.write;
+    const captured = [];
+    process.stderr.write = (chunk) => {
+      captured.push(String(chunk));
+      return true;
+    };
+    try {
+      assert.equal(cli(["--help"]), 0);
+    } finally {
+      process.stderr.write = write;
+    }
+    assert.match(captured.join(""), /Usage: node evals\/tools\/live-profile\.mjs/);
+  });
+});
+
+/* ------------------------------------------------------------------ as a real command */
+
+describe("as a real command", () => {
+  // The bootstrap that turns `cli`'s return value into an exit code cannot run in-process —
+  // it would end the test run — so it is covered the only way it can be: by being run.
+  const tool = path.join(repoRoot, "evals", "tools", "live-profile.mjs");
+  const invoke = (args) =>
+    spawnSync(process.execPath, [tool, ...args], { encoding: "utf8", cwd: repoRoot });
+
+  it("exits 0 for --help", () => {
+    const result = invoke(["--help"]);
+    assert.equal(result.status, 0);
+    assert.match(result.stderr, /Usage: node evals\/tools\/live-profile\.mjs/);
+  });
+
+  it("exits 1 with a message when an option is unknown", () => {
+    const result = invoke(["--nope"]);
+    assert.equal(result.status, 1);
+    assert.match(result.stderr, /unknown option --nope/);
+  });
+
+  it("exits 1 and prints the failing gate when the profile is not clean", () => {
+    const result = invoke(["--extensions-dir", tree("cli-empty-profile"), "--workspace", repoRoot]);
+    assert.equal(result.status, 1);
+    assert.match(result.stderr, /workspace-contributes-no-project-extension/);
+  });
+});
+
+/* -------------------------------------------------------- the repository it ships with */
+
+describe("against this repository", () => {
+  it("fails the workspace precondition when run from this clone, which is the point", () => {
+    // A maintainer proving `/live` from a checkout of this repository is testing the project
+    // extension the repository itself contributes, not the published archive. That is #105's
+    // third problem, and it is invisible without this check.
+    const record = checkLiveProfile({
+      extensionsDir: tree("real-repo-profile"),
+      workspace: repoRoot,
+      archiveDir: path.join(repoRoot, ".github", "extensions", CANVAS_ID),
+      skillsDir: path.join(repoRoot, "skills", "problem-based-srs"),
+    });
+    const g = gate(record, "workspace-contributes-no-project-extension");
+    assert.equal(g.ok, false);
+    assert.match(g.detail, new RegExp(CANVAS_ID));
+    assert.ok(
+      record.observed.projectExtensions.some((p) => p.name === CANVAS_ID && p.registersCanvas),
+    );
+  });
+
+  it("reads the shipped extension's real enum, and finds no `live` in it", () => {
+    const source = fs.readFileSync(
+      path.join(repoRoot, ".github", "extensions", CANVAS_ID, "extension.mjs"),
+      "utf8",
+    );
+    const actions = canvasActions(source);
+    assert.ok(Array.isArray(actions) && actions.length > 0, "the ACTIONS table must be readable");
+    assert.equal(
+      actions.includes(LIVE_ACTION),
+      false,
+      "`/live` ships with the skill, not the canvas archive — the runbook's claim depends on it",
+    );
+  });
+
+  it("finds the reference the skills install supplies /live from", () => {
+    assert.ok(
+      fs.existsSync(path.join(repoRoot, "skills", "problem-based-srs", LIVE_REFERENCE)),
+      `the canonical skill must ship ${LIVE_REFERENCE}`,
+    );
+  });
+});

--- a/evals/tests/release-preflight.test.mjs
+++ b/evals/tests/release-preflight.test.mjs
@@ -1,0 +1,911 @@
+// `evals/tools/release-preflight.mjs` is the rehearsal that #104 says did not exist, and the
+// only gate in this repository that runs on the safe side of an irreversible step. So this
+// suite holds two things:
+//
+//   1. every gate has a **canary** — a scripted world in which that gate is the one that
+//      fails, so a gate that stopped working cannot pass silently;
+//   2. the rehearsal's own contract: it refuses the train it cannot rehearse, it derives the
+//      train verdict from `release-train.mjs` rather than restating it, and it **opens** the
+//      archive it just packaged rather than trusting the packager's exit code.
+//
+// Point 2's last clause is the reason the tool exists at all. The documented pre-flight
+// packaged and stopped; `verify-plugin-archive.mjs` only ran after publication. The
+// `agents/skills/` defect was wrong in every published zip precisely because nothing opened
+// one before it shipped, and a tag cannot be taken back.
+//
+// The world is scripted rather than real: `runPreflight` takes its runner as an argument, so
+// every branch — no interpreter, a failed build, empty notes, a stranded tag, a red suite —
+// is reachable offline, deterministically, without a git remote.
+import { describe, it, before, after } from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { spawnSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
+
+import {
+  GATE_IDS,
+  REHEARSABLE_TRAIN,
+  REPO_ROOT,
+  USAGE,
+  cli,
+  defaultRunner,
+  evalTestFiles,
+  findPython,
+  formatReport,
+  normalizeResult,
+  notesHeadings,
+  parseArgs,
+  parseGithubOutput,
+  runPreflight,
+  sha256,
+} from "../tools/release-preflight.mjs";
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(here, "../..");
+
+let tmp = "";
+
+before(() => {
+  tmp = fs.mkdtempSync(path.join(os.tmpdir(), "pbsrs-preflight-"));
+});
+
+after(() => {
+  if (tmp) fs.rmSync(tmp, { recursive: true, force: true });
+});
+
+/* --------------------------------------------------------------------------- fixtures */
+
+const PLUGIN_VERSION = "9.9.0";
+const PLUGIN_TAG = "v9.9";
+const CANVAS_VERSION = "1.1.0";
+
+/** A repository root the train classifier can read: a manifest and a canvas VERSION. */
+function fixtureRoot(name, overrides = {}) {
+  const root = path.join(tmp, name);
+  fs.rmSync(root, { recursive: true, force: true });
+  const files = {
+    ".claude-plugin/plugin.json": JSON.stringify({
+      name: "problem-based-srs",
+      version: PLUGIN_VERSION,
+    }),
+    VERSION: `${CANVAS_VERSION}\n`,
+    ...overrides,
+  };
+  for (const [rel, body] of Object.entries(files)) {
+    const abs = path.join(root, rel);
+    fs.mkdirSync(path.dirname(abs), { recursive: true });
+    fs.writeFileSync(abs, body);
+  }
+  return root;
+}
+
+const row = (action) => `| \`${action}\` | [\`reference/${action}.md\`](reference/${action}.md) |`;
+
+/** The smallest tree `verifyPluginArchive` accepts, written into `dir`. */
+function writeHealthyArchive(dir, overrides = {}) {
+  const files = {
+    "problem-based-srs/.claude-plugin/plugin.json": JSON.stringify({
+      name: "problem-based-srs",
+      version: PLUGIN_VERSION,
+    }),
+    "problem-based-srs/skills/problem-based-srs/SKILL.md": [
+      "| Action | File |",
+      "|---|---|",
+      row("problems"),
+      row("live"),
+    ].join("\n"),
+    "problem-based-srs/skills/problem-based-srs/reference/problems.md": "# problems\n",
+    "problem-based-srs/skills/problem-based-srs/reference/live.md": "# live\n",
+    ...overrides,
+  };
+  for (const [rel, body] of Object.entries(files)) {
+    const abs = path.join(dir, rel);
+    fs.mkdirSync(path.dirname(abs), { recursive: true });
+    fs.writeFileSync(abs, body);
+  }
+  return dir;
+}
+
+/**
+ * A runner driven by patterns. The first match wins; anything unmatched succeeds silently,
+ * so a test only has to describe the part of the world it is about.
+ */
+function fakeRun(handlers = []) {
+  return (command, args = [], options = {}) => {
+    const line = [command, ...args].join(" ");
+    for (const [pattern, respond] of handlers) {
+      const hit = typeof pattern === "string" ? line.includes(pattern) : pattern.test(line);
+      if (hit) {
+        return typeof respond === "function"
+          ? respond({ command, args, options, line })
+          : respond;
+      }
+    }
+    return { status: 0, stdout: "", stderr: "" };
+  };
+}
+
+const ok = (stdout = "") => ({ status: 0, stdout, stderr: "" });
+const fail = (stderr = "boom", status = 1) => ({ status, stdout: "", stderr });
+
+const SHA = "a".repeat(40);
+
+/**
+ * The handlers that make a rehearsal succeed end to end, before a test breaks one.
+ *
+ * Pass `null` to let the fake packager choose the archive path from the `$GITHUB_OUTPUT` the
+ * tool handed it — which is how a test that does not supply `workDir` can still find it.
+ */
+function healthyHandlers(archiveFile, { archiveOverrides = {} } = {}) {
+  const archiveFor = (options) =>
+    archiveFile ??
+    path.join(path.dirname(options.env.GITHUB_OUTPUT), "dist", "problem-based-srs-v9.9.zip");
+  return [
+    ["git status --porcelain", ok("")],
+    ["git rev-parse --abbrev-ref HEAD", ok("main\n")],
+    ["git rev-parse HEAD", ok(`${SHA}\n`)],
+    ["git rev-parse --verify origin/main", ok(`${SHA}\n`)],
+    ["git ls-remote", ok("")],
+    ["python3 --version", ok("Python 3.14.0\n")],
+    [
+      "build-plugin.py",
+      ({ options }) => {
+        const zip = archiveFor(options);
+        fs.appendFileSync(
+          options.env.GITHUB_OUTPUT,
+          `artifact=${zip}\nversion=9.9\nnotes<<EOF_BUILD_PLUGIN\n### Added\n- a thing\n### Fixed\n- another\nEOF_BUILD_PLUGIN\n`,
+        );
+        fs.mkdirSync(path.dirname(zip), { recursive: true });
+        fs.writeFileSync(zip, "not really a zip, the fake runner extracts for us");
+        return ok("[build] success\n");
+      },
+    ],
+    [
+      "zipfile.ZipFile",
+      ({ args }) => {
+        writeHealthyArchive(args[args.length - 1], archiveOverrides);
+        return ok();
+      },
+    ],
+  ];
+}
+
+function rehearse(overrides = {}, handlerOverrides = []) {
+  const name = overrides.name ?? `run-${Math.random().toString(36).slice(2)}`;
+  const root = overrides.root ?? fixtureRoot(name);
+  const workDir = path.join(tmp, `work-${name}`);
+  fs.mkdirSync(workDir, { recursive: true });
+  const archiveFile = path.join(workDir, "problem-based-srs-v9.9.zip");
+  return runPreflight({
+    tag: PLUGIN_TAG,
+    root,
+    suites: false,
+    workDir,
+    run: fakeRun([...handlerOverrides, ...healthyHandlers(archiveFile)]),
+    ...overrides.options,
+  });
+}
+
+const gate = (record, id) => record.checks.find((c) => c.id === id);
+
+/* ------------------------------------------------------------------------ pure pieces */
+
+describe("parseGithubOutput reads the payload create-release.yml consumes", () => {
+  it("reads plain key=value lines", () => {
+    assert.deepEqual(parseGithubOutput("version=2.6\nartifact=/tmp/a.zip"), {
+      version: "2.6",
+      artifact: "/tmp/a.zip",
+    });
+  });
+
+  it("reads the heredoc form build-plugin.py uses for multi-line notes", () => {
+    const text = "notes<<EOF\n### Added\n- one\n\n- two\nEOF\nversion=2.6\n";
+    assert.deepEqual(parseGithubOutput(text), {
+      notes: "### Added\n- one\n\n- two",
+      version: "2.6",
+    });
+  });
+
+  it("survives an unterminated heredoc rather than losing the rest of the file", () => {
+    assert.deepEqual(parseGithubOutput("notes<<EOF\nline one\nline two"), {
+      notes: "line one\nline two",
+    });
+  });
+
+  it("ignores blank lines and lines with no assignment", () => {
+    assert.deepEqual(parseGithubOutput("\n\nnot-an-assignment\n=leading\nk=v\n"), { k: "v" });
+  });
+
+  it("treats a missing file as no outputs at all", () => {
+    assert.deepEqual(parseGithubOutput(undefined), {});
+  });
+});
+
+describe("notesHeadings records the shape of the notes without gating on it", () => {
+  it("finds ### and #### headings", () => {
+    assert.deepEqual(notesHeadings("### Added\ntext\n#### Folded 2.5\n## Ignored\n"), [
+      "### Added",
+      "#### Folded 2.5",
+    ]);
+  });
+
+  it("returns nothing for an empty body", () => {
+    assert.deepEqual(notesHeadings(null), []);
+  });
+});
+
+describe("the small readers", () => {
+  it("hashes a file so the record names the bytes", () => {
+    const file = path.join(tmp, "hash-me.txt");
+    fs.writeFileSync(file, "abc");
+    assert.equal(
+      sha256(file),
+      "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad",
+    );
+  });
+
+  it("expands the evals suite because spawn does not glob", () => {
+    const files = evalTestFiles(repoRoot);
+    assert.ok(files.length > 10, `expected the real suite, got ${files.length} files`);
+    assert.ok(files.every((f) => f.endsWith(".test.mjs")));
+    assert.ok(files.includes(path.join("evals", "tests", "release-preflight.test.mjs")));
+  });
+
+  it("reports no suite rather than throwing when there is none", () => {
+    assert.deepEqual(evalTestFiles(path.join(tmp, "no-such-repo")), []);
+  });
+
+  it("probes for an interpreter instead of assuming one", () => {
+    assert.equal(findPython(fakeRun([["python3 --version", ok()]])), "python3");
+    assert.equal(
+      findPython(fakeRun([["python3 --version", fail()], ["python --version", ok()]])),
+      "python",
+    );
+    assert.equal(findPython(fakeRun([[/--version/, fail()]])), null);
+  });
+
+  it("normalizes a result whose status is not a number, rather than reading it as success", () => {
+    // A process killed by a signal reports status null. Treating that as anything but a
+    // failure would let a killed packager pass the build gate.
+    assert.deepEqual(normalizeResult({ status: null }), { status: 1, stdout: "", stderr: "" });
+    assert.deepEqual(normalizeResult({ status: 0, stdout: "hi", stderr: "warn" }), {
+      status: 0,
+      stdout: "hi",
+      stderr: "warn",
+    });
+    assert.deepEqual(normalizeResult({ error: new Error("ENOENT") }), {
+      status: 127,
+      stdout: "",
+      stderr: "ENOENT",
+    });
+    assert.equal(normalizeResult({ error: new Error("x"), stdout: "partial" }).stdout, "partial");
+  });
+
+  it("runs real commands, and reports a missing executable as a failure not a crash", () => {
+    const good = defaultRunner(process.execPath, ["-e", "process.stdout.write('hi')"]);
+    assert.equal(good.status, 0);
+    assert.equal(good.stdout, "hi");
+
+    const bad = defaultRunner("pbsrs-no-such-executable-xyz", []);
+    assert.equal(bad.status, 127);
+    assert.ok(bad.stderr.length > 0);
+
+    const withEnv = defaultRunner(
+      process.execPath,
+      ["-e", "process.stdout.write(process.env.PBSRS_PROBE ?? '')"],
+      { cwd: repoRoot, env: { PBSRS_PROBE: "yes" } },
+    );
+    assert.equal(withEnv.stdout, "yes");
+  });
+});
+
+/* -------------------------------------------------------------- what it refuses to do */
+
+describe("it rehearses the plugin train and refuses the other one", () => {
+  it("needs a tag", () => {
+    assert.throws(() => runPreflight({}), /no --tag given/);
+    assert.throws(() => runPreflight(), /no --tag given/);
+  });
+
+  it("refuses a canvas tag, and says why there is nothing to rehearse there", () => {
+    const root = fixtureRoot("canvas-tag");
+    assert.throws(
+      () => runPreflight({ tag: `v${CANVAS_VERSION}`, root, run: fakeRun() }),
+      (error) => {
+        assert.match(error.message, /classifies as canvas/);
+        assert.match(error.message, /dispatch-only/);
+        assert.match(error.message, /release-canvas-ordering\.test\.mjs/);
+        return true;
+      },
+    );
+  });
+
+  it("refuses a tag no train claims", () => {
+    const root = fixtureRoot("orphan-tag");
+    assert.throws(
+      () => runPreflight({ tag: "v0.0.7", root, run: fakeRun() }),
+      /classifies as unknown/,
+    );
+  });
+
+  it("names the only rehearsable train, so the refusal cannot drift from the reason", () => {
+    assert.equal(REHEARSABLE_TRAIN, "plugin");
+  });
+});
+
+/* ---------------------------------------------------------------------- the happy path */
+
+describe("a clean rehearsal", () => {
+  it("passes every gate and records what a maintainer must paste into the issue", () => {
+    const record = rehearse({ name: "happy" });
+
+    assert.equal(record.ok, true, formatReport(record));
+    assert.equal(record.train, "plugin");
+    assert.equal(record.version, "9.9");
+    assert.equal(record.observed.sha, SHA);
+    assert.equal(record.observed.branch, "main");
+    assert.deepEqual(record.observed.notesHeadings, ["### Added", "### Fixed"]);
+    assert.ok(record.archive.sha256.length === 64);
+    assert.ok(record.archive.bytes > 0);
+    assert.equal(record.archive.verification.ok, true);
+  });
+
+  it("runs every gate it declares, in the order it declares them", () => {
+    const record = rehearse({ name: "order" });
+    const ran = record.checks.map((c) => c.id);
+    const expected = GATE_IDS.filter(
+      (id) => id !== "evals-suite-is-green" && id !== "canvas-suite-is-green",
+    );
+    assert.deepEqual(ran, expected);
+  });
+
+  it("keeps the packaged archive and the extracted tree only when asked", () => {
+    const kept = runPreflight({
+      tag: PLUGIN_TAG,
+      root: fixtureRoot("kept"),
+      suites: false,
+      keep: true,
+      run: fakeRun(healthyHandlers(null)),
+    });
+    assert.equal(kept.ok, true, formatReport(kept));
+    assert.ok(fs.existsSync(kept.archive.extractedTo));
+    fs.rmSync(kept.workDir, { recursive: true, force: true });
+  });
+
+  it("cleans up after itself by default, and says so rather than naming a path that is gone", () => {
+    const swept = runPreflight({
+      tag: PLUGIN_TAG,
+      root: fixtureRoot("swept"),
+      suites: false,
+      run: fakeRun(healthyHandlers(null)),
+    });
+    assert.equal(swept.ok, true, formatReport(swept));
+    assert.equal(swept.archive.extractedTo, null);
+    assert.equal(fs.existsSync(swept.workDir), false);
+  });
+});
+
+/* ------------------------------------------------------------------------- canaries */
+
+describe("CANARIES — each gate fails on the defect it exists to catch", () => {
+  it("working-tree-is-clean rejects uncommitted changes", () => {
+    const record = rehearse({ name: "dirty" }, [
+      ["git status --porcelain", ok("?? new-file\n M other\n")],
+    ]);
+    const g = gate(record, "working-tree-is-clean");
+    assert.equal(g.ok, false);
+    assert.match(g.detail, /2 uncommitted change\(s\)/);
+    assert.equal(record.ok, false);
+  });
+
+  it("working-tree-is-clean rejects a git that could not answer", () => {
+    const record = rehearse({ name: "status-broken" }, [
+      ["git status --porcelain", fail("not a git repository")],
+    ]);
+    assert.match(gate(record, "working-tree-is-clean").detail, /git status failed/);
+  });
+
+  it("head-is-the-commit-to-be-tagged rejects a HEAD that is not the release ref", () => {
+    const record = rehearse({ name: "behind" }, [
+      ["git rev-parse --verify origin/main", ok(`${"b".repeat(40)}\n`)],
+    ]);
+    const g = gate(record, "head-is-the-commit-to-be-tagged");
+    assert.equal(g.ok, false);
+    assert.match(g.detail, /HEAD is a{40} but origin\/main is b{40}/);
+  });
+
+  it("head-is-the-commit-to-be-tagged rejects an unresolvable ref", () => {
+    const record = rehearse({ name: "no-ref" }, [
+      ["git rev-parse --verify origin/main", fail("unknown revision")],
+    ]);
+    assert.match(
+      gate(record, "head-is-the-commit-to-be-tagged").detail,
+      /origin\/main could not be resolved/,
+    );
+  });
+
+  it("head-is-the-commit-to-be-tagged rejects a HEAD that cannot be read", () => {
+    const record = rehearse({ name: "no-head" }, [["git rev-parse HEAD", fail("no HEAD")]]);
+    assert.match(
+      gate(record, "head-is-the-commit-to-be-tagged").detail,
+      /git rev-parse HEAD failed/,
+    );
+  });
+
+  it("--against HEAD waives the ref check visibly rather than skipping it", () => {
+    const record = rehearse({ name: "waived", options: { against: "HEAD" } }, [
+      ["git rev-parse --verify HEAD", ok(`${SHA}\n`)],
+    ]);
+    const g = gate(record, "head-is-the-commit-to-be-tagged");
+    assert.equal(g.ok, true);
+    assert.match(g.detail, /waived/, "a waiver that is invisible is a skip");
+    assert.equal(record.observed.against, "HEAD");
+  });
+
+  it("tag-is-not-already-on-origin rejects a stranded tag, and gives the recovery", () => {
+    const record = rehearse({ name: "stranded" }, [
+      ["git ls-remote", ok(`${SHA}\trefs/tags/${PLUGIN_TAG}\n`)],
+    ]);
+    const g = gate(record, "tag-is-not-already-on-origin");
+    assert.equal(g.ok, false);
+    assert.match(g.detail, /already on origin/);
+    assert.match(g.detail, /emits no push event/);
+    assert.match(
+      g.detail,
+      /gh workflow run create-release\.yml --ref v9\.9 -f version=9\.9/,
+      "the recovery must be --ref pinned, or it packages a different commit",
+    );
+  });
+
+  it("tag-is-not-already-on-origin fails when absence could not be established", () => {
+    const record = rehearse({ name: "no-remote" }, [
+      ["git ls-remote", fail("could not read from remote")],
+    ]);
+    const g = gate(record, "tag-is-not-already-on-origin");
+    assert.equal(g.ok, false);
+    assert.match(g.detail, /absence could not be established/);
+  });
+
+  it("build-succeeds treats a missing interpreter as a failure, not a skip", () => {
+    const record = rehearse({ name: "no-python" }, [[/--version/, fail("not found", 127)]]);
+    const g = gate(record, "build-succeeds");
+    assert.equal(g.ok, false);
+    assert.match(g.detail, /no python3\/python interpreter/);
+    assert.match(g.detail, /failure rather than a skip/);
+    assert.equal(gate(record, "packaged-archive-loads").ok, false);
+  });
+
+  it("build-succeeds rejects a packager that exited non-zero", () => {
+    const record = rehearse({ name: "build-red" }, [
+      ["build-plugin.py", fail("::error::version mismatch")],
+    ]);
+    assert.equal(gate(record, "build-succeeds").ok, false);
+    assert.match(gate(record, "build-succeeds").detail, /version mismatch/);
+  });
+
+  it("build-succeeds quotes stdout when the packager failed without writing to stderr", () => {
+    const record = rehearse({ name: "build-red-stdout" }, [
+      ["build-plugin.py", { status: 2, stdout: "[error] no CHANGELOG section\n", stderr: "" }],
+    ]);
+    assert.match(gate(record, "build-succeeds").detail, /no CHANGELOG section/);
+  });
+
+  it("reads no outputs at all when the packager removed the output file", () => {
+    const record = rehearse({ name: "output-clobbered" }, [
+      [
+        "build-plugin.py",
+        ({ options }) => {
+          fs.rmSync(options.env.GITHUB_OUTPUT, { force: true });
+          return ok();
+        },
+      ],
+    ]);
+    assert.equal(gate(record, "release-notes-are-not-empty").ok, false);
+    assert.equal(gate(record, "packaged-archive-loads").ok, false);
+    assert.deepEqual(record.observed.notesHeadings, []);
+  });
+
+  it("release-notes-are-not-empty rejects a version with no CHANGELOG section", () => {
+    const workDir = path.join(tmp, "work-no-notes");
+    fs.mkdirSync(workDir, { recursive: true });
+    const archiveFile = path.join(workDir, "a.zip");
+    const record = runPreflight({
+      tag: PLUGIN_TAG,
+      root: fixtureRoot("no-notes"),
+      suites: false,
+      workDir,
+      run: fakeRun([
+        ...healthyHandlers(archiveFile).filter(([p]) => p !== "build-plugin.py"),
+        [
+          "build-plugin.py",
+          ({ options }) => {
+            fs.appendFileSync(options.env.GITHUB_OUTPUT, `artifact=${archiveFile}\nnotes=\n`);
+            fs.writeFileSync(archiveFile, "zip");
+            return ok();
+          },
+        ],
+      ]),
+    });
+    const g = gate(record, "release-notes-are-not-empty");
+    assert.equal(g.ok, false);
+    assert.match(g.detail, /publishes exactly one CHANGELOG section/);
+  });
+
+  it("packaged-archive-loads fails when the build named no artifact", () => {
+    const workDir = path.join(tmp, "work-no-artifact");
+    fs.mkdirSync(workDir, { recursive: true });
+    const record = runPreflight({
+      tag: PLUGIN_TAG,
+      root: fixtureRoot("no-artifact"),
+      suites: false,
+      workDir,
+      run: fakeRun([
+        ["git rev-parse HEAD", ok(`${SHA}\n`)],
+        ["git rev-parse --verify origin/main", ok(`${SHA}\n`)],
+        ["python3 --version", ok()],
+        [
+          "build-plugin.py",
+          ({ options }) => {
+            fs.appendFileSync(options.env.GITHUB_OUTPUT, "notes<<E\n### Added\nE\n");
+            return ok();
+          },
+        ],
+      ]),
+    });
+    const g = gate(record, "packaged-archive-loads");
+    assert.equal(g.ok, false);
+    assert.match(g.detail, /produced no artifact/);
+  });
+
+  it("packaged-archive-loads fails when the named archive is not there", () => {
+    const workDir = path.join(tmp, "work-ghost-artifact");
+    fs.mkdirSync(workDir, { recursive: true });
+    const record = runPreflight({
+      tag: PLUGIN_TAG,
+      root: fixtureRoot("ghost-artifact"),
+      suites: false,
+      workDir,
+      run: fakeRun([
+        ["git rev-parse HEAD", ok(`${SHA}\n`)],
+        ["git rev-parse --verify origin/main", ok(`${SHA}\n`)],
+        ["python3 --version", ok()],
+        [
+          "build-plugin.py",
+          ({ options }) => {
+            fs.appendFileSync(
+              options.env.GITHUB_OUTPUT,
+              "artifact=/nowhere/problem-based-srs-v9.9.zip\nnotes<<E\n### Added\nE\n",
+            );
+            return ok();
+          },
+        ],
+      ]),
+    });
+    assert.match(gate(record, "packaged-archive-loads").detail, /which does not exist/);
+  });
+
+  it("packaged-archive-loads fails when the archive cannot be extracted", () => {
+    const record = rehearse({ name: "bad-zip" }, [
+      ["zipfile.ZipFile", fail("BadZipFile: File is not a zip file")],
+    ]);
+    const g = gate(record, "packaged-archive-loads");
+    assert.equal(g.ok, false);
+    assert.match(g.detail, /could not be extracted/);
+  });
+
+  it("packaged-archive-loads quotes stdout when extraction failed silently on stderr", () => {
+    const record = rehearse({ name: "bad-zip-stdout" }, [
+      ["zipfile.ZipFile", { status: 1, stdout: "truncated central directory", stderr: "" }],
+    ]);
+    assert.match(gate(record, "packaged-archive-loads").detail, /truncated central directory/);
+  });
+
+  it("packaged-archive-loads catches the defect that shipped in every published zip", () => {
+    // The rehearsal's whole reason for opening the archive: `agents/skills/…` resolved to a
+    // directory that exists nowhere, in every release, because nothing opened one before the
+    // tag. A pre-flight that only checks the packager's exit code passes this tree.
+    const workDir = path.join(tmp, "work-escaping-link");
+    fs.mkdirSync(workDir, { recursive: true });
+    const archiveFile = path.join(workDir, "problem-based-srs-v9.9.zip");
+    const record = runPreflight({
+      tag: PLUGIN_TAG,
+      root: fixtureRoot("escaping-link"),
+      suites: false,
+      workDir,
+      run: fakeRun([
+        ...healthyHandlers(archiveFile).filter(([p]) => p !== "zipfile.ZipFile"),
+        [
+          "zipfile.ZipFile",
+          ({ args }) => {
+            writeHealthyArchive(args[args.length - 1], {
+              "problem-based-srs/agents/problem-based-srs/AGENT.md":
+                "[skill](../skills/problem-based-srs/SKILL.md)\n",
+            });
+            return ok();
+          },
+        ],
+      ]),
+    });
+    const g = gate(record, "packaged-archive-loads");
+    assert.equal(g.ok, false, "a link escaping the archive root must fail the rehearsal");
+    assert.match(g.detail, /relative-links-resolve-inside-the-archive/);
+    assert.equal(record.ok, false);
+  });
+
+  it("evals-suite-is-green and canvas-suite-is-green report a red suite", () => {
+    const workDir = path.join(tmp, "work-red-suites");
+    fs.mkdirSync(workDir, { recursive: true });
+    const archiveFile = path.join(workDir, "problem-based-srs-v9.9.zip");
+    const record = runPreflight({
+      tag: PLUGIN_TAG,
+      root: fixtureRoot("red-suites"),
+      suites: true,
+      workDir,
+      run: fakeRun([
+        ["node --test", fail("3 failing", 1)],
+        ["npm test", fail("2 failing", 1)],
+        ...healthyHandlers(archiveFile),
+      ]),
+    });
+    assert.equal(gate(record, "evals-suite-is-green").ok, false);
+    assert.equal(gate(record, "canvas-suite-is-green").ok, false);
+    assert.equal(record.ok, false);
+  });
+
+  it("runs the suites when it is not told to skip them", () => {
+    const workDir = path.join(tmp, "work-green-suites");
+    fs.mkdirSync(workDir, { recursive: true });
+    const archiveFile = path.join(workDir, "problem-based-srs-v9.9.zip");
+    const seen = [];
+    const handlers = healthyHandlers(archiveFile);
+    const record = runPreflight({
+      tag: PLUGIN_TAG,
+      root: fixtureRoot("green-suites"),
+      suites: true,
+      workDir,
+      run: (command, args, options) => {
+        seen.push([command, ...args].join(" "));
+        return fakeRun(handlers)(command, args, options);
+      },
+    });
+    assert.equal(gate(record, "evals-suite-is-green").ok, true);
+    assert.equal(gate(record, "canvas-suite-is-green").ok, true);
+    assert.ok(seen.some((line) => line.startsWith("node --test")));
+    assert.ok(seen.some((line) => line.startsWith("npm test")));
+    assert.equal(record.ok, true);
+  });
+
+  it("says so in the record when the suites were skipped", () => {
+    const record = rehearse({ name: "skipped-suites" });
+    assert.match(record.observed.suites, /--no-suites/);
+  });
+});
+
+/* ---------------------------------------------------------------------- the CLI surface */
+
+describe("the CLI surface", () => {
+  it("parses every option the runbook uses", () => {
+    const opts = parseArgs([
+      "--tag", "v2.6",
+      "--against", "origin/release",
+      "--root", repoRoot,
+      "--no-suites",
+      "--keep",
+      "--json", "out.json",
+      "--quiet",
+    ]);
+    assert.equal(opts.tag, "v2.6");
+    assert.equal(opts.against, "origin/release");
+    assert.equal(opts.root, repoRoot);
+    assert.equal(opts.suites, false);
+    assert.equal(opts.keep, true);
+    assert.equal(opts.json, "out.json");
+    assert.equal(opts.quiet, true);
+  });
+
+  it("takes the tag positionally, and defaults the rest", () => {
+    const opts = parseArgs(["v2.6"]);
+    assert.equal(opts.tag, "v2.6");
+    assert.equal(opts.against, "origin/main");
+    assert.equal(opts.suites, true);
+    assert.equal(opts.root, REPO_ROOT);
+  });
+
+  it("asks for help", () => {
+    assert.equal(parseArgs(["--help"]).help, true);
+    assert.equal(parseArgs(["-h"]).help, true);
+  });
+
+  it("refuses unknown options, missing values and stray arguments rather than ignoring them", () => {
+    assert.throws(() => parseArgs(["--nope"]), /unknown option --nope/);
+    assert.throws(() => parseArgs(["--tag"]), /--tag needs a value/);
+    assert.throws(() => parseArgs(["v1", "v2"]), /unexpected argument v2/);
+  });
+
+  it("documents every option it accepts", () => {
+    for (const flag of ["--tag", "--against", "--root", "--no-suites", "--keep", "--json", "--quiet"]) {
+      assert.ok(USAGE.includes(flag), `USAGE does not mention ${flag}`);
+    }
+  });
+
+  it("renders a transcript that separates gates from recorded values", () => {
+    const record = rehearse({ name: "report" });
+    const text = formatReport(record);
+    assert.match(text, /gates \(derived — these gate the exit code\)/);
+    assert.match(text, /observed \(recorded — these gate nothing\)/);
+    assert.match(text, /RESULT: every gate passed — v9\.9 is safe to push/);
+  });
+
+  it("names the failing gate, so the record explains itself", () => {
+    const record = rehearse({ name: "report-red" }, [
+      ["git status --porcelain", ok("?? junk\n")],
+    ]);
+    const text = formatReport(record);
+    assert.match(text, /FAIL {2}working-tree-is-clean/);
+    assert.match(text, /RESULT: at least one gate failed — do not push v9\.9/);
+  });
+
+  it("renders a record whose SHA and note are missing rather than printing undefined", () => {
+    const noSha = rehearse({ name: "report-no-sha" }, [["git rev-parse HEAD", fail("no HEAD")]]);
+    assert.match(formatReport(noSha), /commit to be tagged: \(unknown\)/);
+
+    const bare = formatReport({
+      tag: "v9.9",
+      train: "plugin",
+      root: "/somewhere",
+      observed: {},
+      checks: [],
+      ok: false,
+    });
+    assert.match(bare, /commit to be tagged: \(unknown\)/);
+    assert.equal(bare.includes("undefined"), false);
+  });
+});
+
+/* ---------------------------------------------------------------------- the entry point */
+
+describe("the entry point", () => {
+  const streams = () => {
+    const out = [];
+    const err = [];
+    return {
+      out,
+      err,
+      io: { stdout: { write: (s) => out.push(s) }, stderr: { write: (s) => err.push(s) } },
+    };
+  };
+
+  it("exits 0 and writes the record when every gate passed", () => {
+    const s = streams();
+    const jsonFile = path.join(tmp, "cli-record.json");
+    const code = cli(
+      ["--tag", PLUGIN_TAG, "--root", fixtureRoot("cli-green"), "--no-suites", "--json", jsonFile],
+      { ...s.io, run: fakeRun(healthyHandlers(null)) },
+    );
+    assert.equal(code, 0);
+    assert.match(s.err.join(""), /RESULT: every gate passed/);
+    const written = JSON.parse(fs.readFileSync(jsonFile, "utf8"));
+    assert.equal(written.tag, PLUGIN_TAG);
+    assert.equal(written.ok, true);
+  });
+
+  it("exits 1 when a gate failed, and can put the record on stdout", () => {
+    const s = streams();
+    const code = cli(
+      ["--tag", PLUGIN_TAG, "--root", fixtureRoot("cli-red"), "--no-suites", "--json", "-", "--quiet"],
+      {
+        ...s.io,
+        run: fakeRun([["git status --porcelain", ok("?? junk\n")], ...healthyHandlers(null)]),
+      },
+    );
+    assert.equal(code, 1);
+    assert.equal(s.err.join(""), "", "--quiet must suppress the transcript");
+    assert.equal(JSON.parse(s.out.join("")).ok, false);
+  });
+
+  it("prints usage and exits 1 when no tag was given, and exits 0 for --help", () => {
+    const noTag = streams();
+    assert.equal(cli([], noTag.io), 1);
+    assert.match(noTag.err.join(""), /Usage: node evals\/tools\/release-preflight\.mjs/);
+
+    const help = streams();
+    assert.equal(cli(["--help"], help.io), 0);
+    assert.match(help.err.join(""), /--against <ref>/);
+  });
+
+  it("reports a bad option as a message and an exit code, not a stack trace", () => {
+    const s = streams();
+    assert.equal(cli(["--nope"], s.io), 1);
+    assert.match(s.err.join(""), /unknown option --nope/);
+  });
+
+  it("reports a refusal to rehearse as a message and an exit code", () => {
+    const s = streams();
+    const code = cli(
+      ["--tag", `v${CANVAS_VERSION}`, "--root", fixtureRoot("cli-canvas"), "--no-suites"],
+      s.io,
+    );
+    assert.equal(code, 1);
+    assert.match(s.err.join(""), /classifies as canvas/);
+  });
+
+  it("defaults its argv to the process, so the bootstrap needs no arguments", () => {
+    const argv = process.argv;
+    try {
+      process.argv = [argv[0], argv[1], "--help"];
+      const s = streams();
+      assert.equal(cli(undefined, s.io), 0);
+      assert.match(s.err.join(""), /Usage:/);
+    } finally {
+      process.argv = argv;
+    }
+  });
+
+  it("defaults its streams to the process, so the bootstrap needs no io either", () => {
+    const write = process.stderr.write;
+    const captured = [];
+    process.stderr.write = (chunk) => {
+      captured.push(String(chunk));
+      return true;
+    };
+    try {
+      assert.equal(cli(["--help"]), 0);
+    } finally {
+      process.stderr.write = write;
+    }
+    assert.match(captured.join(""), /Usage: node evals\/tools\/release-preflight\.mjs/);
+  });
+});
+
+/* ------------------------------------------------------------------ as a real command */
+
+describe("as a real command", () => {
+  // The one line `cli` cannot cover from inside this process is the bootstrap that turns its
+  // return value into an exit code — running it in-process would end the test run. So it is
+  // covered the only way it can be: by being run.
+  const tool = path.join(repoRoot, "evals", "tools", "release-preflight.mjs");
+  const invoke = (args) =>
+    spawnSync(process.execPath, [tool, ...args], { encoding: "utf8", cwd: repoRoot });
+
+  it("exits 0 for --help", () => {
+    const result = invoke(["--help"]);
+    assert.equal(result.status, 0);
+    assert.match(result.stderr, /Usage: node evals\/tools\/release-preflight\.mjs/);
+  });
+
+  it("exits 1 with usage when no tag was given", () => {
+    const result = invoke([]);
+    assert.equal(result.status, 1);
+    assert.match(result.stderr, /Usage:/);
+  });
+
+  it("exits 1 and explains itself when asked to rehearse the canvas train", () => {
+    const result = invoke(["--tag", "v1.1.0", "--no-suites"]);
+    assert.equal(result.status, 1);
+    assert.match(result.stderr, /only the plugin train has a step to rehearse/);
+  });
+});
+
+
+describe("against this repository", () => {
+  it("classifies the manifest's own tag as the plugin train", () => {
+    const record = runPreflight({
+      tag: "v2.6",
+      root: repoRoot,
+      suites: false,
+      against: "HEAD",
+      workDir: fs.mkdtempSync(path.join(tmp, "real-")),
+      run: fakeRun([
+        ["git status --porcelain", ok("")],
+        ["git rev-parse", ok(`${SHA}\n`)],
+        ["git ls-remote", ok("")],
+        [/--version/, fail("no interpreter here", 127)],
+      ]),
+    });
+    assert.equal(record.train, "plugin");
+    assert.equal(gate(record, "tag-belongs-to-the-plugin-train").ok, true);
+    assert.match(record.trainReason, /plugin\.json/);
+  });
+});

--- a/evals/tests/release-verification-runbook.test.mjs
+++ b/evals/tests/release-verification-runbook.test.mjs
@@ -335,7 +335,8 @@ describe("every step with an executable form names it", () => {
   it("puts the rehearsal before the tag push, which is the only place it can help", () => {
     const rehearsal = runbook.indexOf("release-preflight.mjs");
     const tagPush = runbook.indexOf("git tag vX.Y && git push origin vX.Y");
-    assert.ok(rehearsal !== -1 && tagPush !== -1);
+    assert.ok(rehearsal !== -1, "release-preflight.mjs is not mentioned in the runbook");
+    assert.ok(tagPush !== -1, '"git tag vX.Y && git push origin vX.Y" is not in the runbook');
     assert.ok(rehearsal < tagPush, "the rehearsal is documented after the point of no return");
   });
 

--- a/evals/tests/release-verification-runbook.test.mjs
+++ b/evals/tests/release-verification-runbook.test.mjs
@@ -21,6 +21,7 @@ import {
   coveredReadmeHeadings,
   readmeInstallHeadings,
 } from "../lib/distribution-artifacts.mjs";
+import { NEED_CLUSTER_DEFINITION } from "../tools/evidence-pack.mjs";
 
 const here = path.dirname(fileURLToPath(import.meta.url));
 const repoRoot = path.resolve(here, "../..");
@@ -240,6 +241,117 @@ describe("the /live section separates the two installs it actually depends on", 
   });
 });
 
+/* -------------------------------------------------- the steps that are also executable */
+
+describe("every step with an executable form names it", () => {
+  // A procedure that only prose describes gets performed differently each time — which is how
+  // #104's defect class ("no rehearsal exists") survived a runbook that documented the
+  // pre-flight. Derive the requirement from the tools: a tool that exists but which the
+  // runbook does not name is a tool a maintainer will not run.
+  const EXECUTABLE_STEPS = [
+    { tool: "evals/tools/release-preflight.mjs", flag: "--tag vX.Y" },
+    { tool: "evals/tools/live-profile.mjs", flag: "--archive" },
+    { tool: "evals/tools/evidence-pack.mjs", flag: "--markdown" },
+  ];
+
+  /** Split a command line the way a shell would, so a quoted value stays one token. */
+  const tokenize = (line) =>
+    [...line.matchAll(/"([^"]*)"|(\S+)/g)].map((m) => (m[1] === undefined ? m[2] : m[1]));
+
+  for (const { tool, flag } of EXECUTABLE_STEPS) {
+    it(`names ${tool}, which exists`, () => {
+      assert.ok(fs.existsSync(path.join(repoRoot, tool)), `${tool} is cited but absent`);
+      assert.match(
+        runbook,
+        new RegExp(tool.replace(/[/.]/g, "\\$&")),
+        `${tool} exists but the runbook never tells anyone to run it`,
+      );
+      assert.ok(runbook.includes(flag), `the runbook invokes ${tool} without ${flag}`);
+    });
+
+    it(`mentions no option ${tool} does not have`, async () => {
+      // Prose is where the last wrong option hid: the runbook offered `--skip-dirty`, which
+      // never existed, and the fenced-block check below could not see it because it is not in
+      // a fenced block. Read the options named in the prose that follows this tool's
+      // invocation, up to the next heading, and require the tool's USAGE to document them.
+      // Spans that name a different command (`check-distribution.mjs --strict`) belong to that
+      // command, not this one, so they are skipped rather than mis-attributed.
+      const { USAGE } = await import(`../tools/${path.basename(tool)}`);
+      const name = path.basename(tool);
+      const fenced = [...runbook.matchAll(/```bash\r?\n[\s\S]*?```/g)].find((m) =>
+        m[0].includes(name),
+      );
+      assert.ok(fenced, `no fenced invocation of ${name} to read the prose after`);
+      const start = fenced.index + fenced[0].length;
+      const heading = runbook.slice(start).search(/\r?\n#{2,3} /);
+      const region = runbook.slice(start, heading === -1 ? undefined : start + heading);
+
+      const spans = [...region.matchAll(/`([^`\n]+)`/g)].map((m) => m[1]);
+      const mentioned = new Set();
+      for (const span of spans) {
+        if (/[\w-]+\.(mjs|py|yml|json|md)/.test(span) && !span.includes(name)) continue;
+        for (const [option] of span.matchAll(/(?<![-\w])--[a-z][a-z-]*/g)) mentioned.add(option);
+      }
+      assert.ok(mentioned.size > 0, `the prose after the ${name} invocation offers no options`);
+      for (const option of mentioned) {
+        assert.ok(
+          USAGE.includes(option),
+          `the runbook offers ${option} for ${name}, whose usage does not document it`,
+        );
+      }
+    });
+
+    it(`invokes ${tool} with options its own parser accepts`, async () => {
+      // The runbook's commands are copy-pasted, so an option that has been renamed would fail
+      // at the worst possible moment. Grepping the source for the option string is not enough
+      // — `--tags` appears in `release-preflight.mjs` as an argument to `git ls-remote`, so a
+      // runbook that said `--tags` would have passed that check while failing at runtime.
+      // Run the tool's own `parseArgs` over the runbook's tokens instead.
+      const { parseArgs } = await import(`../tools/${path.basename(tool)}`);
+      const name = path.basename(tool);
+      const blocks = [...runbook.matchAll(/```bash\r?\n([\s\S]*?)```/g)]
+        .map((m) => m[1])
+        .filter((b) => b.includes(name));
+      assert.ok(blocks.length > 0, `no fenced invocation of ${name} in the runbook`);
+
+      let invocations = 0;
+      for (const block of blocks) {
+        // Join shell line-continuations first, so a wrapped command stays one command.
+        for (const line of block.replace(/\\\r?\n\s*/g, " ").split(/\r?\n/)) {
+          if (!line.includes(name)) continue;
+          const argv = tokenize(line.slice(line.indexOf(name) + name.length));
+          assert.ok(argv.some((a) => a.startsWith("--")), `${name} is invoked with no options`);
+          assert.doesNotThrow(
+            () => parseArgs(argv),
+            `the runbook invokes ${name} with arguments it rejects: ${argv.join(" ")}`,
+          );
+          invocations += 1;
+        }
+      }
+      assert.ok(invocations > 0, `no runnable ${name} command line in the runbook`);
+    });
+  }
+
+  it("puts the rehearsal before the tag push, which is the only place it can help", () => {
+    const rehearsal = runbook.indexOf("release-preflight.mjs");
+    const tagPush = runbook.indexOf("git tag vX.Y && git push origin vX.Y");
+    assert.ok(rehearsal !== -1 && tagPush !== -1);
+    assert.ok(rehearsal < tagPush, "the rehearsal is documented after the point of no return");
+  });
+
+  it("says the rehearsal opens the archive, which is what the pre-flight lacked", () => {
+    // Derived: the gate id lives in the tool. If it were renamed or dropped, this fails.
+    const source = fs.readFileSync(path.join(repoRoot, "evals/tools/release-preflight.mjs"), "utf8");
+    assert.match(source, /"packaged-archive-loads"/, "the archive gate was renamed or removed");
+    assert.match(runbook, /packaged-archive-loads/);
+    assert.match(runbook, /on this\s*\n?side of the push/);
+  });
+
+  it("says a missing artefact family fails the pack rather than being skipped", () => {
+    assert.match(runbook, /never skipped/);
+  });
+});
+
 /* ------------------------------------------------------------------- the evidence pack */
 
 describe("the evidence-pack section keeps derived and recorded apart", () => {
@@ -251,8 +363,29 @@ describe("the evidence-pack section keeps derived and recorded apart", () => {
   });
 
   it("labels the graph figures as derived and names the function that derives them", () => {
+    // The definition is derived from the tool, not restated: `NEED_CLUSTER_DEFINITION` is the
+    // string `evidence-pack.mjs` prints, and the earlier wording here ("degree ≥ 4, not an
+    // array length") was true of neither end — `computeHotspots` classifies with an if/else
+    // chain, so an orphaned problem or unmet need of degree ≥ 4 is not a hub.
     assert.match(runbook, /graph-metrics\.mjs/);
     assert.match(runbook, /degree ≥ 4 graph property, not an array length/);
+    assert.ok(
+      NEED_CLUSTER_DEFINITION.includes("orphaned problem"),
+      "the tool's definition no longer mentions the exclusion; re-read this claim",
+    );
+    assert.match(
+      runbook,
+      /excluding\*\* any already classified as an orphaned problem or an unmet need/,
+      "the runbook must carry the exclusion the tool's definition states",
+    );
+    const hotspots = read(".github/extensions/srs-navigator/lib/graph-metrics.mjs");
+    assert.match(hotspots, /orphanedProblems/, "the hotspot buckets were renamed");
+    assert.match(hotspots, /unmetNeeds/, "the hotspot buckets were renamed");
+    assert.match(
+      hotspots,
+      /needClusters: hotspots\.hubs\.length/,
+      "need clusters no longer come from the hub bucket; the definition needs re-deriving",
+    );
     assert.ok(
       fs.existsSync(path.join(repoRoot, ".github/extensions/srs-navigator/lib/graph-metrics.mjs")),
       "the runbook cites a module that must exist",

--- a/evals/tools/evidence-pack.mjs
+++ b/evals/tools/evidence-pack.mjs
@@ -1,0 +1,660 @@
+#!/usr/bin/env node
+// Assemble the evidence pack #92 asks for, with every figure either **derived** from a
+// shipped artefact or explicitly **recorded** — and nothing gated on a count.
+//
+// Why this is a tool (issues #107 and #92). The pack's parts already exist —
+// `verify-plugin-archive.mjs` reads the plugin archive, `distribution-artifacts.mjs` reads a
+// shipped skill tree, `graph-metrics.mjs` computes the health-bar figures outside the browser
+// — and nothing composed them, so the pack was still assembled by hand from snapshots. That
+// is the failure mode #92 exists to fix, applied to itself:
+//
+//   #107 — "#92 accepts on fixed numbers — 12 skill files, 29 nodes, 5 need clusters. Each is
+//           a snapshot of f30dd4a. A tenth action or a sixth need cluster would make a
+//           *correct* product fail the pack, so the numbers get edited to match reality —
+//           which is how an acceptance criterion quietly becomes a formality."
+//
+// So the rule this file implements is: **a number may be recorded, never gated.** Every gate
+// below is a closure property — every action resolves, every link resolves inside the tree,
+// every README install method belongs to exactly one artefact family — and those stay true as
+// the product grows. The counts ride alongside, labelled, so a reader can see them without a
+// later addition turning a correct release red.
+//
+// Two derivations the review specifically corrected, and why they are shaped this way:
+//
+//   * **The skill file count is recorded, not derived from the dispatch table.** The table has
+//     nine rows; the installed tree carries twelve markdown files, because it also ships
+//     `SKILL.md` and two `*-example.md` walkthroughs that no action dispatches. Deriving 12
+//     from 9 is not possible and is not attempted.
+//   * **"Need clusters" is a graph property, not an array length.** It counts nodes whose
+//     total degree reaches 4, so no count of `spec.needs` produces it. It comes from
+//     `healthMetrics()` — the same function the renderer injects into the page — so the pack
+//     and the screenshot cannot disagree.
+//
+// A family with no artefact supplied **fails** its gate rather than being skipped. The whole
+// point of #107 is that the pack proved two of the three artefact families while reading as
+// though it had proved all of them.
+//
+// Usage:
+//   node evals/tools/evidence-pack.mjs [options]
+//
+//   --skills <dir>          installed skill directory (family: repository clone)
+//   --plugin-archive <dir>  extracted problem-based-srs-vX.Y.zip (family: plugin archive)
+//   --canvas-archive <dir>  extracted srs-navigator-X.Y.Z.zip root (family: canvas archive)
+//   --provenance <file>     open-archive-canvas.mjs --provenance output, folded in
+//   --distribution <file>   `check-distribution.mjs --json` output, folded in
+//   --spec <file>           specification the graph figures are derived from
+//   --root <dir>            repository root
+//   --json <file>           write the pack as JSON ("-" for stdout)
+//   --markdown <file>       write the pack as markdown ("-" for stdout)
+//   --quiet                 suppress the human transcript on stderr
+//
+// Exits 0 only when every gate passed.
+
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+
+import {
+  ARTIFACT_FAMILIES,
+  dispatchClosure,
+  linkClosure,
+  readInstalledSkill,
+  readmeInstallHeadings,
+  walkTree,
+} from "../lib/distribution-artifacts.mjs";
+import { verifyPluginArchive } from "./verify-plugin-archive.mjs";
+import { CANVAS_ID } from "./open-archive-canvas.mjs";
+import { buildGraphData } from "../../.github/extensions/srs-navigator/lib/parser.mjs";
+import { healthMetrics } from "../../.github/extensions/srs-navigator/lib/graph-metrics.mjs";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+/** This repository, when the caller does not name another one. */
+export const REPO_ROOT = path.resolve(__dirname, "..", "..");
+
+/** The specification the graph figures come from when none is named. */
+export const DEFAULT_SPEC = path.join(".spec", "crm-system.json");
+
+/** Where the canvas suites live, for the capture-attribution table. */
+export const CANVAS_TESTS = path.join(".github", "extensions", "srs-navigator", "tests");
+
+/**
+ * Why "need clusters" cannot be counted off the specification, spelled out in the pack
+ * itself so a reader does not go looking for an array with that many entries in it.
+ *
+ * The exclusion clause is not a detail. `computeHotspots` classifies with an if/else chain,
+ * so a problem with no downstream and a need with no downstream are labelled *before* the
+ * hub test is reached and never become hubs however connected they are. A definition that
+ * said only "degree >= 4" would over-count on any specification with a well-connected gap,
+ * and the pack would then be explaining a number it does not produce.
+ */
+export const NEED_CLUSTER_DEFINITION =
+  "a graph property: nodes whose total degree (in + out) reaches 4, excluding any already " +
+  "classified as an orphaned problem or an unmet need — the hotspot classification is an " +
+  "if/else chain, so those two win over hub. It is computed from the links; counting " +
+  "spec.needs does not produce it, and where some other array happens to have the same " +
+  "length that is a coincidence rather than a derivation.";
+
+/* -------------------------------------------------------- family / README coverage */
+
+/**
+ * Does every install method the README documents belong to exactly one artefact family?
+ *
+ * The claim the pack makes is that three byte streams cover six documented methods. That is
+ * only true while the mapping is total and unambiguous, so it is checked against the README
+ * rather than asserted.
+ *
+ * `families` is a parameter rather than a closed-over constant so the "each exactly once"
+ * half of the claim is testable at all: the shipped table has no duplicate, so nothing else
+ * could ever exercise that branch, and an unexercised branch is not a check.
+ *
+ * @param {string} readme
+ * @param {ReadonlyArray<{readmeHeadings:ReadonlyArray<string>}>} [families]
+ * @returns {{documented:string[], claimed:string[], uncovered:string[], duplicated:string[], phantom:string[], ok:boolean}}
+ */
+export function familyCoverage(readme, families = ARTIFACT_FAMILIES) {
+  const documented = readmeInstallHeadings(readme);
+  const claimed = families.flatMap((f) => [...f.readmeHeadings]);
+  const seen = new Map();
+  for (const heading of claimed) seen.set(heading, (seen.get(heading) ?? 0) + 1);
+
+  const uncovered = documented.filter((h) => !seen.has(h));
+  const duplicated = [...seen.entries()].filter(([, n]) => n > 1).map(([h]) => h);
+  const phantom = [...seen.keys()].filter((h) => !documented.includes(h)).sort();
+
+  return {
+    documented,
+    claimed: [...seen.keys()].sort(),
+    uncovered,
+    duplicated,
+    phantom,
+    ok:
+      documented.length > 0 &&
+      uncovered.length === 0 &&
+      duplicated.length === 0 &&
+      phantom.length === 0,
+  };
+}
+
+/* ------------------------------------------------------------- family 1: the clone */
+
+/**
+ * Read an installed skill tree — what `npx skills add` copies, or what the plugin archive
+ * ships under `skills/`.
+ *
+ * @param {string|null} dir
+ * @returns {object}
+ */
+export function skillsEvidence(dir) {
+  if (!dir) {
+    return {
+      supplied: false,
+      reason:
+        "no --skills given, so the repository-clone family — the one four README install " +
+        "methods deliver — was not proven by this pack",
+    };
+  }
+  const resolved = path.resolve(dir);
+  if (!fs.existsSync(resolved)) {
+    return { supplied: true, dir: resolved, exists: false, reason: `${resolved} does not exist` };
+  }
+  const skill = readInstalledSkill(resolved);
+  const dispatch = dispatchClosure(skill);
+  const links = linkClosure(resolved, { files: skill.files });
+  return {
+    supplied: true,
+    exists: true,
+    dir: resolved,
+    dispatch,
+    links,
+    recorded: {
+      files: skill.files.length,
+      markdownFiles: skill.files.filter((f) => f.endsWith(".md")).length,
+      referenceFiles: skill.referenceFiles.length,
+      exampleFiles: skill.exampleFiles.length,
+      why:
+        "recorded, not derived: the dispatch table has " +
+        `${dispatch.actions.length} rows while the tree carries ` +
+        `${skill.files.length} files, because it also ships SKILL.md and the *-example.md ` +
+        "walkthroughs that no action dispatches",
+    },
+  };
+}
+
+/* ------------------------------------------------------ family 2: the plugin archive */
+
+/** @param {string|null} dir */
+export function pluginArchiveEvidence(dir) {
+  if (!dir) {
+    return {
+      supplied: false,
+      reason:
+        "no --plugin-archive given. This is the family that had a defect in every published " +
+        "zip because nothing ever opened one, so a pack without it proves two of three.",
+    };
+  }
+  try {
+    return { supplied: true, verification: verifyPluginArchive(dir) };
+  } catch (error) {
+    return { supplied: true, error: error.message };
+  }
+}
+
+/* ------------------------------------------------------ family 3: the canvas archive */
+
+/**
+ * The canvas archive is *served* by `open-archive-canvas.mjs`, so this checks the tree is
+ * the published one and folds in that tool's provenance record rather than booting a second
+ * copy of it.
+ *
+ * @param {string|null} dir
+ * @param {object|null} provenance
+ */
+export function canvasArchiveEvidence(dir, provenance = null) {
+  if (!dir) {
+    return {
+      supplied: false,
+      provenance,
+      reason: "no --canvas-archive given, so the canvas-archive family was not proven",
+    };
+  }
+  const resolved = path.resolve(dir);
+  const problems = [];
+  if (!fs.existsSync(resolved)) problems.push(`${resolved} does not exist`);
+  else {
+    if (!fs.existsSync(path.join(resolved, "extension.mjs"))) {
+      problems.push(
+        `${resolved} contains no extension.mjs, so it is not the archive's ${CANVAS_ID}/ root`,
+      );
+    }
+    if (fs.existsSync(path.join(resolved, "node_modules"))) {
+      problems.push("node_modules is present — an install re-created what packaging removed");
+    }
+    if (resolved.split(path.sep).includes(".github")) {
+      problems.push(
+        'the path sits under ".github", the exact condition extension.mjs uses to treat ' +
+          "itself as an in-repo install; this is the checkout, not the release",
+      );
+    }
+  }
+  return {
+    supplied: true,
+    dir: resolved,
+    provenance,
+    problems,
+    recorded: fs.existsSync(resolved) ? { files: walkTree(resolved).length } : null,
+  };
+}
+
+/* ------------------------------------------------------------------ derived figures */
+
+/**
+ * The health-bar figures, computed from the specification with the same function the page
+ * runs. Derived — never read off a screenshot.
+ *
+ * @param {object|null} spec
+ */
+export function graphFigures(spec) {
+  const graph = buildGraphData(spec);
+  return {
+    derivedBy: ".github/extensions/srs-navigator/lib/graph-metrics.mjs healthMetrics()",
+    needClusters: NEED_CLUSTER_DEFINITION,
+    metrics: healthMetrics(graph),
+  };
+}
+
+/**
+ * Which suite writes which capture, read out of the suites.
+ *
+ * A screenshot proves whatever the suite that wrote it was rendering. #92 attached the
+ * landing page's dashboard to a claim about the *graph* health bar; attribution derived from
+ * the sources cannot make that mistake.
+ *
+ * @param {string} testsDir
+ * @returns {Array<{capture:string, writtenBy:string, line:number}>}
+ */
+export function captureAttribution(testsDir) {
+  if (!fs.existsSync(testsDir)) return [];
+  const out = [];
+  for (const file of fs.readdirSync(testsDir).filter((f) => f.endsWith(".test.mjs")).sort()) {
+    const source = fs.readFileSync(path.join(testsDir, file), "utf8").split(/\r?\n/);
+    source.forEach((line, index) => {
+      const match = /shot\(\s*['"]([^'"]+\.png)['"]\s*\)/.exec(line);
+      if (match) out.push({ capture: match[1], writtenBy: file, line: index + 1 });
+    });
+  }
+  return out.sort((a, b) => a.capture.localeCompare(b.capture));
+}
+
+/**
+ * The monitor's verdict, read from its own `--json` summary rather than from its markdown.
+ *
+ * `--strict` exits 0 on **zero error findings**; warnings and notices exit 0 by design. The
+ * pack has to say that rather than treating an exit code as a fully readable surface.
+ *
+ * @param {object|null} summary
+ */
+export function distributionEvidence(summary) {
+  if (!summary) {
+    return {
+      supplied: false,
+      reason:
+        "no --distribution given, so the third-party surfaces are unproven by this pack. " +
+        "Produce it with `node scripts/check-distribution.mjs --json`.",
+    };
+  }
+  const findings = Array.isArray(summary.findings) ? summary.findings : [];
+  const unverified = Array.isArray(summary.unverified) ? summary.unverified : [];
+  const bySeverity = (severity) => findings.filter((f) => f.severity === severity);
+  return {
+    supplied: true,
+    errors: bySeverity("error").map((f) => f.id ?? f.title ?? "(unnamed)"),
+    warnings: bySeverity("warning").map((f) => f.id ?? f.title ?? "(unnamed)"),
+    unverified: unverified.map((u) => u.id ?? u.title ?? "(unnamed)"),
+    reading:
+      "zero *error* findings is the claim. Warnings and notices exit 0 by design, so each " +
+      "one present is quoted and explained rather than counted as verified.",
+  };
+}
+
+/* ------------------------------------------------------------------------- the pack */
+
+function readJson(file) {
+  if (!file) return null;
+  return JSON.parse(fs.readFileSync(path.resolve(file), "utf8"));
+}
+
+/**
+ * Compose the pack.
+ *
+ * @param {{
+ *   root?: string,
+ *   skillsDir?: string|null,
+ *   pluginArchiveDir?: string|null,
+ *   canvasArchiveDir?: string|null,
+ *   provenanceFile?: string|null,
+ *   distributionFile?: string|null,
+ *   specFile?: string|null,
+ * }} [options]
+ * @returns {object}
+ */
+export function buildEvidencePack(options = {}) {
+  const {
+    root = REPO_ROOT,
+    skillsDir = null,
+    pluginArchiveDir = null,
+    canvasArchiveDir = null,
+    provenanceFile = null,
+    distributionFile = null,
+    specFile = null,
+    families = ARTIFACT_FAMILIES,
+  } = options;
+
+  const readmePath = path.join(root, "README.md");
+  const readme = fs.existsSync(readmePath) ? fs.readFileSync(readmePath, "utf8") : "";
+  const specPath = path.resolve(root, specFile ?? DEFAULT_SPEC);
+  const spec = fs.existsSync(specPath) ? JSON.parse(fs.readFileSync(specPath, "utf8")) : null;
+
+  const checks = [];
+  const check = (id, ok, detail) => checks.push({ id, ok: Boolean(ok), detail });
+
+  const coverage = familyCoverage(readme, families);
+  const skills = skillsEvidence(skillsDir);
+  const pluginArchive = pluginArchiveEvidence(pluginArchiveDir);
+  const canvasArchive = canvasArchiveEvidence(canvasArchiveDir, readJson(provenanceFile));
+  const distribution = distributionEvidence(readJson(distributionFile));
+  const figures = graphFigures(spec);
+
+  /* --------------------------------------------------- gates: closure properties only */
+
+  check(
+    "every-install-method-belongs-to-a-family",
+    coverage.ok,
+    coverage.ok
+      ? `${coverage.documented.length} README install methods map onto ` +
+        `${families.length} artefact families, each exactly once`
+      : [
+          coverage.documented.length === 0 ? "the README documents no install methods" : null,
+          coverage.uncovered.length ? `uncovered: ${coverage.uncovered.join(", ")}` : null,
+          coverage.duplicated.length ? `claimed twice: ${coverage.duplicated.join(", ")}` : null,
+          coverage.phantom.length ? `claimed but undocumented: ${coverage.phantom.join(", ")}` : null,
+        ]
+          .filter(Boolean)
+          .join("; "),
+  );
+
+  check(
+    "repository-clone-family-is-proven",
+    Boolean(skills.supplied && skills.exists && skills.dispatch?.ok && skills.links?.broken?.length === 0),
+    !skills.supplied
+      ? skills.reason
+      : !skills.exists
+        ? skills.reason
+        : !skills.dispatch.ok
+          ? `dispatch does not close: dispatched but not shipped ` +
+            `[${skills.dispatch.unresolved.join(", ")}], shipped but unreachable ` +
+            `[${skills.dispatch.undispatched.join(", ")}]`
+          : skills.links.broken.length
+            ? `links do not close: ${skills.links.broken
+                .map((b) => `${b.file} -> ${b.target} (${b.reason})`)
+                .join("; ")}`
+            : `all ${skills.dispatch.actions.length} actions resolve and all ` +
+              `${skills.links.links} relative links stay inside the install`,
+  );
+
+  check(
+    "plugin-archive-family-is-proven",
+    Boolean(pluginArchive.supplied && pluginArchive.verification?.ok),
+    !pluginArchive.supplied
+      ? pluginArchive.reason
+      : pluginArchive.error
+        ? pluginArchive.error
+        : pluginArchive.verification.ok
+          ? `verify-plugin-archive passed all ${pluginArchive.verification.checks.length} gates`
+          : `verify-plugin-archive rejected it: ${pluginArchive.verification.checks
+              .filter((c) => !c.ok)
+              .map((c) => `${c.id} — ${c.detail}`)
+              .join("; ")}`,
+  );
+
+  check(
+    "canvas-archive-family-is-proven",
+    Boolean(canvasArchive.supplied && canvasArchive.problems?.length === 0),
+    !canvasArchive.supplied
+      ? canvasArchive.reason
+      : canvasArchive.problems.length === 0
+        ? `${canvasArchive.dir} is an extracted published archive` +
+          (canvasArchive.provenance
+            ? `, and the capture that came from it names extension.mjs ` +
+              `${String(canvasArchive.provenance.extensionSha256).slice(0, 12)}…`
+            : "; no --provenance was folded in, so no capture is tied to these bytes")
+        : canvasArchive.problems.join("; "),
+  );
+
+  check(
+    "specification-loads",
+    Boolean(spec) && figures.metrics.nodes > 0,
+    spec
+      ? `${specPath} yields ${figures.metrics.nodes} nodes and ${figures.metrics.links} links`
+      : `${specPath} could not be read, so no graph figure in this pack is derived`,
+  );
+
+  check(
+    "distribution-monitor-reports-zero-errors",
+    Boolean(distribution.supplied && distribution.errors?.length === 0),
+    !distribution.supplied
+      ? distribution.reason
+      : distribution.errors.length === 0
+        ? `zero error findings; ${distribution.warnings.length} warning(s) and ` +
+          `${distribution.unverified.length} notice(s) remain and are listed for explanation`
+        : `error findings present: ${distribution.errors.join(", ")}`,
+  );
+
+  return {
+    tool: "evidence-pack",
+    builtAt: new Date().toISOString(),
+    root,
+    families,
+    coverage,
+    evidence: { skills, pluginArchive, canvasArchive, distribution },
+    figures,
+    captures: captureAttribution(path.join(root, CANVAS_TESTS)),
+    checks,
+    note:
+      "Every gate above is a closure property. Every number is recorded alongside and gates " +
+      "nothing, so a tenth action or a sixth need cluster cannot turn a correct product red.",
+    ok: checks.every((c) => c.ok),
+  };
+}
+
+/* ------------------------------------------------------------------------ rendering */
+
+/** The transcript, for a terminal. */
+export function formatReport(pack) {
+  return [
+    `evidence pack for ${pack.root}`,
+    "",
+    "gates (derived — these gate the exit code):",
+    ...pack.checks.map((c) => `  ${c.ok ? "PASS" : "FAIL"}  ${c.id}: ${c.detail}`),
+    "",
+    "derived figures:",
+    ...Object.entries(pack.figures.metrics).map(([k, v]) => `  ${k}: ${v}`),
+    `  needClusters is ${pack.figures.needClusters}`,
+    "",
+    `captures attributed: ${pack.captures.length}`,
+    "",
+    `  ${pack.note}`,
+    "",
+    pack.ok ? "RESULT: every gate passed" : "RESULT: at least one gate failed",
+  ].join("\n");
+}
+
+/** The pack, as the markdown an issue carries. */
+export function formatMarkdown(pack) {
+  const lines = [
+    "# Evidence pack",
+    "",
+    `Built ${pack.builtAt} from \`${pack.root}\`.`,
+    "",
+    "## Gates — derived, closure properties only",
+    "",
+    "| Gate | Result | Detail |",
+    "|---|---|---|",
+    ...pack.checks.map((c) => `| \`${c.id}\` | ${c.ok ? "PASS" : "FAIL"} | ${c.detail} |`),
+    "",
+    "## Distribution artefact families",
+    "",
+    "| Family | Artefact | README methods |",
+    "|---|---|---|",
+    ...pack.families.map(
+      (f) => `| ${f.label} | \`${f.artifact}\` | ${f.methods.length} |`,
+    ),
+    "",
+    "## Derived figures",
+    "",
+    `Derived by \`${pack.figures.derivedBy}\` — the same function the page runs, so the pack`,
+    "and the screenshot cannot disagree.",
+    "",
+    "| Figure | Value |",
+    "|---|---|",
+    ...Object.entries(pack.figures.metrics).map(([k, v]) => `| ${k} | ${v} |`),
+    "",
+    `**Need clusters** is ${pack.figures.needClusters}`,
+    "",
+    "## Recorded — these gate nothing",
+    "",
+  ];
+
+  const recorded = pack.evidence.skills.recorded;
+  if (recorded) {
+    lines.push(
+      `- installed skill tree: ${recorded.files} files (${recorded.markdownFiles} markdown) — ${recorded.why}`,
+    );
+  }
+  const archiveObserved = pack.evidence.pluginArchive.verification?.observed;
+  if (archiveObserved) {
+    lines.push(
+      `- plugin archive: ${archiveObserved.files} files, ${archiveObserved.actions} actions, ` +
+        `${archiveObserved.relativeLinks} relative links`,
+    );
+  }
+
+  lines.push(
+    "",
+    "## Capture attribution — derived from the suites",
+    "",
+    "| Capture | Written by | Line |",
+    "|---|---|---|",
+    ...pack.captures.map((c) => `| \`${c.capture}\` | \`${c.writtenBy}\` | ${c.line} |`),
+    "",
+    `> ${pack.note}`,
+    "",
+  );
+  return lines.join("\n");
+}
+
+/* --------------------------------------------------------------------------------- CLI */
+
+export function parseArgs(argv) {
+  const out = {
+    root: REPO_ROOT,
+    skillsDir: null,
+    pluginArchiveDir: null,
+    canvasArchiveDir: null,
+    provenanceFile: null,
+    distributionFile: null,
+    specFile: null,
+    json: null,
+    markdown: null,
+    quiet: false,
+    help: false,
+  };
+  const value = (flag, next) => {
+    if (next === undefined) throw new Error(`evidence-pack: ${flag} needs a value`);
+    return next;
+  };
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i];
+    if (arg === "--root") out.root = path.resolve(value(arg, argv[++i]));
+    else if (arg === "--skills") out.skillsDir = value(arg, argv[++i]);
+    else if (arg === "--plugin-archive") out.pluginArchiveDir = value(arg, argv[++i]);
+    else if (arg === "--canvas-archive") out.canvasArchiveDir = value(arg, argv[++i]);
+    else if (arg === "--provenance") out.provenanceFile = value(arg, argv[++i]);
+    else if (arg === "--distribution") out.distributionFile = value(arg, argv[++i]);
+    else if (arg === "--spec") out.specFile = value(arg, argv[++i]);
+    else if (arg === "--json") out.json = value(arg, argv[++i]);
+    else if (arg === "--markdown") out.markdown = value(arg, argv[++i]);
+    else if (arg === "--quiet") out.quiet = true;
+    else if (arg === "--help" || arg === "-h") out.help = true;
+    else if (arg.startsWith("-")) throw new Error(`evidence-pack: unknown option ${arg}`);
+    else throw new Error(`evidence-pack: unexpected argument ${arg}`);
+  }
+  return out;
+}
+
+export const USAGE = `Usage: node evals/tools/evidence-pack.mjs [options]
+
+  --skills <dir>          installed skill directory (repository-clone family)
+  --plugin-archive <dir>  extracted problem-based-srs-vX.Y.zip
+  --canvas-archive <dir>  extracted ${CANVAS_ID}-X.Y.Z.zip root
+  --provenance <file>     open-archive-canvas.mjs --provenance output
+  --distribution <file>   check-distribution.mjs --json output
+  --spec <file>           specification the graph figures are derived from
+  --root <dir>            repository root
+  --json <file>           write the pack as JSON ("-" for stdout)
+  --markdown <file>       write the pack as markdown ("-" for stdout)
+  --quiet                 suppress the human transcript on stderr
+
+A family with no artefact supplied FAILS its gate. Exits 0 only when every gate passed.`;
+
+/**
+ * The CLI as a function: argv in, exit code out, streams injected.
+ *
+ * Shaped this way so the command line — the one path every maintainer actually takes — is
+ * reachable from a test instead of only from a subprocess. The bootstrap below is the only
+ * thing that turns the returned code into an exit.
+ *
+ * @param {string[]} [argv]
+ * @param {{stdout?:{write:Function}, stderr?:{write:Function}}} [io]
+ * @returns {number} exit code
+ */
+export function cli(argv = process.argv.slice(2), io = {}) {
+  const out = io.stdout ?? process.stdout;
+  const err = io.stderr ?? process.stderr;
+
+  let opts;
+  try {
+    opts = parseArgs(argv);
+  } catch (error) {
+    err.write(`${error.message}\n`);
+    return 1;
+  }
+
+  if (opts.help) {
+    err.write(`${USAGE}\n`);
+    return 0;
+  }
+
+  let pack;
+  try {
+    pack = buildEvidencePack(opts);
+  } catch (error) {
+    err.write(`${error.message}\n`);
+    return 1;
+  }
+
+  if (!opts.quiet) err.write(`${formatReport(pack)}\n`);
+  const json = `${JSON.stringify(pack, null, 2)}\n`;
+  if (opts.json === "-") out.write(json);
+  else if (opts.json) fs.writeFileSync(opts.json, json);
+  const markdown = `${formatMarkdown(pack)}\n`;
+  if (opts.markdown === "-") out.write(markdown);
+  else if (opts.markdown) fs.writeFileSync(opts.markdown, markdown);
+
+  return pack.ok ? 0 : 1;
+}
+
+const invokedDirectly =
+  process.argv[1] && pathToFileURL(path.resolve(process.argv[1])).href === import.meta.url;
+
+if (invokedDirectly) process.exit(cli());

--- a/evals/tools/live-profile.mjs
+++ b/evals/tools/live-profile.mjs
@@ -1,0 +1,451 @@
+#!/usr/bin/env node
+// Check the two preconditions that make a manual clean-profile `/live` run mean anything,
+// and record the manual observation it produces — including a refusal to load.
+//
+// Why this exists (issue #105). The loopback harness in `open-archive-canvas.mjs` proves the
+// **published archive's runtime**. #69's box names the *app*, so the second witness has to be
+// the Copilot app's own extension loader — a manual run. `docs/release-verification.md`
+// describes that run, and both of its preconditions are prose that nothing checks:
+//
+//   #105 problem 3 — "'The extensions directory is empty' is **not** a clean loader test.
+//                     This repository's own workspace contributes
+//                     `.github/extensions/srs-navigator` as a *project* extension. It loads
+//                     alongside a user-scope install and registers the same canvas id and the
+//                     same tool name **twice**."
+//   #105 problem 4 — "`/live` and the panel come from **different installs** … Installing
+//                     only the canvas archive and typing `/live` therefore tests a command
+//                     that archive never shipped. An evidence pack has to name both installs."
+//
+// A maintainer who misses either produces a screenshot that looks exactly like a correct one.
+// That is the failure mode the whole #69 sequence exists to end, so the preconditions are
+// checked here rather than trusted.
+//
+// The command-source gate is derived, not restated: it reads the archive's own `ACTIONS`
+// table and requires `live` to be absent from it, and requires the skills install to actually
+// ship `reference/live.md`. If the archive ever does dispatch `live`, this gate changes its
+// mind on its own instead of asserting a sentence that has gone stale.
+//
+// The load verdict is an **observation**, not a gate. `--loaded no` is a legitimate, complete
+// result — #105: "If the host refuses to load it, the refusal is recorded verbatim — a failed
+// load is a result." It is recorded and rendered prominently; it never silently flips the
+// exit code, because the exit code is about whether the run was set up honestly.
+//
+// Usage:
+//   node evals/tools/live-profile.mjs [options]
+//
+//   --extensions-dir <dir>  the profile to check (default: ~/.copilot/extensions)
+//   --workspace <dir>       the workspace the app will run in (default: cwd)
+//   --archive <dir>         the extracted canvas archive (its `srs-navigator/` root)
+//   --skills <dir>          the installed skill directory that supplies `/live`
+//   --profile-only          check only the profile and workspace; the command-source claim
+//                           is then reported as NOT established rather than passed
+//   --loaded <yes|no|not-run>  what the app reported (default: not-run)
+//   --log <path>            the extension log path from the extension inspector
+//   --note <text>           the refusal verbatim, or any observation worth keeping
+//   --json <file>           write the record ("-" for stdout)
+//   --quiet                 suppress the human transcript on stderr
+//
+// Exits 0 only when every precondition gate passed.
+
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { pathToFileURL } from "node:url";
+
+import { LIVE_COMMAND_SOURCES, CANVAS_ID } from "./open-archive-canvas.mjs";
+
+/** The action that opens the canvas, and the reason both installs have to be named. */
+export const LIVE_ACTION = "live";
+
+/** The reference file the skills install must ship for `/live` to exist at all. */
+export const LIVE_REFERENCE = path.join("reference", `${LIVE_ACTION}.md`);
+
+/** What the app reported. `not-run` is the honest default: nobody has looked yet. */
+export const LOAD_VERDICTS = Object.freeze(["yes", "no", "not-run"]);
+
+/** Precondition gate ids, in the order they run. */
+export const GATE_IDS = Object.freeze([
+  "profile-has-no-prior-install",
+  "workspace-contributes-no-project-extension",
+  "archive-carries-no-node-modules",
+  "command-source-is-established",
+]);
+
+/** The default profile the Copilot app discovers user-scope extensions from. */
+export function defaultExtensionsDir(home = os.homedir()) {
+  return path.join(home, ".copilot", "extensions");
+}
+
+/**
+ * The actions the canvas extension's tool dispatches, read from its source.
+ *
+ * Derived on purpose. The claim "`/live` does not come from the canvas archive" is only true
+ * while `live` is absent from this table, so the table is what gets read — a restatement
+ * would keep passing after the fact changed.
+ *
+ * @param {string} source contents of `extension.mjs`
+ * @returns {string[]|null} null when the table cannot be found at all
+ */
+export function canvasActions(source) {
+  const table = /const ACTIONS = \[([\s\S]*?)\];/.exec(String(source ?? ""));
+  if (!table) return null;
+  return [...table[1].matchAll(/action:\s*["']([a-z-]+)["']/g)].map((m) => m[1]);
+}
+
+/**
+ * Every directory under `dir` whose name matches the canvas, plus anything else that looks
+ * like an extension install. Missing directories are "nothing installed", not an error: a
+ * profile that has never had an extension is the cleanest one there is.
+ *
+ * @param {string} dir
+ * @returns {string[]}
+ */
+export function installedExtensions(dir) {
+  if (!dir || !fs.existsSync(dir)) return [];
+  return fs
+    .readdirSync(dir, { withFileTypes: true })
+    .filter((e) => e.isDirectory())
+    .map((e) => e.name)
+    .sort();
+}
+
+/**
+ * Project extensions the workspace contributes, and whether any of them registers this
+ * canvas.
+ *
+ * The name is not enough to go on: a directory called something else can still register
+ * `srs-navigator`, and it is the *registration* that collides. So each candidate's source is
+ * read for the canvas id.
+ *
+ * @param {string} workspace
+ * @returns {Array<{name:string, dir:string, registersCanvas:boolean}>}
+ */
+export function projectExtensions(workspace) {
+  const dir = path.join(workspace, ".github", "extensions");
+  if (!fs.existsSync(dir)) return [];
+  return fs
+    .readdirSync(dir, { withFileTypes: true })
+    .filter((e) => e.isDirectory())
+    .map((e) => {
+      const extDir = path.join(dir, e.name);
+      const entry = path.join(extDir, "extension.mjs");
+      const source = fs.existsSync(entry) ? fs.readFileSync(entry, "utf8") : "";
+      return {
+        name: e.name,
+        dir: extDir,
+        registersCanvas: source.includes(CANVAS_ID),
+      };
+    })
+    .sort((a, b) => a.name.localeCompare(b.name));
+}
+
+/**
+ * Check the preconditions and assemble the record the evidence pack carries.
+ *
+ * @param {{
+ *   extensionsDir?: string,
+ *   workspace?: string,
+ *   archiveDir?: string|null,
+ *   skillsDir?: string|null,
+ *   profileOnly?: boolean,
+ *   loaded?: string,
+ *   log?: string|null,
+ *   note?: string|null,
+ * }} [options]
+ * @returns {object}
+ */
+export function checkLiveProfile(options = {}) {
+  const {
+    extensionsDir = defaultExtensionsDir(),
+    workspace = process.cwd(),
+    archiveDir = null,
+    skillsDir = null,
+    profileOnly = false,
+    loaded = "not-run",
+    log = null,
+    note = null,
+  } = options;
+
+  if (!LOAD_VERDICTS.includes(loaded)) {
+    throw new Error(
+      `live-profile: --loaded must be one of ${LOAD_VERDICTS.join(", ")}; got "${loaded}"`,
+    );
+  }
+
+  const checks = [];
+  const unverified = [];
+  const record = {
+    tool: "live-profile",
+    checkedAt: new Date().toISOString(),
+    extensionsDir,
+    workspace: path.resolve(workspace),
+    archiveDir: archiveDir ? path.resolve(archiveDir) : null,
+    skillsDir: skillsDir ? path.resolve(skillsDir) : null,
+    observed: {},
+    checks,
+    unverified,
+    manual: { loaded, log, note },
+    ok: false,
+  };
+  const check = (id, ok, detail) => checks.push({ id, ok: Boolean(ok), detail });
+
+  /* ------------------------------------------------------------------ the profile */
+
+  const installed = installedExtensions(extensionsDir);
+  const prior = installed.filter((name) => name === CANVAS_ID);
+  check(
+    "profile-has-no-prior-install",
+    prior.length === 0,
+    prior.length === 0
+      ? `${extensionsDir} contains no ${CANVAS_ID} (${installed.length} other extension(s))`
+      : `${extensionsDir} already contains ${CANVAS_ID}; the run would load a previous ` +
+        "install rather than the archive under test",
+  );
+  record.observed.profileExtensions = installed;
+
+  /* ---------------------------------------------------------------- the workspace */
+
+  const project = projectExtensions(record.workspace);
+  const colliding = project.filter((p) => p.registersCanvas);
+  check(
+    "workspace-contributes-no-project-extension",
+    colliding.length === 0,
+    colliding.length === 0
+      ? `${record.workspace} contributes no project extension registering "${CANVAS_ID}"`
+      : `${record.workspace} contributes ${colliding.map((p) => p.name).join(", ")}, which ` +
+        `register "${CANVAS_ID}" as a project extension. It loads alongside the user-scope ` +
+        "install and registers the same canvas id and tool name twice, so the run would " +
+        "test a double registration rather than the published archive. Use a neutral " +
+        "workspace, or disable every project copy first.",
+  );
+  record.observed.projectExtensions = project.map((p) => ({
+    name: p.name,
+    registersCanvas: p.registersCanvas,
+  }));
+
+  /* ------------------------------------------------- the archive, if one was named */
+
+  if (!archiveDir) {
+    check(
+      "archive-carries-no-node-modules",
+      false,
+      "no --archive given, so nothing established that the extracted archive is the one the " +
+        "app will load, or that no `npm install` was run into it",
+    );
+  } else {
+    const resolved = path.resolve(archiveDir);
+    const modules = path.join(resolved, "node_modules");
+    const exists = fs.existsSync(resolved);
+    const clean = exists && !fs.existsSync(modules);
+    check(
+      "archive-carries-no-node-modules",
+      clean,
+      !exists
+        ? `${resolved} does not exist`
+        : clean
+          ? `${resolved} carries no node_modules, so it is the archive as published`
+          : `${resolved} contains node_modules — an install step re-created the tree the ` +
+            "packaging work removed, so this is no longer the published archive",
+    );
+    record.observed.archiveEntries = exists
+      ? fs.readdirSync(resolved).sort()
+      : [];
+  }
+
+  /* ------------------------------------------------------- which install supplies what */
+
+  record.commandSources = LIVE_COMMAND_SOURCES;
+
+  if (profileOnly) {
+    unverified.push({
+      id: "command-source-not-established",
+      detail:
+        "--profile-only was used, so neither install was read. The pack must still name " +
+        `which install supplies /${LIVE_ACTION} (the skill) and which supplies the panel ` +
+        "(the canvas archive); this run did not establish it.",
+    });
+  } else {
+    const entry = archiveDir ? path.join(path.resolve(archiveDir), "extension.mjs") : null;
+    const actions = entry && fs.existsSync(entry)
+      ? canvasActions(fs.readFileSync(entry, "utf8"))
+      : null;
+    const referencePath = skillsDir ? path.join(path.resolve(skillsDir), LIVE_REFERENCE) : null;
+    const shipsReference = Boolean(referencePath && fs.existsSync(referencePath));
+
+    const reasons = [];
+    if (actions === null) {
+      reasons.push(
+        entry
+          ? `the ACTIONS table could not be read from ${entry}`
+          : "no --archive given, so the canvas archive's action enum was never read",
+      );
+    } else if (actions.includes(LIVE_ACTION)) {
+      reasons.push(
+        `the archive now dispatches \`${LIVE_ACTION}\` (${actions.length} actions), so the ` +
+          "two-install claim in the runbook is stale and must be corrected before this " +
+          "evidence is filed",
+      );
+    }
+    if (!shipsReference) {
+      reasons.push(
+        referencePath
+          ? `the skills install does not ship ${LIVE_REFERENCE} (looked in ${referencePath})`
+          : `no --skills given, so nothing established where /${LIVE_ACTION} comes from`,
+      );
+    }
+
+    check(
+      "command-source-is-established",
+      reasons.length === 0,
+      reasons.length === 0
+        ? `/${LIVE_ACTION} comes from the skills install (${LIVE_REFERENCE}); the panel comes ` +
+          `from the canvas archive, whose ${actions.length}-action enum excludes ` +
+          `\`${LIVE_ACTION}\``
+        : reasons.join("; "),
+    );
+    record.observed.canvasActions = actions;
+    record.observed.skillShipsLiveReference = shipsReference;
+  }
+
+  record.observed.note =
+    "The load verdict is an observation, not a gate: a refusal to load is a result, and " +
+    "the loopback capture answers a different question and cannot be substituted for it.";
+  record.ok = checks.every((c) => c.ok);
+  return record;
+}
+
+/* --------------------------------------------------------------------------------- CLI */
+
+export function parseArgs(argv) {
+  const out = {
+    extensionsDir: defaultExtensionsDir(),
+    workspace: process.cwd(),
+    archiveDir: null,
+    skillsDir: null,
+    profileOnly: false,
+    loaded: "not-run",
+    log: null,
+    note: null,
+    json: null,
+    quiet: false,
+    help: false,
+  };
+  const value = (flag, next) => {
+    if (next === undefined) throw new Error(`live-profile: ${flag} needs a value`);
+    return next;
+  };
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i];
+    if (arg === "--extensions-dir") out.extensionsDir = value(arg, argv[++i]);
+    else if (arg === "--workspace") out.workspace = value(arg, argv[++i]);
+    else if (arg === "--archive") out.archiveDir = value(arg, argv[++i]);
+    else if (arg === "--skills") out.skillsDir = value(arg, argv[++i]);
+    else if (arg === "--profile-only") out.profileOnly = true;
+    else if (arg === "--loaded") out.loaded = value(arg, argv[++i]);
+    else if (arg === "--log") out.log = value(arg, argv[++i]);
+    else if (arg === "--note") out.note = value(arg, argv[++i]);
+    else if (arg === "--json") out.json = value(arg, argv[++i]);
+    else if (arg === "--quiet") out.quiet = true;
+    else if (arg === "--help" || arg === "-h") out.help = true;
+    else if (arg.startsWith("-")) throw new Error(`live-profile: unknown option ${arg}`);
+    else throw new Error(`live-profile: unexpected argument ${arg}`);
+  }
+  return out;
+}
+
+export const USAGE = `Usage: node evals/tools/live-profile.mjs [options]
+
+  --extensions-dir <dir>     profile to check (default: ~/.copilot/extensions)
+  --workspace <dir>          workspace the app will run in (default: cwd)
+  --archive <dir>            extracted canvas archive (its ${CANVAS_ID}/ root)
+  --skills <dir>             installed skill directory that supplies /${LIVE_ACTION}
+  --profile-only             skip the command-source claim, and say it was not established
+  --loaded <yes|no|not-run>  what the app reported; a refusal is a result
+  --log <path>               extension log path from the extension inspector
+  --note <text>              the refusal verbatim, or any observation worth keeping
+  --json <file>              write the record ("-" for stdout)
+  --quiet                    suppress the human transcript on stderr
+
+Exits 0 only when every precondition gate passed.`;
+
+/** Render the record as the transcript #105 attaches. */
+export function formatReport(record) {
+  const verdict = {
+    yes: "the app loaded the archive",
+    no: "the app REFUSED to load the archive — recorded as a result",
+    "not-run": "the app has not been run yet",
+  }[record.manual.loaded];
+
+  return [
+    `clean-profile check for /${LIVE_ACTION}`,
+    `profile:   ${record.extensionsDir}`,
+    `workspace: ${record.workspace}`,
+    `archive:   ${record.archiveDir ?? "(not given)"}`,
+    `skills:    ${record.skillsDir ?? "(not given)"}`,
+    "",
+    "preconditions (derived — these gate the exit code):",
+    ...record.checks.map((c) => `  ${c.ok ? "PASS" : "FAIL"}  ${c.id}: ${c.detail}`),
+    ...(record.unverified.length
+      ? ["", "not established this run:", ...record.unverified.map((u) => `  ${u.id}: ${u.detail}`)]
+      : []),
+    "",
+    "manual observation (recorded — this gates nothing):",
+    `  loaded: ${record.manual.loaded} — ${verdict}`,
+    `  log:    ${record.manual.log ?? "(none)"}`,
+    `  note:   ${record.manual.note ?? "(none)"}`,
+    "",
+    record.ok
+      ? `RESULT: every precondition passed; the app reported: ${verdict}`
+      : "RESULT: at least one precondition failed — a capture taken now would not prove what " +
+        "it claims",
+  ].join("\n");
+}
+
+/**
+ * The CLI as a function: argv in, exit code out, streams injected.
+ *
+ * Shaped this way so the command line — the one path every maintainer actually takes — is
+ * reachable from a test instead of only from a subprocess. The bootstrap below is the only
+ * thing that turns the returned code into an exit.
+ *
+ * @param {string[]} [argv]
+ * @param {{stdout?:{write:Function}, stderr?:{write:Function}}} [io]
+ * @returns {number} exit code
+ */
+export function cli(argv = process.argv.slice(2), io = {}) {
+  const out = io.stdout ?? process.stdout;
+  const err = io.stderr ?? process.stderr;
+
+  let opts;
+  try {
+    opts = parseArgs(argv);
+  } catch (error) {
+    err.write(`${error.message}\n`);
+    return 1;
+  }
+
+  if (opts.help) {
+    err.write(`${USAGE}\n`);
+    return 0;
+  }
+
+  let record;
+  try {
+    record = checkLiveProfile(opts);
+  } catch (error) {
+    err.write(`${error.message}\n`);
+    return 1;
+  }
+
+  if (!opts.quiet) err.write(`${formatReport(record)}\n`);
+  const json = `${JSON.stringify(record, null, 2)}\n`;
+  if (opts.json === "-") out.write(json);
+  else if (opts.json) fs.writeFileSync(opts.json, json);
+
+  return record.ok ? 0 : 1;
+}
+
+const invokedDirectly =
+  process.argv[1] && pathToFileURL(path.resolve(process.argv[1])).href === import.meta.url;
+
+if (invokedDirectly) process.exit(cli());

--- a/evals/tools/release-preflight.mjs
+++ b/evals/tools/release-preflight.mjs
@@ -1,0 +1,606 @@
+#!/usr/bin/env node
+// Rehearse a plugin release **before** the tag exists — the step #104 says does not exist.
+//
+// Why this is a tool and not another paragraph in the runbook. The tag is the point of no
+// return: `create-release.yml` is triggered *by* the tag push, so a failed run leaves a tag
+// behind and re-pushing an existing ref emits no `push` event. `docs/release-verification.md`
+// documents a pre-flight for exactly that reason, and every command in it can be skipped,
+// mistyped, or run against a tree other than the one about to be tagged. #104:
+//
+//   "3. No rehearsal exists. The tag is the point of no return."
+//
+// One gap in that documented pre-flight is worse than "someone might skip a step", and it is
+// the reason this file loads the archive rather than merely building it. The pre-flight
+// *packages* (`build-plugin.py build`) and stops there; `verify-plugin-archive.mjs` only ever
+// runs **after** publication, against the download. So the defect class #104 exists for —
+// `agents/skills/` links that were wrong in *every* published zip because nothing opened one
+// — could still sail past the tag and be discovered on the release page. The gate that would
+// have caught it therefore has to run on this side of the push, against the bytes the
+// packager just wrote. That is `packaged-archive-loads` below.
+//
+//   #104 — "`npx skills add` does not consume the release … add a direct download/extract
+//           inspection of the published zip if the acceptance text claims the released
+//           artefact was verified."
+//
+// Everything here is derived. Nothing restates a rule that lives somewhere else:
+//
+//   * the train verdict comes from `scripts/release-train.mjs`'s own `tagTrain()`, so this
+//     tool cannot disagree with the gate the workflows run;
+//   * the archive path and the release notes are read out of the `$GITHUB_OUTPUT` payload
+//     `build-plugin.py` writes — the same channel `create-release.yml` consumes, rather than
+//     a second parse of `CHANGELOG.md` that could drift from `extract_notes()`;
+//   * the archive is checked by `verifyPluginArchive()`, the reader the post-publication step
+//     already uses, so pre-flight and post-flight cannot answer differently.
+//
+// Counts are recorded, never gated, for the reason the rest of this suite gives: a snapshot
+// presented as a threshold turns a correct product red on its next routine addition, and the
+// number then gets edited to match reality.
+//
+// Usage:
+//   node evals/tools/release-preflight.mjs --tag v2.6 [options]
+//
+//   --tag <tag>       the tag about to be pushed (required)
+//   --against <ref>   the ref HEAD must equal (default: origin/main). Pass HEAD to waive it;
+//                     the waiver is then visible in the record instead of being invisible.
+//   --root <dir>      repository root (default: this repository)
+//   --no-suites       skip the two test-suite gates (they are the slow ones)
+//   --keep            keep the packaged archive and the extracted tree, and print where
+//   --json <file>     write the machine-readable rehearsal record ("-" for stdout)
+//   --quiet           suppress the human transcript on stderr
+//
+// Exit code is 0 only when every gate passed, so it composes into the release procedure:
+//   node evals/tools/release-preflight.mjs --tag v2.6 --json preflight.json \
+//     && git tag v2.6 && git push origin v2.6
+
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import crypto from "node:crypto";
+import { spawnSync } from "node:child_process";
+import { fileURLToPath, pathToFileURL } from "node:url";
+
+import { verifyPluginArchive } from "./verify-plugin-archive.mjs";
+import { readCanvasVersions, readPluginVersion, tagTrain } from "../../scripts/release-train.mjs";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+/** This repository, when the caller does not name another one. */
+export const REPO_ROOT = path.resolve(__dirname, "..", "..");
+
+/**
+ * The only train with a "before the tag" moment to rehearse.
+ *
+ * This is not a scope shortcut. `release-canvas.yml` is dispatch-only and creates its tag as
+ * part of `gh release create`, so a failed publish cannot strand a tag and there is no
+ * irreversible step to stand in front of — its ordering is the guarantee, and that ordering
+ * is guarded by `evals/tests/release-canvas-ordering.test.mjs`. `create-release.yml` is
+ * triggered *by* a tag push, so its tag outlives a failed run. Rehearsing is what you do
+ * before something you cannot take back.
+ */
+export const REHEARSABLE_TRAIN = "plugin";
+
+/** Gate ids, in the order they run. Every one is a closure property, never a count. */
+export const GATE_IDS = Object.freeze([
+  "working-tree-is-clean",
+  "head-is-the-commit-to-be-tagged",
+  "tag-belongs-to-the-plugin-train",
+  "tag-is-not-already-on-origin",
+  "build-succeeds",
+  "release-notes-are-not-empty",
+  "packaged-archive-loads",
+  "evals-suite-is-green",
+  "canvas-suite-is-green",
+]);
+
+/* --------------------------------------------------------------------------- the runner */
+
+/**
+ * Normalize a `spawnSync` result into the shape every gate reads.
+ *
+ * Separated out because the fallbacks matter and are otherwise unreachable: a process killed
+ * by a signal reports `status: null`, which would compare equal to nothing and silently read
+ * as "not zero, but also not a number I can print". A rehearsal that mis-reports that as a
+ * clean run is worse than one that crashes.
+ *
+ * @param {{status?:number|null, stdout?:string|null, stderr?:string|null, error?:Error}} result
+ * @returns {{status:number, stdout:string, stderr:string}}
+ */
+export function normalizeResult(result) {
+  if (result.error) {
+    return { status: 127, stdout: result.stdout ?? "", stderr: result.error.message };
+  }
+  return { status: result.status ?? 1, stdout: result.stdout ?? "", stderr: result.stderr ?? "" };
+}
+
+/**
+ * Run one command and return its result. Injected everywhere so the rehearsal's own logic is
+ * testable without a git remote, a Python interpreter or a network.
+ *
+ * @param {string} command
+ * @param {string[]} args
+ * @param {{cwd?:string, env?:Record<string,string>}} [options]
+ * @returns {{status:number, stdout:string, stderr:string}}
+ */
+export function defaultRunner(command, args, options = {}) {
+  return normalizeResult(
+    spawnSync(command, args, {
+      cwd: options.cwd,
+      env: options.env ? { ...process.env, ...options.env } : process.env,
+      encoding: "utf8",
+      maxBuffer: 64 * 1024 * 1024,
+    }),
+  );
+}
+
+/**
+ * The interpreter `build-plugin.py` will run under, or null when there is none.
+ *
+ * Probed rather than assumed: "no interpreter" and "the packager is broken" are different
+ * results, and a rehearsal that reports the second for the first sends a maintainer looking
+ * in the wrong place.
+ *
+ * @param {typeof defaultRunner} run
+ * @returns {string|null}
+ */
+export function findPython(run) {
+  return ["python3", "python"].find((exe) => run(exe, ["--version"]).status === 0) ?? null;
+}
+
+/* ------------------------------------------------------------------ deriving, not restating */
+
+/**
+ * Parse a `$GITHUB_OUTPUT` file the way Actions does, including the heredoc form
+ * `build-plugin.py` uses for multi-line release notes.
+ *
+ * Reading this file is what makes the notes gate honest: it is the exact payload
+ * `create-release.yml` consumes, so the rehearsal cannot approve notes the release would not
+ * publish.
+ *
+ * @param {string} text
+ * @returns {Record<string,string>}
+ */
+export function parseGithubOutput(text) {
+  const lines = String(text ?? "").split(/\r?\n/);
+  const out = {};
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i];
+    if (!line) continue;
+    const heredoc = /^([^=<]+)<<(.+)$/.exec(line);
+    if (heredoc) {
+      const [, key, delimiter] = heredoc;
+      const body = [];
+      i += 1;
+      while (i < lines.length && lines[i] !== delimiter) {
+        body.push(lines[i]);
+        i += 1;
+      }
+      out[key.trim()] = body.join("\n");
+      continue;
+    }
+    const eq = line.indexOf("=");
+    if (eq > 0) out[line.slice(0, eq).trim()] = line.slice(eq + 1);
+  }
+  return out;
+}
+
+/**
+ * The `###` headings inside a release-notes body.
+ *
+ * Recorded, never gated. #104 asks that the notes "contain the folded 2.5 entries as well as
+ * the 2.6 ones", and a *reader* can see that from the headings; a gate on them would encode
+ * one release's shape into every later one.
+ *
+ * @param {string} notes
+ * @returns {string[]}
+ */
+export function notesHeadings(notes) {
+  return [...String(notes ?? "").matchAll(/^#{3,4} .*$/gm)].map((m) => m[0].trim());
+}
+
+/** SHA-256 of a file, so the record names the bytes the rehearsal read. */
+export function sha256(file) {
+  return crypto.createHash("sha256").update(fs.readFileSync(file)).digest("hex");
+}
+
+/** Every `evals/tests/*.test.mjs`, expanded here because spawn does not glob. */
+export function evalTestFiles(root) {
+  const dir = path.join(root, "evals", "tests");
+  if (!fs.existsSync(dir)) return [];
+  return fs
+    .readdirSync(dir)
+    .filter((f) => f.endsWith(".test.mjs"))
+    .sort()
+    .map((f) => path.join("evals", "tests", f));
+}
+
+/* ------------------------------------------------------------------------ the rehearsal */
+
+/**
+ * Rehearse the release. Returns the record; only throws for input it cannot act on at all,
+ * because a caller wants the failing record rather than an exception.
+ *
+ * @param {{
+ *   tag: string,
+ *   root?: string,
+ *   against?: string,
+ *   suites?: boolean,
+ *   keep?: boolean,
+ *   run?: typeof defaultRunner,
+ *   workDir?: string,
+ * }} options
+ * @returns {object} rehearsal record
+ */
+export function runPreflight(options) {
+  const {
+    tag,
+    root = REPO_ROOT,
+    against = "origin/main",
+    suites = true,
+    keep = false,
+    run = defaultRunner,
+  } = options ?? {};
+
+  if (!tag) throw new Error("release-preflight: no --tag given");
+
+  const pluginVersion = readPluginVersion(root);
+  const verdict = tagTrain({
+    tag,
+    pluginVersion,
+    canvasVersions: readCanvasVersions(root),
+  });
+
+  if (verdict.train !== REHEARSABLE_TRAIN) {
+    throw new Error(
+      `release-preflight: ${tag} classifies as ${verdict.train}, and only the ` +
+        `${REHEARSABLE_TRAIN} train has a step to rehearse.\n${verdict.reason}\n` +
+        "release-canvas.yml is dispatch-only and creates its tag as part of publishing, so a " +
+        "failed run there cannot strand a tag — there is nothing irreversible to stand in " +
+        "front of. Its ordering is guarded by evals/tests/release-canvas-ordering.test.mjs.",
+    );
+  }
+
+  const version = String(tag).replace(/^v/i, "");
+  const checks = [];
+  const record = {
+    tool: "release-preflight",
+    tag,
+    train: verdict.train,
+    trainReason: verdict.reason,
+    version,
+    manifestVersion: pluginVersion,
+    root,
+    rehearsedAt: new Date().toISOString(),
+    observed: {},
+    checks,
+    ok: false,
+  };
+  const check = (id, ok, detail) => {
+    checks.push({ id, ok: Boolean(ok), detail });
+    return Boolean(ok);
+  };
+  const git = (...args) => run("git", args, { cwd: root });
+
+  /* ------------------------------------------------- the tree the tag will point at */
+
+  const status = git("status", "--porcelain");
+  const dirty = status.stdout.split(/\r?\n/).filter(Boolean);
+  check(
+    "working-tree-is-clean",
+    status.status === 0 && dirty.length === 0,
+    status.status !== 0
+      ? `git status failed: ${status.stderr.trim()}`
+      : dirty.length === 0
+        ? "no uncommitted changes, so the recorded SHA describes what was rehearsed"
+        : `${dirty.length} uncommitted change(s): ${dirty.slice(0, 5).join(", ")}`,
+  );
+
+  const head = git("rev-parse", "HEAD");
+  const sha = head.status === 0 ? head.stdout.trim() : null;
+  const target = git("rev-parse", "--verify", against);
+  const targetSha = target.status === 0 ? target.stdout.trim() : null;
+  check(
+    "head-is-the-commit-to-be-tagged",
+    Boolean(sha) && sha === targetSha,
+    !sha
+      ? `git rev-parse HEAD failed: ${head.stderr.trim()}`
+      : !targetSha
+        ? `${against} could not be resolved: ${target.stderr.trim()}`
+        : sha === targetSha
+          ? against === "HEAD"
+            ? `waived: --against HEAD, so this compares ${sha} with itself`
+            : `HEAD is ${sha}, which is ${against}`
+          : `HEAD is ${sha} but ${against} is ${targetSha}`,
+  );
+
+  record.observed.sha = sha;
+  record.observed.against = against;
+  record.observed.branch =
+    git("rev-parse", "--abbrev-ref", "HEAD").stdout.trim() || null;
+
+  /* ------------------------------------------------------------------------ the tag */
+
+  check(
+    "tag-belongs-to-the-plugin-train",
+    verdict.train === REHEARSABLE_TRAIN,
+    verdict.reason,
+  );
+
+  const remote = git("ls-remote", "--tags", "origin", `refs/tags/${tag}`);
+  const alreadyThere = remote.stdout.split(/\r?\n/).filter(Boolean);
+  check(
+    "tag-is-not-already-on-origin",
+    remote.status === 0 && alreadyThere.length === 0,
+    remote.status !== 0
+      ? `git ls-remote failed, so absence could not be established: ${remote.stderr.trim()}`
+      : alreadyThere.length === 0
+        ? `${tag} is not on origin yet`
+        : `${tag} is already on origin. Re-pushing it emits no push event, so nothing would ` +
+          "re-run; recover by dispatch instead: " +
+          `gh workflow run create-release.yml --ref ${tag} -f version=${version}`,
+  );
+
+  /* -------------------------------------------------- build, then open what it built */
+
+  const python = findPython(run);
+  const workDir = options?.workDir ?? fs.mkdtempSync(path.join(os.tmpdir(), "release-preflight-"));
+  const outDir = path.join(workDir, "dist");
+  const outputFile = path.join(workDir, "github-output.txt");
+  fs.mkdirSync(outDir, { recursive: true });
+  fs.writeFileSync(outputFile, "");
+
+  let built = null;
+  if (!python) {
+    check(
+      "build-succeeds",
+      false,
+      "no python3/python interpreter, so build-plugin.py could not run. The release needs " +
+        "one, so this is a failure rather than a skip.",
+    );
+  } else {
+    built = run(
+      python,
+      ["-B", path.join(root, "scripts", "build-plugin.py"), "build", "--version", version,
+        "--out-dir", outDir],
+      {
+        cwd: root,
+        env: { PYTHONDONTWRITEBYTECODE: "1", GITHUB_OUTPUT: outputFile },
+      },
+    );
+    check(
+      "build-succeeds",
+      built.status === 0,
+      built.status === 0
+        ? `build-plugin.py build --version ${version} succeeded`
+        : `build-plugin.py exited ${built.status}: ${(built.stderr || built.stdout).trim()}`,
+    );
+  }
+
+  const outputs = parseGithubOutput(
+    fs.existsSync(outputFile) ? fs.readFileSync(outputFile, "utf8") : "",
+  );
+  const notes = outputs.notes ?? "";
+  check(
+    "release-notes-are-not-empty",
+    notes.trim().length > 0,
+    notes.trim().length > 0
+      ? `the notes create-release.yml will publish are ${notes.length} chars across ` +
+        `${notesHeadings(notes).length} section(s)`
+      : "build-plugin.py emitted no notes for this version, so the release would publish an " +
+        "empty body. extract_notes() publishes exactly one CHANGELOG section.",
+  );
+  record.observed.notesHeadings = notesHeadings(notes);
+  record.observed.notesChars = notes.length;
+
+  const archivePath = outputs.artifact ?? null;
+  let archiveRecord = null;
+  if (!archivePath || !fs.existsSync(archivePath)) {
+    check(
+      "packaged-archive-loads",
+      false,
+      archivePath
+        ? `the packager named ${archivePath}, which does not exist`
+        : "the build produced no artifact to open, so the archive gate could not run",
+    );
+  } else {
+    const extracted = path.join(workDir, "extracted");
+    fs.mkdirSync(extracted, { recursive: true });
+    const unzip = run(
+      python,
+      [
+        "-B",
+        "-c",
+        "import sys,zipfile;zipfile.ZipFile(sys.argv[1]).extractall(sys.argv[2])",
+        archivePath,
+        extracted,
+      ],
+      { cwd: root, env: { PYTHONDONTWRITEBYTECODE: "1" } },
+    );
+    if (unzip.status !== 0) {
+      check(
+        "packaged-archive-loads",
+        false,
+        `the archive could not be extracted: ${(unzip.stderr || unzip.stdout).trim()}`,
+      );
+    } else {
+      archiveRecord = verifyPluginArchive(extracted);
+      const failed = archiveRecord.checks.filter((c) => !c.ok);
+      check(
+        "packaged-archive-loads",
+        archiveRecord.ok,
+        archiveRecord.ok
+          ? `every gate in verify-plugin-archive passed against the bytes just packaged ` +
+            `(${archiveRecord.checks.length} checks)`
+          : `verify-plugin-archive rejected the packaged archive: ` +
+            failed.map((c) => `${c.id} — ${c.detail}`).join("; "),
+      );
+      record.archive = {
+        path: archivePath,
+        bytes: fs.statSync(archivePath).size,
+        sha256: sha256(archivePath),
+        extractedTo: extracted,
+        verification: archiveRecord,
+      };
+      record.observed.archive = archiveRecord.observed;
+    }
+  }
+
+  /* -------------------------------------------------------------------- the suites */
+
+  if (suites) {
+    const evalsRun = run("node", ["--test", ...evalTestFiles(root)], { cwd: root });
+    check(
+      "evals-suite-is-green",
+      evalsRun.status === 0,
+      evalsRun.status === 0
+        ? `node --test evals/tests/*.test.mjs passed (${evalTestFiles(root).length} files)`
+        : `node --test evals/tests/*.test.mjs exited ${evalsRun.status}`,
+    );
+
+    const canvasDir = path.join(root, ".github", "extensions", "srs-navigator");
+    const canvasRun = run("npm", ["test", "--silent"], { cwd: canvasDir });
+    check(
+      "canvas-suite-is-green",
+      canvasRun.status === 0,
+      canvasRun.status === 0
+        ? "the srs-navigator suite passed"
+        : `npm test in ${path.relative(root, canvasDir)} exited ${canvasRun.status}`,
+    );
+  } else {
+    record.observed.suites =
+      "skipped with --no-suites; the runbook's own suite commands still apply";
+  }
+
+  /* ------------------------------------------------------------------------ cleanup */
+
+  record.workDir = workDir;
+  if (!keep && !options?.workDir) {
+    fs.rmSync(workDir, { recursive: true, force: true });
+    if (record.archive) record.archive.extractedTo = null;
+  }
+
+  record.observed.note =
+    "Observed values are recorded, not asserted. The gates above are closure properties, " +
+    "which survive a tenth action; a count would not.";
+  record.ok = checks.every((c) => c.ok);
+  return record;
+}
+
+/* --------------------------------------------------------------------------------- CLI */
+
+export function parseArgs(argv) {
+  const out = {
+    tag: null,
+    root: REPO_ROOT,
+    against: "origin/main",
+    suites: true,
+    keep: false,
+    json: null,
+    quiet: false,
+    help: false,
+  };
+  const value = (flag, next) => {
+    if (next === undefined) throw new Error(`release-preflight: ${flag} needs a value`);
+    return next;
+  };
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i];
+    if (arg === "--tag") out.tag = value(arg, argv[++i]);
+    else if (arg === "--root") out.root = path.resolve(value(arg, argv[++i]));
+    else if (arg === "--against") out.against = value(arg, argv[++i]);
+    else if (arg === "--no-suites") out.suites = false;
+    else if (arg === "--keep") out.keep = true;
+    else if (arg === "--json") out.json = value(arg, argv[++i]);
+    else if (arg === "--quiet") out.quiet = true;
+    else if (arg === "--help" || arg === "-h") out.help = true;
+    else if (arg.startsWith("-")) throw new Error(`release-preflight: unknown option ${arg}`);
+    else if (!out.tag) out.tag = arg;
+    else throw new Error(`release-preflight: unexpected argument ${arg}`);
+  }
+  return out;
+}
+
+export const USAGE = `Usage: node evals/tools/release-preflight.mjs --tag <tag> [options]
+
+  --tag <tag>      the tag about to be pushed (required)
+  --against <ref>  the ref HEAD must equal (default: origin/main; HEAD waives it visibly)
+  --root <dir>     repository root
+  --no-suites      skip the two test-suite gates
+  --keep           keep the packaged archive and extracted tree
+  --json <file>    write the rehearsal record ("-" for stdout)
+  --quiet          suppress the human transcript on stderr
+
+Exits 0 only when every gate passed, so it composes:
+  node evals/tools/release-preflight.mjs --tag v2.6 && git tag v2.6 && git push origin v2.6`;
+
+/** Render the record as the transcript a release issue can carry. */
+export function formatReport(record) {
+  return [
+    `release rehearsal: ${record.tag} (${record.train} train)`,
+    `repository: ${record.root}`,
+    `commit to be tagged: ${record.observed.sha ?? "(unknown)"}`,
+    "",
+    "gates (derived — these gate the exit code):",
+    ...record.checks.map((c) => `  ${c.ok ? "PASS" : "FAIL"}  ${c.id}: ${c.detail}`),
+    "",
+    "observed (recorded — these gate nothing):",
+    ...Object.entries(record.observed)
+      .filter(([key]) => key !== "note")
+      .map(([key, value]) => `  ${key}: ${JSON.stringify(value)}`),
+    `  ${record.observed.note ?? ""}`,
+    "",
+    record.ok
+      ? `RESULT: every gate passed — ${record.tag} is safe to push`
+      : `RESULT: at least one gate failed — do not push ${record.tag}`,
+  ].join("\n");
+}
+
+/**
+ * The CLI as a function: argv in, exit code out, streams injected.
+ *
+ * Shaped this way so the entry point is reachable from a test rather than only from a
+ * subprocess. A `main()` that calls `process.exit` directly cannot be exercised in-process,
+ * which means the one path every maintainer actually takes — the command line — is the one
+ * path with no coverage. This returns the code instead, and the bootstrap below is the only
+ * thing that turns it into an exit.
+ *
+ * @param {string[]} [argv]
+ * @param {{stdout?:{write:Function}, stderr?:{write:Function}, run?:typeof defaultRunner}} [io]
+ * @returns {number} exit code
+ */
+export function cli(argv = process.argv.slice(2), io = {}) {
+  const out = io.stdout ?? process.stdout;
+  const err = io.stderr ?? process.stderr;
+
+  let opts;
+  try {
+    opts = parseArgs(argv);
+  } catch (error) {
+    err.write(`${error.message}\n`);
+    return 1;
+  }
+
+  if (opts.help || !opts.tag) {
+    err.write(`${USAGE}\n`);
+    return opts.help ? 0 : 1;
+  }
+
+  let record;
+  try {
+    record = runPreflight({ ...opts, run: io.run ?? defaultRunner });
+  } catch (error) {
+    err.write(`${error.message}\n`);
+    return 1;
+  }
+
+  if (!opts.quiet) err.write(`${formatReport(record)}\n`);
+  const json = `${JSON.stringify(record, null, 2)}\n`;
+  if (opts.json === "-") out.write(json);
+  else if (opts.json) fs.writeFileSync(opts.json, json);
+
+  return record.ok ? 0 : 1;
+}
+
+const invokedDirectly =
+  process.argv[1] && pathToFileURL(path.resolve(process.argv[1])).href === import.meta.url;
+
+if (invokedDirectly) process.exit(cli());


### PR DESCRIPTION
## What this is

I went through all nine open issues (#69, #89, #90, #91, #92, #104, #105, #107, #108) and their comments. Every one of them says **"Repo-side work: done"** — what is left on each is a maintainer action that cannot be done from a PR and cannot be undone once done:

| Issue | What remains | Why it isn't here |
|---|---|---|
| #89 / #104 | cut plugin `v2.6`, verify the downloaded asset | irreversible tag push |
| #90 / #105 | cut canvas `v1.1.1`, prove `/live` in the real app | tag push + a manual run of the Copilot app |
| #91 | re-submit at skills.sh | third-party web form |
| #92 / #107 | assemble the evidence pack | needs the published artefacts |
| #69 / #108 | reconcile and close | depends on all of the above |

What each of those issues *also* leaves un-landed is the **executable half of its own procedure**. `docs/release-verification.md` describes a pre-flight, a `/live` proof and an evidence pack in prose, and nothing runs any of them — so each gets performed slightly differently every time, and the numbers in a pack are hand-copied snapshots that age silently. This PR lands that half. It changes no release, publishes nothing, and touches no workflow.

## The three tools

### `evals/tools/release-preflight.mjs` — #104's stated problem 3, *"No rehearsal exists"*

Nine gates run **before the tag exists**, which is the last moment anything can be fixed cheaply: `create-release.yml` is triggered *by* the tag push, so a failed run strands a tag and re-pushing an existing ref emits no `push` event.

The gate the documented pre-flight never had is `packaged-archive-loads`. `build-plugin.py build` *packages* an archive and stops; `verify-plugin-archive.mjs` has only ever run **after** publication, against the download. So the defect class #104 exists for — `agents/skills/` links that were broken in **every** published zip because nothing opened one — could sail past the tag and be found on the release page. This extracts the bytes the packager just wrote and puts `verifyPluginArchive` through them, on this side of the push.

Everything is derived, not restated: the train comes from importing `tagTrain()` out of `scripts/release-train.mjs`, and the release notes are read from the `$GITHUB_OUTPUT` payload `build-plugin.py` writes (the only place it emits them, heredoc-encoded). A `vX.Y.Z` canvas tag is **refused** rather than guessed at — that train creates its tag *as part of* publishing, so it has no "before the tag" moment to rehearse.

Run against this branch:

```
PASS  tag-belongs-to-the-plugin-train: v2.6 matches .claude-plugin/plugin.json (2.6.0)
PASS  build-succeeds / release-notes-are-not-empty (9804 chars across 3 sections)
PASS  packaged-archive-loads: every gate in verify-plugin-archive passed
      against the bytes just packaged (8 checks)
FAIL  working-tree-is-clean: 9 uncommitted change(s)   <- correct, this branch was dirty
```

### `evals/tools/live-profile.mjs` — #105's problems 3 and 4

Workspace isolation and command source were prose conditions nothing checked, so a maintainer could produce `/live` evidence from a profile where this repository's own `.github/extensions/srs-navigator` registers the same canvas id and tool name a second time. It reads the archive's own `ACTIONS` table rather than restating that `live` is absent from it, so adding `live` to the extension changes the verdict instead of leaving the runbook quietly wrong.

`--loaded` / `--log` / `--note` record the manual half and **gate nothing** — the tool cannot observe the app and must not appear to.

### `evals/tools/evidence-pack.mjs` — #107 / #92

The parts existed (`graph-metrics.mjs`, `distribution-artifacts.mjs`, `verify-plugin-archive.mjs`); nothing composed them. Every figure is labelled derived or recorded. A family whose artefact was not supplied **fails** and is never skipped, because a pack that quietly omits the family it could not prove reads exactly like one that proved it.

It also **sharpens a claim the runbook had wrong**. "Need clusters is a degree >= 4 property, not an array length" was imprecise at both ends: `computeHotspots` classifies with an if/else chain, so an orphaned problem or unmet need of degree >= 4 is *not* counted as a hub; and on the shipped demo the figure (5) coincides with two spec arrays of length 5, so "not an array length" is a coincidence claim, not a derivation claim. Both ends are now stated precisely, in the tool and in the runbook, and the runbook guard derives the wording from the tool.

## Tests

166 new tests across three suites, **100% line, branch and function coverage** on all three tools, with a canary per gate. The bootstrap line (`process.exit(cli())`) can't be covered in-process — it would end the test run — so each suite runs its tool as a real subprocess instead, which is what closed the last branch.

Every guard was **negative-tested by mutation** (mutate -> confirm red -> restore -> confirm green), including the two new runbook guards.

`evals/tests/release-verification-runbook.test.mjs` gains three rules, all derived rather than asserted:

- the runbook must **name** each executable that exists (a tool a runbook doesn't mention is a tool nobody runs);
- every documented command line is run through **the tool's own `parseArgs`**. A plain source grep was tried first and was too weak — `--tags` appears in `release-preflight.mjs` as an argument to `git ls-remote`, so a runbook saying `--tags` would have passed while failing at runtime;
- an option named in the **prose** must appear in the tool's `USAGE`. This is what caught a `--skip-dirty` I had documented and never implemented.

## Verification

| Check | Result |
|---|---|
| `node --test evals/tests/*.test.mjs` | **858 / 858** (baseline 680) |
| `.github/extensions/srs-navigator` -> `npm test` | **295 / 295** |
| `npm run test:e2e` (Playwright, run last) | **41 / 41** |
| `python scripts/build-plugin.py validate` | success — `problem-based-srs v2.6.0`, 1 skill |
| coverage of the three new tools | **100% / 100% / 100%** |
| all three tools run end-to-end | pre-flight packaged + opened the real archive; `live-profile` passed 4/4 against an extracted copy; `evidence-pack` derived 29 nodes / 32 links / 5 need clusters / 100% traceability and failed the two unsupplied families and the three live distribution errors |

## What is deliberately *not* here

No tag was pushed, no release cut, no workflow dispatched, no skills.sh submission, and no `VERSION` bump — those are the maintainer-only halves listed in the table at the top, and the request was for a PR, not a merge. When you do cut `v2.6`, the first command is now:

```bash
node evals/tools/release-preflight.mjs --tag v2.6
```