### PR TITLE
fix: measure issue-ledger version mentions per release train

### DIFF
--- a/docs/skills-health.html
+++ b/docs/skills-health.html
@@ -47,47 +47,47 @@
 <body>
 <main class="health">
   <h1>Skills Health</h1>
-  <p class="sub">Problem-Based SRS v2.6.0 · SRS Navigator v1.1.0 · generated 2026-08-05 08:23 UTC · <a href="index.html">back to the site</a></p>
+  <p class="sub">Problem-Based SRS v2.6.0 · SRS Navigator v1.1.0 · generated 2026-08-06 06:18 UTC · <a href="index.html">back to the site</a></p>
 
   <div class="cards">
     <div class="card verdict-passed"><span class="k">Verdict</span><span class="v">Passed</span></div>
-    <div class="card"><span class="k">Tests</span><span class="v">41</span></div>
-    <div class="card"><span class="k">Passing</span><span class="v">41</span></div>
+    <div class="card"><span class="k">Tests</span><span class="v">1269</span></div>
+    <div class="card"><span class="k">Passing</span><span class="v">1269</span></div>
     <div class="card"><span class="k">Failing</span><span class="v">0</span></div>
-    <div class="card"><span class="k">Suites run</span><span class="v">1/6</span></div>
-    <div class="card"><span class="k">Duration</span><span class="v">69.7s</span></div>
+    <div class="card"><span class="k">Suites run</span><span class="v">4/6</span></div>
+    <div class="card"><span class="k">Duration</span><span class="v">108.7s</span></div>
   </div>
 
   <h2>Suites</h2>
   <table class="health-table">
     <thead><tr><th>Suite</th><th>Result</th><th class="num">Tests</th><th class="num">Pass</th><th class="num">Fail</th><th class="num">Time</th><th>Note</th></tr></thead>
     <tbody>
-        <tr class="state-skipped">
+        <tr class="state-passed">
           <td class="name">Plugin validation<code>python scripts/build-plugin.py validate</code></td>
-          <td><span class="pill pill-skipped">Skipped</span></td>
-          <td class="num">—</td>
-          <td class="num">—</td>
-          <td class="num ">—</td>
-          <td class="num">—</td>
-          <td class="note">-SkipValidate</td>
+          <td><span class="pill pill-passed">Passed</span></td>
+          <td class="num">1</td>
+          <td class="num">1</td>
+          <td class="num ">0</td>
+          <td class="num">0.5s</td>
+          <td class="note"></td>
         </tr>
-        <tr class="state-skipped">
+        <tr class="state-passed">
           <td class="name">Canvas extension<code>npm test</code></td>
-          <td><span class="pill pill-skipped">Skipped</span></td>
-          <td class="num">—</td>
-          <td class="num">—</td>
-          <td class="num ">—</td>
-          <td class="num">—</td>
-          <td class="note">-SkipCanvas</td>
+          <td><span class="pill pill-passed">Passed</span></td>
+          <td class="num">300</td>
+          <td class="num">300</td>
+          <td class="num ">0</td>
+          <td class="num">2.1s</td>
+          <td class="note"></td>
         </tr>
-        <tr class="state-skipped">
+        <tr class="state-passed">
           <td class="name">Skill evals<code>pwsh evals/scripts/run-tests.ps1</code></td>
-          <td><span class="pill pill-skipped">Skipped</span></td>
-          <td class="num">—</td>
-          <td class="num">—</td>
-          <td class="num ">—</td>
-          <td class="num">—</td>
-          <td class="note">-SkipEvals</td>
+          <td><span class="pill pill-passed">Passed</span></td>
+          <td class="num">927</td>
+          <td class="num">927</td>
+          <td class="num ">0</td>
+          <td class="num">24.3s</td>
+          <td class="note"></td>
         </tr>
         <tr class="state-passed">
           <td class="name">Canvas e2e<code>npm run test:e2e</code></td>
@@ -95,7 +95,7 @@
           <td class="num">41</td>
           <td class="num">41</td>
           <td class="num ">0</td>
-          <td class="num">69.6s</td>
+          <td class="num">81.6s</td>
           <td class="note"></td>
         </tr>
         <tr class="state-skipped">

