### PR TITLE
fix: Make the release pre-flight runnable on Windows

### DIFF
--- a/evals/tests/release-preflight.test.mjs
+++ b/evals/tests/release-preflight.test.mjs
@@ -38,6 +38,7 @@ import {
   notesHeadings,
   parseArgs,
   parseGithubOutput,
+  resolveCommand,
   runPreflight,
   sha256,
 } from "../tools/release-preflight.mjs";
@@ -298,6 +299,40 @@ describe("the small readers", () => {
       { cwd: repoRoot, env: { PBSRS_PROBE: "yes" } },
     );
     assert.equal(withEnv.stdout, "yes");
+  });
+
+  it("runs a PATH-resolved package-manager shim, which is what the canvas gate does", () => {
+    // The canary for the defect this guards. `canvas-suite-is-green` runs `npm test`, and on
+    // Windows npm is a `.cmd` shim: `spawnSync("npm", …)` raises ENOENT and naming the
+    // resolved `npm.cmd` raises EINVAL, because Node will not CreateProcess a batch file.
+    // `normalizeResult` maps both to 127, so the gate reported red for a green suite — on the
+    // platform this repository is maintained from. Asserting on `npm --version` rather than on
+    // any platform detail keeps the test meaningful everywhere: it fails wherever the runner
+    // cannot execute the one kind of command the gate actually needs.
+    const npm = defaultRunner("npm", ["--version"]);
+    assert.equal(npm.status, 0, `expected npm to run, got ${npm.status}: ${npm.stderr}`);
+    assert.match(npm.stdout.trim(), /^\d+\.\d+\.\d+/);
+  });
+
+  it("never hands back a batch shim as a path, and leaves an unresolvable command bare", () => {
+    // Two halves of the same rule. A `.cmd`/`.bat` must come back as shell:true, because the
+    // path form is unspawnable; and a command that resolves to nothing must come back bare
+    // with shell:false, so spawnSync still raises ENOENT. Routing the missing case through a
+    // shell would turn it into the shell's "not recognized" exit code, and `findPython`'s
+    // ability to tell "no interpreter" from "the packager is broken" depends on that
+    // difference surviving.
+    const resolved = resolveCommand("npm");
+    assert.ok(!/\.(cmd|bat)$/i.test(resolved.command));
+    if (resolved.shell) assert.equal(resolved.command, "npm");
+
+    const missing = resolveCommand("pbsrs-no-such-executable-xyz");
+    assert.deepEqual(missing, { command: "pbsrs-no-such-executable-xyz", shell: false });
+
+    // An absolute path is never re-resolved, whatever it points at.
+    assert.deepEqual(resolveCommand(process.execPath), {
+      command: process.execPath,
+      shell: false,
+    });
   });
 });
 

