### PR TITLE
docs: address open documentation-improvement gaps with issue-ledger guard

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -268,6 +268,10 @@ same discipline to all future changes.
 5. **Keep the default suite green.** `npm test` must stay fast and deterministic (no network
    / no API keys). Put anything requiring an LLM or credentials behind
    `npm run test:skill-behavior`.
+6. **Guard sequenced issue ledgers with a command.** If a change updates closure criteria in
+   long-form issue ledgers (for example #69/#92/#108), add or update
+   `evals/tools/issue-ledger.mjs` + `evals/tests/issue-ledger.test.mjs` so drift is detected:
+   open boxes without blocker, ticked boxes without citation, and stale version claims.
 
 #### Required verification before committing a behavior change
 

--- a/docs/release-verification.md
+++ b/docs/release-verification.md
@@ -13,6 +13,7 @@ which tag, what the distribution monitor reports) and links back to this file fo
 - [Thursday release cadence](#thursday-release-cadence)
 - [Plugin train — cutting `vX.Y`](#plugin-train--cutting-vxy)
 - [Canvas train — cutting `vX.Y.Z`](#canvas-train--cutting-vxyz)
+- [Issue-ledger drift guard for sequenced closure](#issue-ledger-drift-guard-for-sequenced-closure)
 - [Proving `/live` in the app itself](#proving-live-in-the-app-itself)
 - [Deriving an evidence pack](#deriving-an-evidence-pack)
 
@@ -211,6 +212,25 @@ condition `extension.mjs` uses to treat itself as an in-repo install — a captu
 would show the checkout while being filed as archive evidence. `--provenance` records the
 extracted path, the archive version and the SHA-256 of `extension.mjs`, so a screenshot can
 be tied to the bytes that produced it.
+
+---
+
+## Issue-ledger drift guard for sequenced closure
+
+The closure sequence issues (`#69`, `#89`, `#90`, `#91`, `#92`, `#104`, `#105`, `#107`, `#108`)
+carry long checkbox ledgers. This command reads the **live issue bodies** and reports:
+
+- checked vs. open boxes,
+- open boxes missing an explicit blocker (`Blocked on #...` / URL),
+- ticked boxes with no citation, and
+- box text still naming a version older than the manifest.
+
+```bash
+node evals/tools/issue-ledger.mjs 69 89 90 91 92 104 105 107 108 --json issue-ledger.json
+```
+
+It reports; it does not edit. Reconciliation remains a human judgement. The guard exists so a
+body drifting away from its evidence is detected by command rather than discovered in review.
 
 ---
 

--- a/evals/README.md
+++ b/evals/README.md
@@ -231,7 +231,8 @@ evals/
 │   └── graders.mjs          # rubric grading + LLM judge
 ├── tests/                   # deterministic node --test files (offline)
 ├── tools/
-│   └── open-archive-canvas.mjs  # boot the canvas from an extracted release archive
+│   ├── open-archive-canvas.mjs  # boot the canvas from an extracted release archive
+│   └── issue-ledger.mjs         # report checkbox-ledger drift in sequenced GitHub issues
 ├── cases/                   # live eval cases (opt-in)
 │   ├── _shared.mjs
 │   └── *.case.mjs

--- a/evals/tests/issue-ledger.test.mjs
+++ b/evals/tests/issue-ledger.test.mjs
@@ -1,0 +1,97 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  analyzeIssueBody,
+  compareVersions,
+  hasCitation,
+  hasExplicitBlocker,
+  normalizeVersion,
+  parseArgs,
+  parseChecklistLine,
+} from "../tools/issue-ledger.mjs";
+
+describe("version helpers", () => {
+  it("normalizes two-part and three-part versions", () => {
+    assert.deepEqual(normalizeVersion("2.6"), [2, 6, 0]);
+    assert.deepEqual(normalizeVersion("2.6.1"), [2, 6, 1]);
+  });
+
+  it("compares normalized versions", () => {
+    assert.equal(compareVersions("2.5.0", "2.6.0"), -1);
+    assert.equal(compareVersions("2.6", "2.6.0"), 0);
+    assert.equal(compareVersions("2.6.2", "2.6.1"), 1);
+  });
+});
+
+describe("line classifiers", () => {
+  it("detects citations in checkbox lines", () => {
+    assert.equal(hasCitation("done in #108"), true);
+    assert.equal(hasCitation("see https://example.com"), true);
+    assert.equal(hasCitation("ran `node --test evals/tests/*.test.mjs`"), true);
+    assert.equal(hasCitation("just done"), false);
+  });
+
+  it("detects explicit blockers for open boxes", () => {
+    assert.equal(hasExplicitBlocker("Blocked on #91"), true);
+    assert.equal(hasExplicitBlocker("blocked by https://example.com/ticket"), true);
+    assert.equal(hasExplicitBlocker("waiting on #91"), false);
+  });
+
+  it("parses checkbox lines and superseded version mentions", () => {
+    const parsed = parseChecklistLine("- [ ] Cut v2.5.0 before closing", "2.6.0");
+    assert.ok(parsed);
+    assert.equal(parsed.checked, false);
+    assert.deepEqual(parsed.supersededVersions, ["2.5.0"]);
+  });
+});
+
+describe("issue body analysis", () => {
+  it("passes when all boxes are ticked with citations", () => {
+    const body = [
+      "- [x] done in #108",
+      "- [x] runbook updated in `docs/release-verification.md`",
+    ].join("\n");
+    const analyzed = analyzeIssueBody(body, "2.6.0");
+    assert.equal(analyzed.counts.open, 0);
+    assert.equal(analyzed.counts.tickedWithoutCitation, 0);
+    assert.equal(analyzed.counts.openWithoutBlocker, 0);
+    assert.equal(analyzed.counts.supersededVersionMentions, 0);
+  });
+
+  it("fails an unticked box without explicit blocker", () => {
+    const analyzed = analyzeIssueBody("- [ ] still pending", "2.6.0");
+    assert.equal(analyzed.counts.open, 1);
+    assert.equal(analyzed.counts.openWithoutBlocker, 1);
+  });
+
+  it("accepts an unticked box with explicit blocker", () => {
+    const analyzed = analyzeIssueBody("- [ ] Blocked on #91 until re-crawl lands", "2.6.0");
+    assert.equal(analyzed.counts.open, 1);
+    assert.equal(analyzed.counts.openWithoutBlocker, 0);
+  });
+
+  it("flags ticked boxes that have no citation", () => {
+    const analyzed = analyzeIssueBody("- [x] completed", "2.6.0");
+    assert.equal(analyzed.counts.tickedWithoutCitation, 1);
+  });
+
+  it("flags boxes that still name a superseded version", () => {
+    const analyzed = analyzeIssueBody("- [ ] release link points at v2.5", "2.6.0");
+    assert.equal(analyzed.counts.supersededVersionMentions, 1);
+  });
+});
+
+describe("argument parsing", () => {
+  it("accepts numeric issue numbers and known options", () => {
+    const args = parseArgs(["69", "91", "--repo", "owner/repo", "--json", "-", "--quiet"]);
+    assert.deepEqual(args.issues, [69, 91]);
+    assert.equal(args.repo, "owner/repo");
+    assert.equal(args.json, "-");
+    assert.equal(args.quiet, true);
+  });
+
+  it("rejects non-numeric issue identifiers", () => {
+    assert.throws(() => parseArgs(["abc"]), /invalid issue number/);
+  });
+});

--- a/evals/tests/release-verification-runbook.test.mjs
+++ b/evals/tests/release-verification-runbook.test.mjs
@@ -337,12 +337,15 @@ describe("every step with an executable form names it", () => {
     });
   }
 
-  it("puts the rehearsal before the tag push, which is the only place it can help", () => {
+  it("puts the rehearsal before the release dispatch, which is the only place it can help", () => {
     const rehearsal = runbook.indexOf("release-preflight.mjs");
-    const tagPush = runbook.indexOf("git tag vX.Y && git push origin vX.Y");
+    const dispatch = runbook.indexOf("gh workflow run create-release.yml --ref main -f version=X.Y");
     assert.ok(rehearsal !== -1, "release-preflight.mjs is not mentioned in the runbook");
-    assert.ok(tagPush !== -1, '"git tag vX.Y && git push origin vX.Y" is not in the runbook');
-    assert.ok(rehearsal < tagPush, "the rehearsal is documented after the point of no return");
+    assert.ok(
+      dispatch !== -1,
+      '"gh workflow run create-release.yml --ref main -f version=X.Y" is not in the runbook',
+    );
+    assert.ok(rehearsal < dispatch, "the rehearsal is documented after the point of no return");
   });
 
   it("says the rehearsal opens the archive, which is what the pre-flight lacked", () => {

--- a/evals/tools/issue-ledger.mjs
+++ b/evals/tools/issue-ledger.mjs
@@ -1,0 +1,297 @@
+#!/usr/bin/env node
+// Report issue-body ledger health for sequenced release/documentation issues.
+//
+// The goal is not to auto-edit issue bodies. It is to make drift visible in one command:
+// how many boxes are open/closed, which open boxes are missing an explicit blocker, which
+// ticked boxes carry no citation, and whether any box still names a version older than the
+// manifest currently advertises.
+
+import fs from "node:fs";
+import path from "node:path";
+import { spawnSync } from "node:child_process";
+import { fileURLToPath, pathToFileURL } from "node:url";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+export const REPO_ROOT = path.resolve(__dirname, "..", "..");
+
+export function normalizeResult(result) {
+  if (result.error) {
+    return { status: 127, stdout: result.stdout ?? "", stderr: result.error.message };
+  }
+  return { status: result.status ?? 1, stdout: result.stdout ?? "", stderr: result.stderr ?? "" };
+}
+
+export function defaultRunner(command, args, options = {}) {
+  return normalizeResult(
+    spawnSync(command, args, {
+      cwd: options.cwd,
+      encoding: "utf8",
+      env: options.env ? { ...process.env, ...options.env } : process.env,
+      maxBuffer: 16 * 1024 * 1024,
+    }),
+  );
+}
+
+export function normalizeVersion(version) {
+  const m = /^(\d+)\.(\d+)(?:\.(\d+))?$/.exec(String(version ?? "").trim());
+  if (!m) return null;
+  return [Number(m[1]), Number(m[2]), Number(m[3] ?? 0)];
+}
+
+export function compareVersions(a, b) {
+  const left = normalizeVersion(a);
+  const right = normalizeVersion(b);
+  if (!left || !right) return null;
+  for (let i = 0; i < 3; i++) {
+    if (left[i] < right[i]) return -1;
+    if (left[i] > right[i]) return 1;
+  }
+  return 0;
+}
+
+export function versionMentions(text) {
+  return [...String(text ?? "").matchAll(/\bv(\d+\.\d+(?:\.\d+)?)\b/g)].map((m) => m[1]);
+}
+
+export function hasCitation(text) {
+  return (
+    /https?:\/\//i.test(text) ||
+    /#\d{2,}/.test(text) ||
+    /`[^`]+`/.test(text) ||
+    /\b[A-Za-z0-9._/-]+\.(?:md|mjs|js|ts|yml|yaml|json)(?::\d+)?\b/.test(text)
+  );
+}
+
+export function hasExplicitBlocker(text) {
+  return (
+    /(blocked on|blocked by|blocker|follow-up|tracked observation|downgrade)/i.test(text) &&
+    (/#\d{2,}/.test(text) || /https?:\/\//i.test(text))
+  );
+}
+
+export function parseChecklistLine(line, currentVersion) {
+  const m = /^\s*-\s\[( |x|X)\]\s+(.*)\s*$/.exec(line);
+  if (!m) return null;
+  const checked = m[1].toLowerCase() === "x";
+  const text = m[2];
+  const mentions = versionMentions(text);
+  const superseded = mentions.filter((v) => compareVersions(v, currentVersion) === -1);
+  return {
+    checked,
+    text,
+    hasCitation: hasCitation(text),
+    hasExplicitBlocker: hasExplicitBlocker(text),
+    versionMentions: mentions,
+    supersededVersions: superseded,
+  };
+}
+
+export function analyzeIssueBody(body, currentVersion) {
+  const lines = String(body ?? "").split(/\r?\n/);
+  const boxes = [];
+  for (const line of lines) {
+    const parsed = parseChecklistLine(line, currentVersion);
+    if (parsed) boxes.push(parsed);
+  }
+  const checked = boxes.filter((b) => b.checked);
+  const open = boxes.filter((b) => !b.checked);
+  const openWithoutBlocker = open.filter((b) => !b.hasExplicitBlocker);
+  const tickedWithoutCitation = checked.filter((b) => !b.hasCitation);
+  const supersededVersionMentions = boxes.flatMap((b) => b.supersededVersions);
+
+  return {
+    boxes,
+    counts: {
+      total: boxes.length,
+      checked: checked.length,
+      open: open.length,
+      openWithoutBlocker: openWithoutBlocker.length,
+      tickedWithoutCitation: tickedWithoutCitation.length,
+      supersededVersionMentions: supersededVersionMentions.length,
+    },
+    findings: {
+      openWithoutBlocker: openWithoutBlocker.map((b) => b.text),
+      tickedWithoutCitation: tickedWithoutCitation.map((b) => b.text),
+      supersededVersionMentions,
+    },
+  };
+}
+
+export function readPluginVersion(root = REPO_ROOT) {
+  const file = path.join(root, ".claude-plugin", "plugin.json");
+  const data = JSON.parse(fs.readFileSync(file, "utf8"));
+  return data.version;
+}
+
+export function parseRepoFromRemoteUrl(url) {
+  const text = String(url ?? "").trim();
+  const m =
+    /github\.com[:/](?<owner>[^/]+)\/(?<repo>[^/.]+)(?:\.git)?$/i.exec(text) ??
+    /^https?:\/\/[^/]+\/(?<owner>[^/]+)\/(?<repo>[^/.]+)(?:\.git)?$/i.exec(text);
+  if (!m?.groups) return null;
+  return `${m.groups.owner}/${m.groups.repo}`;
+}
+
+export function detectRepo(root, run = defaultRunner) {
+  const remote = run("git", ["config", "--get", "remote.origin.url"], { cwd: root });
+  if (remote.status !== 0) return null;
+  return parseRepoFromRemoteUrl(remote.stdout);
+}
+
+export function fetchIssue(number, repo, run = defaultRunner, root = REPO_ROOT) {
+  const args = ["issue", "view", String(number), "--json", "number,title,url,body"];
+  if (repo) args.push("--repo", repo);
+  const result = run("gh", args, { cwd: root });
+  if (result.status !== 0) {
+    throw new Error(`issue-ledger: failed to read #${number}: ${result.stderr.trim() || "gh failed"}`);
+  }
+  return JSON.parse(result.stdout);
+}
+
+export function buildLedger(options, run = defaultRunner) {
+  const currentVersion = readPluginVersion(options.root);
+  const repo = options.repo || detectRepo(options.root, run);
+  const issues = options.issues.map((n) => {
+    const issue = fetchIssue(n, repo, run, options.root);
+    const analysis = analyzeIssueBody(issue.body, currentVersion);
+    return {
+      number: issue.number,
+      title: issue.title,
+      url: issue.url,
+      ...analysis,
+    };
+  });
+
+  const totals = issues.reduce(
+    (acc, issue) => {
+      acc.issues += 1;
+      acc.boxes += issue.counts.total;
+      acc.checked += issue.counts.checked;
+      acc.open += issue.counts.open;
+      acc.openWithoutBlocker += issue.counts.openWithoutBlocker;
+      acc.tickedWithoutCitation += issue.counts.tickedWithoutCitation;
+      acc.supersededVersionMentions += issue.counts.supersededVersionMentions;
+      return acc;
+    },
+    {
+      issues: 0,
+      boxes: 0,
+      checked: 0,
+      open: 0,
+      openWithoutBlocker: 0,
+      tickedWithoutCitation: 0,
+      supersededVersionMentions: 0,
+    },
+  );
+
+  const record = {
+    repo,
+    currentVersion,
+    generatedAt: new Date().toISOString(),
+    issues,
+    totals,
+  };
+  record.ok =
+    totals.openWithoutBlocker === 0 &&
+    totals.tickedWithoutCitation === 0 &&
+    totals.supersededVersionMentions === 0;
+  return record;
+}
+
+export const USAGE = `Usage: node evals/tools/issue-ledger.mjs <issue-number...> [options]
+
+Options:
+  --repo <owner/repo>  GitHub repository (default: inferred from remote.origin.url)
+  --root <dir>         repository root (default: this repository)
+  --json <file>        write JSON output ("-" for stdout)
+  --quiet              suppress human-readable output
+  --help, -h           show this help`;
+
+export function parseArgs(argv) {
+  const out = {
+    issues: [],
+    repo: null,
+    root: REPO_ROOT,
+    json: null,
+    quiet: false,
+    help: false,
+  };
+  const value = (flag, next) => {
+    if (next === undefined) throw new Error(`issue-ledger: ${flag} needs a value`);
+    return next;
+  };
+
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i];
+    if (arg === "--repo") out.repo = value(arg, argv[++i]);
+    else if (arg === "--root") out.root = path.resolve(value(arg, argv[++i]));
+    else if (arg === "--json") out.json = value(arg, argv[++i]);
+    else if (arg === "--quiet") out.quiet = true;
+    else if (arg === "--help" || arg === "-h") out.help = true;
+    else if (arg.startsWith("-")) throw new Error(`issue-ledger: unknown option ${arg}`);
+    else if (/^\d+$/.test(arg)) out.issues.push(Number(arg));
+    else throw new Error(`issue-ledger: invalid issue number ${arg}`);
+  }
+  return out;
+}
+
+export function formatReport(record) {
+  const lines = [
+    `issue ledger for ${record.repo ?? "(repo not detected)"}`,
+    `manifest version: ${record.currentVersion}`,
+    "",
+    ...record.issues.map((issue) => {
+      const prefix = `#${issue.number} ${issue.title}`;
+      return [
+        prefix,
+        `  boxes: ${issue.counts.checked} checked, ${issue.counts.open} open (${issue.counts.total} total)`,
+        `  open without blocker: ${issue.counts.openWithoutBlocker}`,
+        `  ticked without citation: ${issue.counts.tickedWithoutCitation}`,
+        `  superseded version mentions: ${issue.counts.supersededVersionMentions}`,
+      ].join("\n");
+    }),
+    "",
+    `totals: ${record.totals.checked} checked, ${record.totals.open} open, ${record.totals.boxes} boxes`,
+    `flags: ${record.totals.openWithoutBlocker} open-without-blocker, ` +
+      `${record.totals.tickedWithoutCitation} ticked-without-citation, ` +
+      `${record.totals.supersededVersionMentions} superseded-version-mentions`,
+    "",
+    record.ok ? "RESULT: ledger is consistent" : "RESULT: ledger has drift to reconcile",
+  ];
+  return lines.join("\n");
+}
+
+export function cli(argv = process.argv.slice(2), io = {}) {
+  const out = io.stdout ?? process.stdout;
+  const err = io.stderr ?? process.stderr;
+  let opts;
+  try {
+    opts = parseArgs(argv);
+  } catch (error) {
+    err.write(`${error.message}\n`);
+    return 1;
+  }
+
+  if (opts.help || opts.issues.length === 0) {
+    err.write(`${USAGE}\n`);
+    return opts.help ? 0 : 1;
+  }
+
+  let record;
+  try {
+    record = buildLedger(opts, io.run ?? defaultRunner);
+  } catch (error) {
+    err.write(`${error.message}\n`);
+    return 1;
+  }
+
+  if (!opts.quiet) err.write(`${formatReport(record)}\n`);
+  const json = `${JSON.stringify(record, null, 2)}\n`;
+  if (opts.json === "-") out.write(json);
+  else if (opts.json) fs.writeFileSync(opts.json, json);
+  return record.ok ? 0 : 1;
+}
+
+const invokedDirectly =
+  process.argv[1] && pathToFileURL(path.resolve(process.argv[1])).href === import.meta.url;
+if (invokedDirectly) process.exit(cli());


### PR DESCRIPTION
## Summary
This PR bundles repository-side fixes for the currently open documentation-improvement issues by adding an executable ledger guard and aligning release documentation tests with the dispatch-based release workflow.

### What changed
- Added `evals/tools/issue-ledger.mjs` to report issue-ledger drift from live GitHub issue bodies:
  - open vs checked boxes
  - open boxes without explicit blockers
  - checked boxes without citations
  - superseded version mentions vs current manifest version
- Added `evals/tests/issue-ledger.test.mjs` with deterministic canaries for all rule branches.
- Fixed `evals/tests/release-verification-runbook.test.mjs` to validate pre-flight ordering against the **release dispatch** command (current workflow), not the legacy tag-push command.
- Updated `docs/release-verification.md` with an explicit **Issue-ledger drift guard** section and executable command.
- Updated `.github/copilot-instructions.md` to require issue-ledger guards for sequenced closure ledgers.
- Updated `evals/README.md` tool layout to include `issue-ledger.mjs`.

## Validation
- `node --test evals/tests/issue-ledger.test.mjs evals/tests/release-verification-runbook.test.mjs evals/tests/evals-readme.test.mjs`
- `node --test evals/tests/*.test.mjs`
- `python scripts/build-plugin.py validate`

## Related open documentation issues
- #118
- #117
- #115
- #113
- #107
- #92
- #91
- #69