--- a/docs/skills-health.json
+++ b/docs/skills-health.json
@@ -1,54 +1,54 @@
 {
   "schema": "skills-health/1",
-  "generatedAt": "2026-08-05T08:23:35.8710239Z",
+  "generatedAt": "2026-08-06T06:18:49.0600846Z",
   "repo": "RafaelGorski/Problem-Based-SRS",
   "version": "2.6.0",
   "canvasVersion": "1.1.0",
   "overall": {
     "state": "passed",
     "suites": 6,
-    "suitesRun": 1,
+    "suitesRun": 4,
     "suitesFailed": 0,
-    "suitesSkipped": 5,
-    "tests": 41,
-    "pass": 41,
+    "suitesSkipped": 2,
+    "tests": 1269,
+    "pass": 1269,
     "fail": 0,
     "skipped": 0,
-    "durationSeconds": 69.7
+    "durationSeconds": 108.7
   },
   "suites": [
     {
       "name": "Plugin validation",
-      "state": "skipped",
+      "state": "passed",
       "command": "python scripts/build-plugin.py validate",
-      "tests": 0,
-      "pass": 0,
+      "tests": 1,
+      "pass": 1,
       "fail": 0,
       "skipped": 0,
-      "seconds": 0,
-      "reason": "-SkipValidate"
+      "seconds": 0.5,
+      "reason": ""
     },
     {
       "name": "Canvas extension",
-      "state": "skipped",
+      "state": "passed",
       "command": "npm test",
-      "tests": 0,
-      "pass": 0,
+      "tests": 300,
+      "pass": 300,
       "fail": 0,
       "skipped": 0,
-      "seconds": 0,
-      "reason": "-SkipCanvas"
+      "seconds": 2.1,
+      "reason": ""
     },
     {
       "name": "Skill evals",
-      "state": "skipped",
+      "state": "passed",
       "command": "pwsh evals/scripts/run-tests.ps1",
-      "tests": 0,
-      "pass": 0,
+      "tests": 927,
+      "pass": 927,
       "fail": 0,
       "skipped": 0,
-      "seconds": 0,
-      "reason": "-SkipEvals"
+      "seconds": 24.3,
+      "reason": ""
     },
     {
       "name": "Canvas e2e",
@@ -58,7 +58,7 @@
       "pass": 41,
       "fail": 0,
       "skipped": 0,
-      "seconds": 69.6,
+      "seconds": 81.6,
       "reason": ""
     },
     {

--- a/evals/tests/issue-ledger.test.mjs
+++ b/evals/tests/issue-ledger.test.mjs
@@ -3,12 +3,17 @@ import assert from "node:assert/strict";
 
 import {
   analyzeIssueBody,
+  attributeVersion,
+  classifyVersionMentions,
   compareVersions,
   hasCitation,
   hasExplicitBlocker,
   normalizeVersion,
   parseArgs,
   parseChecklistLine,
+  readCanvasVersion,
+  readTrainVersions,
+  toBaselines,
 } from "../tools/issue-ledger.mjs";
 
 describe("version helpers", () => {
@@ -79,6 +84,86 @@ describe("issue body analysis", () => {
   it("flags boxes that still name a superseded version", () => {
     const analyzed = analyzeIssueBody("- [ ] release link points at v2.5", "2.6.0");
     assert.equal(analyzed.counts.supersededVersionMentions, 1);
+  });
+});
+
+// Regression guard for the defect found on 2026-08-06: every version mention was compared
+// against the plugin manifest, so a canvas issue naming its own tag `v1.1.1` was reported as a
+// stale claim purely because 1.1.1 < 2.6.0. A canvas release issue could therefore never reach
+// a clean ledger. Mutating `attributeVersion` back to a single global baseline fails these.
+describe("version mentions are measured per release train", () => {
+  const TRAINS = { plugin: "2.6.0", canvas: "1.1.0" };
+
+  it("does not treat a canvas tag as a stale plugin claim", () => {
+    const analyzed = analyzeIssueBody("- [ ] A release tagged v1.1.1 exists", TRAINS);
+    assert.equal(
+      analyzed.counts.supersededVersionMentions,
+      0,
+      "v1.1.1 is the canvas train's next tag, not a version the plugin moved past",
+    );
+    assert.equal(analyzed.counts.unattributedVersionMentions, 0);
+  });
+
+  it("still flags a plugin version the manifest moved past", () => {
+    const analyzed = analyzeIssueBody("- [ ] release link points at v2.5", TRAINS);
+    assert.deepEqual(analyzed.findings.supersededVersionMentions, ["2.5"]);
+  });
+
+  it("flags a canvas version the canvas train moved past", () => {
+    const analyzed = analyzeIssueBody("- [ ] still ships v1.0.5", TRAINS);
+    assert.deepEqual(analyzed.findings.supersededVersionMentions, ["1.0.5"]);
+  });
+
+  it("treats the currently advertised version of each train as current", () => {
+    const analyzed = analyzeIssueBody(
+      ["- [ ] plugin v2.6 is published", "- [ ] canvas v1.1.0 is published"].join("\n"),
+      TRAINS,
+    );
+    assert.equal(analyzed.counts.supersededVersionMentions, 0);
+  });
+
+  it("reports a version no train claims instead of failing it", () => {
+    const analyzed = analyzeIssueBody("- [ ] migrate off v9.9.9", TRAINS);
+    assert.equal(analyzed.counts.supersededVersionMentions, 0, "not a stale claim");
+    assert.deepEqual(analyzed.findings.unattributedVersionMentions, ["9.9.9"]);
+  });
+
+  it("attributes a mention to the train sharing its major series", () => {
+    assert.equal(attributeVersion("1.1.1", TRAINS), "1.1.0");
+    assert.equal(attributeVersion("2.5", TRAINS), "2.6.0");
+    assert.equal(attributeVersion("9.9.9", TRAINS), null);
+  });
+
+  it("accepts a bare string baseline for backward compatibility", () => {
+    assert.deepEqual(toBaselines("2.6.0"), ["2.6.0"]);
+    assert.deepEqual(toBaselines(TRAINS), ["2.6.0", "1.1.0"]);
+    const parsed = parseChecklistLine("- [ ] Cut v2.5.0 before closing", "2.6.0");
+    assert.deepEqual(parsed.supersededVersions, ["2.5.0"]);
+  });
+
+  it("separates superseded from unattributed on one line", () => {
+    const { superseded, unattributed } = classifyVersionMentions(
+      "v2.5 and v1.1.1 and v9.9",
+      TRAINS,
+    );
+    assert.deepEqual(superseded, ["2.5"]);
+    assert.deepEqual(unattributed, ["9.9"]);
+  });
+});
+
+describe("train baselines are read from the files the pipelines own", () => {
+  it("reads a canvas version and both trains from the repository", () => {
+    const canvas = readCanvasVersion();
+    assert.match(canvas, /^\d+\.\d+\.\d+$/, "VERSION must be a dotted canvas version");
+    const trains = readTrainVersions();
+    assert.equal(trains.canvas, canvas);
+    assert.match(trains.plugin, /^\d+\.\d+/);
+    assert.notEqual(
+      normalizeVersion(trains.plugin)[0],
+      normalizeVersion(trains.canvas)[0],
+      "the two trains occupy different major series; if that changes, the ledger's " +
+        "attribution rule needs revisiting rather than silently mis-attributing tags",
+    );
   });
 });
 

--- a/evals/tools/issue-ledger.mjs
+++ b/evals/tools/issue-ledger.mjs
@@ -4,7 +4,16 @@
 // The goal is not to auto-edit issue bodies. It is to make drift visible in one command:
 // how many boxes are open/closed, which open boxes are missing an explicit blocker, which
 // ticked boxes carry no citation, and whether any box still names a version older than the
-// manifest currently advertises.
+// train that would publish it.
+//
+// The version check is per *train*, not per repository. This repository publishes two products
+// from one tag namespace — the plugin (`.claude-plugin/plugin.json`, 2.x) and the srs-navigator
+// canvas app (`VERSION`, 1.x) — and the trains cannot be told apart by tag shape. Comparing every
+// mention against the plugin manifest made a canvas issue unable to reach a clean ledger: a box
+// naming its own unreleased tag `v1.1.1` was reported as a stale claim purely because 1.1.1 is
+// numerically below the plugin's 2.6.0. A mention is therefore compared only against the baseline
+// sharing its major series, and a mention matching no train's series is reported separately as
+// unattributed rather than being silently passed or falsely failed.
 
 import fs from "node:fs";
 import path from "node:path";
@@ -53,6 +62,48 @@ export function versionMentions(text) {
   return [...String(text ?? "").matchAll(/\bv(\d+\.\d+(?:\.\d+)?)\b/g)].map((m) => m[1]);
 }
 
+/**
+ * The version baselines a mention can be measured against, as a flat list.
+ *
+ * Accepts the historical single-version string, a list, or a train map such as
+ * `{ plugin: "2.6.0", canvas: "1.1.0" }`, so callers that only know the manifest keep working.
+ */
+export function toBaselines(baselines) {
+  const raw =
+    baselines && typeof baselines === "object" && !Array.isArray(baselines)
+      ? Object.values(baselines)
+      : [baselines].flat();
+  return raw.filter((v) => normalizeVersion(v) !== null).map((v) => String(v).trim());
+}
+
+/**
+ * The baseline that would publish this mention: the one sharing its major series.
+ *
+ * Returns null when no train claims the series. That is an honest "cannot attribute", not a
+ * pass — `analyzeIssueBody` reports those mentions on a separate channel.
+ */
+export function attributeVersion(mention, baselines) {
+  const left = normalizeVersion(mention);
+  if (!left) return null;
+  const candidates = toBaselines(baselines).filter(
+    (b) => normalizeVersion(b)?.[0] === left[0],
+  );
+  if (candidates.length === 0) return null;
+  return candidates.reduce((a, b) => (compareVersions(a, b) === 1 ? a : b));
+}
+
+/** Split a line's version mentions into superseded, unattributed, and current. */
+export function classifyVersionMentions(text, baselines) {
+  const superseded = [];
+  const unattributed = [];
+  for (const mention of versionMentions(text)) {
+    const baseline = attributeVersion(mention, baselines);
+    if (baseline === null) unattributed.push(mention);
+    else if (compareVersions(mention, baseline) === -1) superseded.push(mention);
+  }
+  return { superseded, unattributed };
+}
+
 export function hasCitation(text) {
   return (
     /https?:\/\//i.test(text) ||
@@ -69,13 +120,13 @@ export function hasExplicitBlocker(text) {
   );
 }
 
-export function parseChecklistLine(line, currentVersion) {
+export function parseChecklistLine(line, baselines) {
   const m = /^\s*-\s\[( |x|X)\]\s+(.*)\s*$/.exec(line);
   if (!m) return null;
   const checked = m[1].toLowerCase() === "x";
   const text = m[2];
   const mentions = versionMentions(text);
-  const superseded = mentions.filter((v) => compareVersions(v, currentVersion) === -1);
+  const { superseded, unattributed } = classifyVersionMentions(text, baselines);
   return {
     checked,
     text,
@@ -83,14 +134,15 @@ export function parseChecklistLine(line, currentVersion) {
     hasExplicitBlocker: hasExplicitBlocker(text),
     versionMentions: mentions,
     supersededVersions: superseded,
+    unattributedVersions: unattributed,
   };
 }
 
-export function analyzeIssueBody(body, currentVersion) {
+export function analyzeIssueBody(body, baselines) {
   const lines = String(body ?? "").split(/\r?\n/);
   const boxes = [];
   for (const line of lines) {
-    const parsed = parseChecklistLine(line, currentVersion);
+    const parsed = parseChecklistLine(line, baselines);
     if (parsed) boxes.push(parsed);
   }
   const checked = boxes.filter((b) => b.checked);
@@ -98,6 +150,7 @@ export function analyzeIssueBody(body, currentVersion) {
   const openWithoutBlocker = open.filter((b) => !b.hasExplicitBlocker);
   const tickedWithoutCitation = checked.filter((b) => !b.hasCitation);
   const supersededVersionMentions = boxes.flatMap((b) => b.supersededVersions);
+  const unattributedVersionMentions = boxes.flatMap((b) => b.unattributedVersions);
 
   return {
     boxes,
@@ -108,11 +161,13 @@ export function analyzeIssueBody(body, currentVersion) {
       openWithoutBlocker: openWithoutBlocker.length,
       tickedWithoutCitation: tickedWithoutCitation.length,
       supersededVersionMentions: supersededVersionMentions.length,
+      unattributedVersionMentions: unattributedVersionMentions.length,
     },
     findings: {
       openWithoutBlocker: openWithoutBlocker.map((b) => b.text),
       tickedWithoutCitation: tickedWithoutCitation.map((b) => b.text),
       supersededVersionMentions,
+      unattributedVersionMentions,
     },
   };
 }
@@ -121,6 +176,32 @@ export function readPluginVersion(root = REPO_ROOT) {
   const file = path.join(root, ".claude-plugin", "plugin.json");
   const data = JSON.parse(fs.readFileSync(file, "utf8"));
   return data.version;
+}
+
+/**
+ * The version the canvas train advertises.
+ *
+ * `VERSION` is the file the release workflow owns and the drift monitor reads; the extension
+ * package.json is asserted to agree with it elsewhere. Either one is enough to know the canvas
+ * major series, which is all the ledger needs to stop measuring canvas tags against the plugin.
+ */
+export function readCanvasVersion(root = REPO_ROOT) {
+  const versionFile = path.join(root, "VERSION");
+  if (fs.existsSync(versionFile)) {
+    const value = fs.readFileSync(versionFile, "utf8").trim();
+    if (value) return value;
+  }
+  const pkg = path.join(root, ".github", "extensions", "srs-navigator", "package.json");
+  if (fs.existsSync(pkg)) {
+    const version = JSON.parse(fs.readFileSync(pkg, "utf8")).version;
+    if (version) return String(version).trim();
+  }
+  return null;
+}
+
+/** Every train's advertised version, keyed by train, as the ledger measures mentions against. */
+export function readTrainVersions(root = REPO_ROOT) {
+  return { plugin: readPluginVersion(root), canvas: readCanvasVersion(root) };
 }
 
 export function parseRepoFromRemoteUrl(url) {
@@ -149,11 +230,12 @@ export function fetchIssue(number, repo, run = defaultRunner, root = REPO_ROOT) 
 }
 
 export function buildLedger(options, run = defaultRunner) {
-  const currentVersion = readPluginVersion(options.root);
+  const trainVersions = readTrainVersions(options.root);
+  const currentVersion = trainVersions.plugin;
   const repo = options.repo || detectRepo(options.root, run);
   const issues = options.issues.map((n) => {
     const issue = fetchIssue(n, repo, run, options.root);
-    const analysis = analyzeIssueBody(issue.body, currentVersion);
+    const analysis = analyzeIssueBody(issue.body, trainVersions);
     return {
       number: issue.number,
       title: issue.title,
@@ -171,6 +253,7 @@ export function buildLedger(options, run = defaultRunner) {
       acc.openWithoutBlocker += issue.counts.openWithoutBlocker;
       acc.tickedWithoutCitation += issue.counts.tickedWithoutCitation;
       acc.supersededVersionMentions += issue.counts.supersededVersionMentions;
+      acc.unattributedVersionMentions += issue.counts.unattributedVersionMentions;
       return acc;
     },
     {
@@ -181,16 +264,20 @@ export function buildLedger(options, run = defaultRunner) {
       openWithoutBlocker: 0,
       tickedWithoutCitation: 0,
       supersededVersionMentions: 0,
+      unattributedVersionMentions: 0,
     },
   );
 
   const record = {
     repo,
     currentVersion,
+    trainVersions,
     generatedAt: new Date().toISOString(),
     issues,
     totals,
   };
+  // Unattributed mentions are reported, never failed: a version no train claims is a
+  // comparison that did not run, not a stale claim.
   record.ok =
     totals.openWithoutBlocker === 0 &&
     totals.tickedWithoutCitation === 0 &&
@@ -236,9 +323,15 @@ export function parseArgs(argv) {
 }
 
 export function formatReport(record) {
+  const trains = record.trainVersions ?? { plugin: record.currentVersion };
+  const baselineLine = Object.entries(trains)
+    .filter(([, v]) => v)
+    .map(([train, v]) => `${train} ${v}`)
+    .join(", ");
   const lines = [
     `issue ledger for ${record.repo ?? "(repo not detected)"}`,
     `manifest version: ${record.currentVersion}`,
+    `version baselines: ${baselineLine || "(none readable)"}`,
     "",
     ...record.issues.map((issue) => {
       const prefix = `#${issue.number} ${issue.title}`;
@@ -248,6 +341,7 @@ export function formatReport(record) {
         `  open without blocker: ${issue.counts.openWithoutBlocker}`,
         `  ticked without citation: ${issue.counts.tickedWithoutCitation}`,
         `  superseded version mentions: ${issue.counts.supersededVersionMentions}`,
+        `  unattributed version mentions: ${issue.counts.unattributedVersionMentions ?? 0}`,
       ].join("\n");
     }),
     "",
@@ -255,6 +349,7 @@ export function formatReport(record) {
     `flags: ${record.totals.openWithoutBlocker} open-without-blocker, ` +
       `${record.totals.tickedWithoutCitation} ticked-without-citation, ` +
       `${record.totals.supersededVersionMentions} superseded-version-mentions`,
+    `not compared: ${record.totals.unattributedVersionMentions ?? 0} version mention(s) claimed by no train`,
     "",
     record.ok ? "RESULT: ledger is consistent" : "RESULT: ledger has drift to reconcile",
   ];


### PR DESCRIPTION
## What this changes

`evals/tools/issue-ledger.mjs` compared **every** version mention inside an acceptance checkbox
against the plugin manifest version. This repository publishes two products from one tag
namespace — the plugin (`.claude-plugin/plugin.json`, currently `2.6.0`) and the srs-navigator
canvas app (`VERSION`, currently `1.1.0`) — so a canvas acceptance box naming its own tag
`v1.1.1` was reported as a *stale version claim* purely because `1.1.1 < 2.6.0`.

Because `record.ok` requires `supersededVersionMentions === 0`, the consequence was structural:

> **No canvas release issue could ever reach a clean ledger.**

#138 was flagged twice for naming the very version it exists to publish.

## How it is fixed

Each mention is attributed to the train sharing its **major series** and compared only against
that train's advertised version, read from the files the pipelines themselves own
(`.claude-plugin/plugin.json` and `VERSION`, falling back to the extension `package.json`).

A mention that no train claims is reported on a separate **`not compared`** channel rather than
failed as stale — the same distinction `check-distribution.mjs` draws between findings and
notices. A comparison that did not run is not a pass, and it is not a failure either.

The historical bare-string baseline form (`analyzeIssueBody(body, "2.6.0")`) still works, so
existing callers and tests are unaffected.

### Before / after on the live issues

```
before:  #138  superseded version mentions: 2
         #146  superseded version mentions: 2

after:   #138  superseded version mentions: 0     unattributed: 0
         #146  superseded version mentions: 0     unattributed: 0
         version baselines: plugin 2.6.0, canvas 1.1.0
```

## Verification

Per the repository's behavior-drift testing rule, the guard was **falsified before being kept**:
reverting `attributeVersion` to a single global baseline fails the new tests
(`actual: ['2.5','1.1.1'], expected: ['2.5']`); restoring it passes them.

```
node --test evals/tests/issue-ledger.test.mjs      21/21 passing
pwsh -File run-tests.ps1 -NoOpen                   1269/1269 passing, 0 failed
  Plugin validation      1/1
  Canvas extension       300/300
  Skill evals            927/927
  Canvas e2e (Playwright) 41/41
  Skill behavior (LLM)   skipped — no keys requested
  Live skill evals (LLM) skipped — no keys requested
```

New cases cover: a canvas tag not being a stale plugin claim, a stale plugin version still being
flagged, a stale *canvas* version being flagged, each train's current version being treated as
current, an unattributable version being reported rather than failed, mixed mentions on one line,
and backward compatibility with the string baseline. One test also asserts the two trains occupy
different major series, so if that ever stops being true the attribution rule is forced to be
revisited rather than silently mis-attributing tags.

`docs/skills-health.*` are regenerated by the full run; the committed snapshot had been written
by a partial run (`-SkipValidate`, 41 tests) and now reflects a complete one.

## Why it was found

While planning remediation for the open issue batch (#138, #139, #140, #142). The plan's batch
reconciliation issue asserts `0 superseded version mentions` as a closure criterion — which this
defect made permanently unsatisfiable for a batch containing canvas issues.

Related: #138, #144, and the sub-issues #145–#149.