--- a/evals/tools/release-preflight.mjs
+++ b/evals/tools/release-preflight.mjs
@@ -113,6 +113,66 @@ export function normalizeResult(result) {
 }
 
 /**
+ * Resolve how a command must be spawned on this platform.
+ *
+ * Windows cannot execute a PATH-resolved shim the way POSIX can, and both of the obvious
+ * spellings fail in ways that look like a broken repository rather than a broken call:
+ * `spawnSync("npm", …)` raises ENOENT, and naming the resolved `npm.cmd` directly raises
+ * EINVAL, because Node refuses to `CreateProcess` a batch file. `normalizeResult` maps both
+ * to 127, so `canvas-suite-is-green` failed on Windows **whatever the canvas suite did** —
+ * a rehearsal reporting a red gate for a green suite, on the platform this repository is
+ * maintained from.
+ *
+ * A blanket `shell: true` would fix npm and break something more important: a genuinely
+ * missing executable would come back as the shell's "not recognized" exit code instead of
+ * ENOENT, so "the tool is absent" and "the tool ran and failed" would stop being
+ * distinguishable. That distinction is the reason `findPython` can tell those apart. So the
+ * shell is used only where it is the only option: a command that resolves to a `.cmd`/`.bat`
+ * shim. An unresolvable command is deliberately left bare, to keep its ENOENT.
+ *
+ * @param {string} command
+ * @param {NodeJS.ProcessEnv} [env]
+ * @returns {{command:string, shell:boolean}}
+ */
+export function resolveCommand(command, env = process.env) {
+  if (process.platform !== "win32") return { command, shell: false };
+  if (path.isAbsolute(command) || /[\\/]/.test(command) || path.extname(command)) {
+    return { command, shell: false };
+  }
+
+  const extensions = (env.PATHEXT ?? ".COM;.EXE;.BAT;.CMD").split(";").filter(Boolean);
+  const directories = (env.Path ?? env.PATH ?? "").split(path.delimiter).filter(Boolean);
+
+  for (const directory of directories) {
+    for (const extension of extensions) {
+      const candidate = path.join(directory, command + extension);
+      if (!fs.existsSync(candidate)) continue;
+      // Batch shims are the only case Node cannot spawn directly.
+      return /\.(cmd|bat)$/i.test(extension)
+        ? { command, shell: true }
+        : { command: candidate, shell: false };
+    }
+  }
+
+  return { command, shell: false };
+}
+
+/**
+ * Quote one argument for `cmd.exe`.
+ *
+ * Only reached on the shell path. Node's own warning (DEP0190) is that `args` passed
+ * alongside `shell: true` are concatenated without escaping; quoting here and passing a
+ * single command string means nothing is concatenated on our behalf.
+ *
+ * @param {string} argument
+ * @returns {string}
+ */
+function quoteForCmd(argument) {
+  if (argument.length > 0 && !/[\s"^&|<>()%!]/.test(argument)) return argument;
+  return `"${argument.replace(/(\\*)"/g, '$1$1\\"').replace(/(\\+)$/, "$1$1")}"`;
+}
+
+/**
  * Run one command and return its result. Injected everywhere so the rehearsal's own logic is
  * testable without a git remote, a Python interpreter or a network.
  *
@@ -122,12 +182,20 @@ export function normalizeResult(result) {
  * @returns {{status:number, stdout:string, stderr:string}}
  */
 export function defaultRunner(command, args, options = {}) {
+  const env = options.env ? { ...process.env, ...options.env } : process.env;
+  const resolved = resolveCommand(command, env);
+  const [file, argv] = resolved.shell
+    ? [[resolved.command, ...args].map(quoteForCmd).join(" "), []]
+    : [resolved.command, args];
+
   return normalizeResult(
-    spawnSync(command, args, {
+    spawnSync(file, argv, {
       cwd: options.cwd,
-      env: options.env ? { ...process.env, ...options.env } : process.env,
+      env,
       encoding: "utf8",
       maxBuffer: 64 * 1024 * 1024,
+      shell: resolved.shell,
+      windowsHide: true,
     }),
   );
 }


### PR DESCRIPTION
Found while verifying the remediation plan for the open issues (see #124 and the seven new
sub-issues #125–#131): **the release pre-flight could not pass on Windows**, the platform
this repository is maintained from.

## The symptom

```
FAIL  canvas-suite-is-green: npm test in .github\extensions\srs-navigator exited 127
```

`npm test` in that directory passes — **295/295**. The 127 came from the rehearsal itself.

## Root cause

`defaultRunner` called `spawnSync(command, args)` with no shell. On Windows `npm` is a `.cmd`
shim, and both spellings fail:

| call | result |
|---|---|
| `spawnSync("npm", …)` | `ENOENT` |
| `spawnSync("C:\…\npm.cmd", …)` | `EINVAL` — Node will not `CreateProcess` a batch file |
| `spawnSync("npm", …, { shell: true })` | works |

`normalizeResult` maps both failures to 127, so `canvas-suite-is-green` failed **whatever the
canvas suite did**.

This is not cosmetic. The only visible symptom is a red gate on the one train with an
irreversible step in front of it, and the natural reading is *"the rehearsal is a bit broken
locally, proceed anyway"* — which is what happened in #124, where the failing gate was
dismissed as regenerated health files. #110, *"Make the release runbook executable on the
machine that has to run it"*, is closed, so this was believed handled.

## The fix

A blanket `shell: true` would have fixed npm and broken something more valuable: a genuinely
missing executable would come back as the shell's *"not recognized"* exit code instead of
`ENOENT`, and `findPython`'s ability to tell *"no interpreter"* from *"the packager is
broken"* depends on that difference surviving.

So `resolveCommand()` uses the shell **only** where it is the only option — a command that
PATH-resolves to a `.cmd`/`.bat` shim. Resolvable binaries are spawned by absolute path; an
unresolvable command is left bare so it still raises `ENOENT` → 127. Arguments are quoted
into a single command string on the shell path, so nothing is concatenated unescaped
(DEP0190).

## Guards

Two tests in `evals/tests/release-preflight.test.mjs`:

- a **canary** running `npm --version` through `defaultRunner` — it fails wherever the runner
  cannot execute the one kind of command this gate actually needs, without asserting on any
  platform detail;
- a rule test pinning both halves: a batch shim never comes back as a path, and an
  unresolvable command keeps `shell: false`.

**Negative-tested** by reverting the platform branch — the canary fails, 62/63. Restored: 63/63.

## Verification

| Gate | Before | After |
|---|---|---|
| `release-preflight.mjs --tag v2.6` | `canvas-suite-is-green` FAIL 127 | ✅ PASS |
| canvas `npm test` | 295/295 | 295/295 |
| `node --test evals/tests/*.test.mjs` | 881/881 | **883/883** |
| Playwright `npm run test:e2e` | 41/41 | 41/41 |
| `build-plugin.py validate` | OK | OK |

On this branch the pre-flight now reports 8/9, and its single remaining failure is
`head-is-the-commit-to-be-tagged` — correct, because this is a feature branch. Once merged to
`main`, all nine gates pass and #128's first acceptance criterion becomes executable on this
platform; it was not before.

No behaviour outside `defaultRunner` changes, and no release was dispatched.